### PR TITLE
Introduce Decision/Path IR

### DIFF
--- a/docs/rdd/08_specs/README.md
+++ b/docs/rdd/08_specs/README.md
@@ -14,6 +14,7 @@
 - [rust_native_modeling_specs.md](rust_native_modeling_specs.md)
 - [explicit_engine_and_evidence_specs.md](explicit_engine_and_evidence_specs.md)
 - [testgen_contract_coverage_specs.md](testgen_contract_coverage_specs.md)
+- [decision_path_ir.md](decision_path_ir.md)
 - [ai_solver_selfcheck_specs.md](ai_solver_selfcheck_specs.md)
 - [full_technology_usage_plan.md](full_technology_usage_plan.md)
 - [../09_reference](../09_reference)

--- a/docs/rdd/08_specs/decision_path_ir.md
+++ b/docs/rdd/08_specs/decision_path_ir.md
@@ -1,0 +1,64 @@
+# Decision / Path IR
+
+## 目的
+
+`coverage` / `explain` / `testgen` が同じ経路語彙を共有できるように、
+遷移の判断点を `Decision`、実行経路を `Path` で表現する。
+
+既存の `path_tags` は互換用途として残すが、一次情報は `Decision` / `Path`
+に寄せる。
+
+## IR
+
+- `DecisionPoint`
+  - 遷移中の判断点を表すメタデータ
+  - `decision_id`
+  - `action_id`
+  - `kind`
+    - `Guard`
+    - `StateUpdate`
+  - `label`
+  - `field`
+  - `reads`
+  - `writes`
+  - `path_tags`
+- `Decision`
+  - `DecisionPoint` に実行時の結果を与えたもの
+  - `outcome`
+    - `GuardTrue`
+    - `GuardFalse`
+    - `UpdateApplied`
+- `Path`
+  - `Decision` の列
+  - 互換用途として `legacy_path_tags()` を持つ
+
+## 生成規則
+
+- `ActionIr::decision_path()`
+  - guard=true の遷移として `Path` を構築する
+- `ActionIr::decision_path_for_guard(false)`
+  - guard=false の判断点のみを構築する
+- `TraceStep.path`
+  - 実際に実行された step の `Path`
+- `TestVector.expected_path`
+  - ベクトルが期待する `Path`
+
+## 利用方針
+
+- `coverage`
+  - `step.path` または `ActionIr::decision_path*()` から decision coverage を計算する
+  - `path_tag_counts` は `Path::legacy_path_tags()` から集計する
+- `testgen`
+  - trace 由来ベクトルは `TraceStep.path` を束ねて `expected_path` を作る
+  - model exploration 由来ベクトルは `ActionIr::decision_path*()` から `expected_path`
+    を作る
+- `explain`
+  - failing step の `Path` を `decision_path` として返す
+  - 既存の `failing_action_path_tags` は `decision_path.legacy_path_tags()` から導出する
+
+## 互換性
+
+- `path_tags` は残す
+- `note = "path_tag:..."` も fallback として残す
+- JSON/text 出力は既存の `path_tags` を維持しつつ、構造化された `path` /
+  `decision_path` を追加する

--- a/packages/valid/src/api/mod.rs
+++ b/packages/valid/src/api/mod.rs
@@ -12,7 +12,7 @@ use crate::{
     },
     engine::{CheckErrorEnvelope, CheckOutcome, PropertySelection, RunManifest, RunPlan},
     frontend,
-    ir::ModelIr,
+    ir::{DecisionKind, DecisionOutcome, ModelIr, Path},
     orchestrator::run_all_properties_with_backend,
     solver::{capabilities_for_config, run_with_adapter, AdapterConfig, CapabilityMatrix},
     support::{
@@ -130,6 +130,7 @@ pub struct ExplainResponse {
     pub property_id: String,
     pub failure_step_index: usize,
     pub failing_action_id: Option<String>,
+    pub decision_path: Path,
     pub failing_action_reads: Vec<String>,
     pub failing_action_writes: Vec<String>,
     pub failing_action_path_tags: Vec<String>,
@@ -791,7 +792,8 @@ pub fn explain_source(request: &CheckRequest) -> Result<ExplainResponse, CheckEr
                 failure_step.action_id.as_ref().map(|action_id| {
                     let mut reads = std::collections::BTreeSet::new();
                     let mut writes = std::collections::BTreeSet::new();
-                    let mut path_tags = std::collections::BTreeSet::new();
+                    let traced_path = failure_step.path.clone();
+                    let mut decision_path = failure_step.path.clone().unwrap_or_default();
                     for action in model
                         .actions
                         .iter()
@@ -800,14 +802,16 @@ pub fn explain_source(request: &CheckRequest) -> Result<ExplainResponse, CheckEr
                         if matches!(evaluate_guard(model, &state, action), Ok(true)) {
                             reads.extend(action.reads.iter().cloned());
                             writes.extend(action.writes.iter().cloned());
-                            path_tags.extend(action.path_tags.iter().cloned());
+                            if traced_path.is_none() {
+                                decision_path.extend(action.decision_path());
+                            }
                         }
                     }
                     (
                         action_id.clone(),
                         reads.into_iter().collect::<Vec<_>>(),
                         writes.into_iter().collect::<Vec<_>>(),
-                        path_tags.into_iter().collect::<Vec<_>>(),
+                        decision_path,
                     )
                 })
             });
@@ -844,7 +848,8 @@ pub fn explain_source(request: &CheckRequest) -> Result<ExplainResponse, CheckEr
                 ]
             } else {
                 let mut causes = Vec::new();
-                if let Some((action_id, reads, writes, path_tags)) = &action_metadata {
+                if let Some((action_id, reads, writes, decision_path)) = &action_metadata {
+                    let path_tags = decision_path.legacy_path_tags();
                     if !write_overlap.is_empty() {
                         causes.push(ExplainCandidateCause {
                             kind: "write_set_overlap".to_string(),
@@ -970,6 +975,11 @@ pub fn explain_source(request: &CheckRequest) -> Result<ExplainResponse, CheckEr
                 property_id: trace.property_id.clone(),
                 failure_step_index: failure_step.index,
                 failing_action_id: failure_step.action_id.clone(),
+                decision_path: action_metadata
+                    .as_ref()
+                    .map(|(_, _, _, path)| path.clone())
+                    .or_else(|| failure_step.path.clone())
+                    .unwrap_or_default(),
                 failing_action_reads: action_metadata
                     .as_ref()
                     .map(|(_, reads, _, _)| reads.clone())
@@ -980,7 +990,7 @@ pub fn explain_source(request: &CheckRequest) -> Result<ExplainResponse, CheckEr
                     .unwrap_or_default(),
                 failing_action_path_tags: action_metadata
                     .as_ref()
-                    .map(|(_, _, _, path_tags)| path_tags.clone())
+                    .map(|(_, _, _, path)| path.legacy_path_tags())
                     .unwrap_or_default(),
                 write_overlap_fields: write_overlap.clone(),
                 involved_fields,
@@ -1546,7 +1556,7 @@ pub fn render_inspect_text(response: &InspectResponse) -> String {
 
 pub fn render_explain_json(response: &ExplainResponse) -> String {
     format!(
-        "{{\"schema_version\":\"{}\",\"request_id\":\"{}\",\"status\":\"{}\",\"evidence_id\":\"{}\",\"property_id\":\"{}\",\"failure_step_index\":{},\"failing_action_id\":{},\"failing_action_reads\":{},\"failing_action_writes\":{},\"failing_action_path_tags\":{},\"write_overlap_fields\":{},\"involved_fields\":{},\"candidate_causes\":[{}],\"repair_hints\":{},\"next_steps\":{},\"confidence\":{},\"best_practices\":{},\"review_summary\":{{\"headline\":\"{}\",\"review_level\":\"{}\"}}}}",
+        "{{\"schema_version\":\"{}\",\"request_id\":\"{}\",\"status\":\"{}\",\"evidence_id\":\"{}\",\"property_id\":\"{}\",\"failure_step_index\":{},\"failing_action_id\":{},\"decision_path\":{},\"failing_action_reads\":{},\"failing_action_writes\":{},\"failing_action_path_tags\":{},\"write_overlap_fields\":{},\"involved_fields\":{},\"candidate_causes\":[{}],\"repair_hints\":{},\"next_steps\":{},\"confidence\":{},\"best_practices\":{},\"review_summary\":{{\"headline\":\"{}\",\"review_level\":\"{}\"}}}}",
         escape_json(&response.schema_version),
         escape_json(&response.request_id),
         escape_json(&response.status),
@@ -1558,6 +1568,7 @@ pub fn render_explain_json(response: &ExplainResponse) -> String {
             .as_ref()
             .map(|value| format!("\"{}\"", escape_json(value)))
             .unwrap_or_else(|| "null".to_string()),
+        render_path_json(&response.decision_path),
         render_string_array(&response.failing_action_reads),
         render_string_array(&response.failing_action_writes),
         render_string_array(&response.failing_action_path_tags),
@@ -1606,6 +1617,21 @@ pub fn render_explain_text(response: &ExplainResponse) -> String {
     ));
     if let Some(action_id) = &response.failing_action_id {
         out.push_str(&format!("failing_action_id: {}\n", action_id));
+    }
+    if !response.decision_path.decisions.is_empty() {
+        out.push_str("decision_path:\n");
+        for decision in &response.decision_path.decisions {
+            out.push_str(&format!(
+                "- {} [{}] {}\n",
+                decision.point.decision_id,
+                match decision.outcome {
+                    DecisionOutcome::GuardTrue => "guard_true",
+                    DecisionOutcome::GuardFalse => "guard_false",
+                    DecisionOutcome::UpdateApplied => "update_applied",
+                },
+                decision.point.label
+            ));
+        }
     }
     if !response.failing_action_reads.is_empty() || !response.failing_action_writes.is_empty() {
         out.push_str(&format!(
@@ -2388,10 +2414,77 @@ pub fn validate_explain_response(response: &ExplainResponse) -> Result<(), Strin
     require_non_empty(&response.request_id, "request_id")?;
     require_non_empty(&response.evidence_id, "evidence_id")?;
     require_non_empty(&response.property_id, "property_id")?;
+    for decision in &response.decision_path.decisions {
+        require_non_empty(
+            &decision.point.decision_id,
+            "decision_path.decisions[].decision_id",
+        )?;
+        require_non_empty(
+            &decision.point.action_id,
+            "decision_path.decisions[].action_id",
+        )?;
+    }
     if !(0.0..=1.0).contains(&response.confidence) {
         return Err("confidence must be between 0.0 and 1.0".to_string());
     }
     Ok(())
+}
+
+fn render_path_json(path: &Path) -> String {
+    let mut out = String::from("{\"decisions\":[");
+    for (index, decision) in path.decisions.iter().enumerate() {
+        if index > 0 {
+            out.push(',');
+        }
+        out.push('{');
+        out.push_str(&format!(
+            "\"decision_id\":\"{}\"",
+            escape_json(&decision.decision_id())
+        ));
+        out.push_str(&format!(
+            ",\"action_id\":\"{}\"",
+            escape_json(&decision.point.action_id)
+        ));
+        out.push_str(&format!(
+            ",\"kind\":\"{}\"",
+            match decision.point.kind {
+                DecisionKind::Guard => "guard",
+                DecisionKind::StateUpdate => "state_update",
+            }
+        ));
+        out.push_str(&format!(
+            ",\"label\":\"{}\"",
+            escape_json(&decision.point.label)
+        ));
+        if let Some(field) = &decision.point.field {
+            out.push_str(&format!(",\"field\":\"{}\"", escape_json(field)));
+        } else {
+            out.push_str(",\"field\":null");
+        }
+        out.push_str(&format!(
+            ",\"reads\":{}",
+            render_string_array(&decision.point.reads)
+        ));
+        out.push_str(&format!(
+            ",\"writes\":{}",
+            render_string_array(&decision.point.writes)
+        ));
+        out.push_str(&format!(
+            ",\"path_tags\":{}",
+            render_string_array(&decision.point.path_tags)
+        ));
+        out.push_str(&format!(
+            ",\"outcome\":\"{}\"",
+            match decision.outcome {
+                DecisionOutcome::GuardTrue => "guard_true",
+                DecisionOutcome::GuardFalse => "guard_false",
+                DecisionOutcome::UpdateApplied => "update_applied",
+            }
+        ));
+        out.push('}');
+    }
+    out.push_str("]}");
+    out
 }
 
 pub fn validate_minimize_request(request: &MinimizeRequest) -> Result<(), String> {
@@ -2639,6 +2732,7 @@ mod tests {
         assert_eq!(response.property_id, "P_SAFE");
         assert_eq!(response.failure_step_index, 0);
         assert_eq!(response.involved_fields, vec!["x".to_string()]);
+        assert!(!response.decision_path.decisions.is_empty());
         assert!(response
             .candidate_causes
             .iter()
@@ -2660,6 +2754,7 @@ mod tests {
             .repair_hints
             .iter()
             .any(|hint| hint.contains("both guard outcomes")));
+        assert!(super::render_explain_json(&response).contains("\"decision_path\""));
         validate_explain_response(&response).unwrap();
     }
 

--- a/packages/valid/src/bin/valid.rs
+++ b/packages/valid/src/bin/valid.rs
@@ -28,7 +28,7 @@ use valid::{
         render_trace_mermaid, render_trace_sequence_mermaid, GraphView,
     },
     selfcheck::{run_smoke_selfcheck, write_selfcheck_artifact},
-    testgen::render_replay_json,
+    testgen::{render_replay_json, replay_path_for_model},
 };
 
 fn main() {
@@ -610,18 +610,12 @@ fn cmd_replay(args: Vec<String>) {
             valid::kernel::eval::eval_expr(&model, &terminal, &property.expr),
             Ok(valid::ir::Value::Bool(true))
         );
-        let mut path_tags = std::collections::BTreeSet::new();
-        for action_id in &parsed.actions {
-            for action in model
-                .actions
-                .iter()
-                .filter(|action| action.action_id == *action_id)
-            {
-                for tag in &action.path_tags {
-                    path_tags.insert(tag.clone());
-                }
-            }
-        }
+        let replay_path = replay_path_for_model(
+            &model,
+            &parsed.actions,
+            parsed.focus_action_id.as_deref(),
+            focus_enabled,
+        );
         Ok(render_replay_json(
             property_id,
             &parsed.actions,
@@ -629,7 +623,7 @@ fn cmd_replay(args: Vec<String>) {
             parsed.focus_action_id.as_deref(),
             focus_enabled,
             Some(property_holds),
-            &path_tags.into_iter().collect::<Vec<_>>(),
+            &replay_path,
         ))
     }
     .unwrap_or_else(|message| {

--- a/packages/valid/src/bundled_models.rs
+++ b/packages/valid/src/bundled_models.rs
@@ -296,7 +296,7 @@ pub fn replay_bundled_model(
     action_ids: &[String],
     focus_action_id: Option<&str>,
 ) -> Result<String, String> {
-    let (terminal_state, property_id, focus_action_enabled, property_holds, path_tags) =
+    let (terminal_state, property_id, focus_action_enabled, property_holds, path) =
         match parse_model_ref(model_ref) {
             Some(BundledModel::Counter) => {
                 replay_machine_actions::<CounterModel>(property_id, action_ids, focus_action_id)?
@@ -318,7 +318,7 @@ pub fn replay_bundled_model(
         focus_action_id,
         focus_action_enabled,
         Some(property_holds),
-        &path_tags,
+        &path,
     ))
 }
 

--- a/packages/valid/src/coverage/mod.rs
+++ b/packages/valid/src/coverage/mod.rs
@@ -20,10 +20,14 @@ pub struct CoverageReport {
     pub schema_version: String,
     pub model_id: String,
     pub transition_coverage_percent: u32,
+    pub decision_coverage_percent: u32,
     pub guard_full_coverage_percent: u32,
     pub covered_actions: BTreeSet<String>,
+    pub covered_decisions: BTreeSet<String>,
     pub total_actions: BTreeSet<String>,
+    pub total_decisions: BTreeSet<String>,
     pub action_execution_counts: BTreeMap<String, usize>,
+    pub decision_counts: BTreeMap<String, usize>,
     pub visited_state_count: usize,
     pub repeated_state_count: usize,
     pub max_depth_observed: u32,
@@ -58,7 +62,19 @@ pub fn collect_coverage(model: &ModelIr, traces: &[EvidenceTrace]) -> CoverageRe
         .iter()
         .map(|a| a.action_id.clone())
         .collect::<BTreeSet<_>>();
+    let total_decisions = model
+        .actions
+        .iter()
+        .flat_map(|action| {
+            action
+                .decision_path()
+                .decision_ids()
+                .into_iter()
+                .chain(action.decision_path_for_guard(false).decision_ids())
+        })
+        .collect::<BTreeSet<_>>();
     let mut covered_actions = BTreeSet::new();
+    let mut covered_decisions = BTreeSet::new();
     let mut visited_states = BTreeSet::new();
     let mut all_seen_states = 0usize;
     let mut max_depth_observed = 0u32;
@@ -68,6 +84,7 @@ pub fn collect_coverage(model: &ModelIr, traces: &[EvidenceTrace]) -> CoverageRe
     let mut guard_false_counts = BTreeMap::new();
     let mut path_tag_counts = BTreeMap::new();
     let mut action_execution_counts = BTreeMap::new();
+    let mut decision_counts = BTreeMap::new();
     let mut depth_histogram = BTreeMap::new();
     let mut step_count = 0usize;
     for trace in traces {
@@ -91,17 +108,29 @@ pub fn collect_coverage(model: &ModelIr, traces: &[EvidenceTrace]) -> CoverageRe
                 *action_execution_counts
                     .entry(action_id.clone())
                     .or_insert(0) += 1;
-                if let Some(state) = machine_state_from_snapshot(model, &step.state_before) {
-                    for action in model
+                let path = step.path.clone().or_else(|| {
+                    let state = machine_state_from_snapshot(model, &step.state_before)?;
+                    model
                         .actions
                         .iter()
-                        .filter(|action| &action.action_id == action_id)
+                        .find(|action| {
+                            &action.action_id == action_id
+                                && matches!(evaluate_guard(model, &state, action), Ok(true))
+                        })
+                        .map(|action| action.decision_path())
+                });
+                if let Some(path) = path {
+                    for decision_id in path
+                        .decisions
+                        .iter()
+                        .skip(1)
+                        .map(|decision| decision.decision_id().to_string())
                     {
-                        if matches!(evaluate_guard(model, &state, action), Ok(true)) {
-                            for tag in &action.path_tags {
-                                *path_tag_counts.entry(tag.clone()).or_insert(0) += 1;
-                            }
-                        }
+                        covered_decisions.insert(decision_id.clone());
+                        *decision_counts.entry(decision_id).or_insert(0) += 1;
+                    }
+                    for tag in path.legacy_path_tags() {
+                        *path_tag_counts.entry(tag).or_insert(0) += 1;
                     }
                 }
             }
@@ -110,12 +139,32 @@ pub fn collect_coverage(model: &ModelIr, traces: &[EvidenceTrace]) -> CoverageRe
                 for action in &model.actions {
                     match evaluate_guard(model, &state, action) {
                         Ok(true) => {
+                            for decision_id in action
+                                .decision_path_for_guard(true)
+                                .decisions
+                                .into_iter()
+                                .take(1)
+                                .map(|decision| decision.decision_id())
+                            {
+                                covered_decisions.insert(decision_id.clone());
+                                *decision_counts.entry(decision_id).or_insert(0) += 1;
+                            }
                             guard_true_actions.insert(action.action_id.clone());
                             *guard_true_counts
                                 .entry(action.action_id.clone())
                                 .or_insert(0) += 1;
                         }
                         Ok(false) => {
+                            for decision_id in action
+                                .decision_path_for_guard(false)
+                                .decisions
+                                .into_iter()
+                                .take(1)
+                                .map(|decision| decision.decision_id())
+                            {
+                                covered_decisions.insert(decision_id.clone());
+                                *decision_counts.entry(decision_id).or_insert(0) += 1;
+                            }
                             guard_false_actions.insert(action.action_id.clone());
                             *guard_false_counts
                                 .entry(action.action_id.clone())
@@ -134,6 +183,11 @@ pub fn collect_coverage(model: &ModelIr, traces: &[EvidenceTrace]) -> CoverageRe
         100
     } else {
         ((covered_actions.len() * 100) / total_actions.len()) as u32
+    };
+    let decision_coverage_percent = if total_decisions.is_empty() {
+        100
+    } else {
+        ((covered_decisions.len() * 100) / total_decisions.len()) as u32
     };
     let fully_covered_guards = total_actions
         .iter()
@@ -164,10 +218,14 @@ pub fn collect_coverage(model: &ModelIr, traces: &[EvidenceTrace]) -> CoverageRe
         schema_version: "1.0.0".to_string(),
         model_id: model.model_id.clone(),
         transition_coverage_percent,
+        decision_coverage_percent,
         guard_full_coverage_percent,
         covered_actions,
+        covered_decisions,
         total_actions,
+        total_decisions,
         action_execution_counts,
+        decision_counts,
         visited_state_count: visited_states.len(),
         repeated_state_count: all_seen_states.saturating_sub(visited_states.len()),
         max_depth_observed,
@@ -212,8 +270,9 @@ pub fn render_coverage_json(report: &CoverageReport) -> String {
     out.push_str(&format!("\"schema_version\":\"{}\"", report.schema_version));
     out.push_str(&format!(",\"model_id\":\"{}\"", report.model_id));
     out.push_str(&format!(
-        ",\"summary\":{{\"transition_coverage_percent\":{},\"guard_full_coverage_percent\":{},\"visited_state_count\":{},\"repeated_state_count\":{},\"step_count\":{},\"max_depth_observed\":{}}}",
+        ",\"summary\":{{\"transition_coverage_percent\":{},\"decision_coverage_percent\":{},\"guard_full_coverage_percent\":{},\"visited_state_count\":{},\"repeated_state_count\":{},\"step_count\":{},\"max_depth_observed\":{}}}",
         report.transition_coverage_percent,
+        report.decision_coverage_percent,
         report.guard_full_coverage_percent,
         report.visited_state_count,
         report.repeated_state_count,
@@ -232,6 +291,23 @@ pub fn render_coverage_json(report: &CoverageReport) -> String {
             report
                 .action_execution_counts
                 .get(action)
+                .copied()
+                .unwrap_or(0)
+        ));
+    }
+    out.push(']');
+    out.push_str(",\"decisions\":[");
+    for (index, decision_id) in report.total_decisions.iter().enumerate() {
+        if index > 0 {
+            out.push(',');
+        }
+        out.push_str(&format!(
+            "{{\"decision_id\":\"{}\",\"covered\":{},\"count\":{}}}",
+            decision_id,
+            report.covered_decisions.contains(decision_id),
+            report
+                .decision_counts
+                .get(decision_id)
                 .copied()
                 .unwrap_or(0)
         ));
@@ -318,9 +394,10 @@ pub fn render_coverage_json(report: &CoverageReport) -> String {
 pub fn render_coverage_text(report: &CoverageReport) -> String {
     let gate = evaluate_coverage_gate(report, 80);
     format!(
-        "COVERAGE model={}\ntransition_coverage_percent={}\nguard_full_coverage_percent={}\nvisited_state_count={}\nrepeated_state_count={}\nstep_count={}\nmax_depth_observed={}\ngate_status={}\n{}",
+        "COVERAGE model={}\ntransition_coverage_percent={}\ndecision_coverage_percent={}\nguard_full_coverage_percent={}\nvisited_state_count={}\nrepeated_state_count={}\nstep_count={}\nmax_depth_observed={}\ngate_status={}\n{}",
         report.model_id,
         report.transition_coverage_percent,
+        report.decision_coverage_percent,
         report.guard_full_coverage_percent,
         report.visited_state_count,
         report.repeated_state_count,
@@ -350,6 +427,9 @@ pub fn validate_coverage_report(report: &CoverageReport) -> Result<(), String> {
     if report.transition_coverage_percent > 100 {
         return Err("transition_coverage_percent must not exceed 100".to_string());
     }
+    if report.decision_coverage_percent > 100 {
+        return Err("decision_coverage_percent must not exceed 100".to_string());
+    }
     if report.guard_full_coverage_percent > 100 {
         return Err("guard_full_coverage_percent must not exceed 100".to_string());
     }
@@ -364,6 +444,19 @@ pub fn validate_coverage_report(report: &CoverageReport) -> Result<(), String> {
     for action in report.action_execution_counts.keys() {
         if !report.total_actions.contains(action) {
             return Err("action_execution_counts must reference declared actions only".to_string());
+        }
+    }
+    if report.covered_decisions.len() > report.total_decisions.len() {
+        return Err("covered_decisions must be a subset of total_decisions".to_string());
+    }
+    for decision_id in &report.covered_decisions {
+        if !report.total_decisions.contains(decision_id) {
+            return Err("covered_decisions must reference declared decisions only".to_string());
+        }
+    }
+    for decision_id in report.decision_counts.keys() {
+        if !report.total_decisions.contains(decision_id) {
+            return Err("decision_counts must reference declared decisions only".to_string());
         }
     }
     for action in report.guard_true_counts.keys() {
@@ -394,6 +487,7 @@ pub fn validate_rendered_coverage_json(body: &str) -> Result<(), String> {
         "summary",
     )?;
     require_number_field(summary, "transition_coverage_percent")?;
+    require_number_field(summary, "decision_coverage_percent")?;
     require_number_field(summary, "guard_full_coverage_percent")?;
     require_number_field(summary, "visited_state_count")?;
     require_number_field(summary, "repeated_state_count")?;
@@ -404,6 +498,12 @@ pub fn validate_rendered_coverage_json(body: &str) -> Result<(), String> {
         require_string_field(action_object, "action_id")?;
         require_bool_field(action_object, "covered")?;
         require_number_field(action_object, "count")?;
+    }
+    for decision in require_array_field(object, "decisions")? {
+        let decision_object = require_object(decision, "decisions[]")?;
+        require_string_field(decision_object, "decision_id")?;
+        require_bool_field(decision_object, "covered")?;
+        require_number_field(decision_object, "count")?;
     }
     for guard in require_array_field(object, "guards")? {
         let guard_object = require_object(guard, "guards[]")?;
@@ -493,6 +593,7 @@ mod tests {
                 depth: 1,
                 state_before: BTreeMap::from([("x".to_string(), Value::UInt(0))]),
                 state_after: BTreeMap::from([("x".to_string(), Value::UInt(1))]),
+                path: None,
                 note: None,
             }],
         };
@@ -500,6 +601,7 @@ mod tests {
         assert_eq!(report.schema_version, "1.0.0");
         assert_eq!(report.model_id, "A");
         assert_eq!(report.transition_coverage_percent, 50);
+        assert_eq!(report.decision_coverage_percent, 50);
         assert_eq!(report.guard_full_coverage_percent, 0);
         assert_eq!(report.visited_state_count, 2);
         assert_eq!(report.repeated_state_count, 0);
@@ -523,6 +625,7 @@ mod tests {
         let text = render_coverage_text(&report);
         assert!(text.contains("gate_status=fail"));
         assert!(text.contains("transition_coverage_percent=50"));
+        assert!(text.contains("decision_coverage_percent=50"));
         assert!(text.contains("repeated_state_count=0"));
     }
 

--- a/packages/valid/src/engine/explicit.rs
+++ b/packages/valid/src/engine/explicit.rs
@@ -62,6 +62,7 @@ struct NodeRecord {
     state: MachineState,
     depth: usize,
     parent: Option<usize>,
+    via_action_index: Option<usize>,
     via_action: Option<String>,
     note: Option<String>,
 }
@@ -100,6 +101,7 @@ fn run_explicit(model: &ModelIr, plan: &RunPlan) -> Result<ExplicitRunResult, Di
         state: initial.clone(),
         depth: 0,
         parent: None,
+        via_action_index: None,
         via_action: None,
         note: Some("initial state".to_string()),
     }];
@@ -127,7 +129,7 @@ fn run_explicit(model: &ModelIr, plan: &RunPlan) -> Result<ExplicitRunResult, Di
         }
 
         let mut enabled = 0usize;
-        for action in &model.actions {
+        for (action_index, action) in model.actions.iter().enumerate() {
             explored_transitions += 1;
             match apply_action_transition(model, &node.state, action)? {
                 Some(next_state) => {
@@ -153,6 +155,7 @@ fn run_explicit(model: &ModelIr, plan: &RunPlan) -> Result<ExplicitRunResult, Di
                             state: next_state,
                             depth: node.depth + 1,
                             parent: Some(node_index),
+                            via_action_index: Some(action_index),
                             via_action: Some(action.action_id.clone()),
                             note: None,
                         });
@@ -445,6 +448,10 @@ fn build_trace(
             depth: to.depth as u32,
             state_before: from.state.as_named_map(model),
             state_after: to.state.as_named_map(model),
+            path: to
+                .via_action_index
+                .and_then(|action_index| model.actions.get(action_index))
+                .map(|action| action.decision_path()),
             note: if window[1] == end_index {
                 final_note.clone().or_else(|| to.note.clone())
             } else {

--- a/packages/valid/src/evidence/mod.rs
+++ b/packages/valid/src/evidence/mod.rs
@@ -7,7 +7,7 @@ use crate::{
         explicit::{CheckErrorEnvelope, CheckOutcome, ExplicitRunResult},
         ArtifactPolicy, AssuranceLevel, ErrorStatus, RunStatus, UnknownReason,
     },
-    ir::Value,
+    ir::{DecisionKind, DecisionOutcome, Path, Value},
     support::{
         artifact::{evidence_path, run_result_path, vector_path},
         diagnostics::Diagnostic,
@@ -48,6 +48,7 @@ pub struct TraceStep {
     pub depth: u32,
     pub state_before: BTreeMap<String, Value>,
     pub state_after: BTreeMap<String, Value>,
+    pub path: Option<Path>,
     pub note: Option<String>,
 }
 
@@ -116,6 +117,19 @@ pub fn validate_trace(trace: &EvidenceTrace) -> Result<(), String> {
         }
         require_non_empty(&step.from_state_id, "steps[].from_state_id")?;
         require_non_empty(&step.to_state_id, "steps[].to_state_id")?;
+        if let Some(path) = &step.path {
+            for decision in &path.decisions {
+                require_non_empty(
+                    &decision.point.decision_id,
+                    "steps[].path.decisions[].decision_id",
+                )?;
+                require_non_empty(
+                    &decision.point.action_id,
+                    "steps[].path.decisions[].action_id",
+                )?;
+                require_non_empty(&decision.point.label, "steps[].path.decisions[].label")?;
+            }
+        }
     }
     Ok(())
 }
@@ -194,6 +208,11 @@ pub fn render_trace_json(trace: &EvidenceTrace) -> String {
         out.push_str(&format!(",\"depth\":{}", step.depth));
         append_state_map(&mut out, "state_before", &step.state_before);
         append_state_map(&mut out, "state_after", &step.state_after);
+        if let Some(path) = &step.path {
+            out.push_str(&format!(",\"path\":{}", render_path_json(path)));
+        } else {
+            out.push_str(",\"path\":null");
+        }
         out.push('}');
     }
     out.push_str("]}");
@@ -277,6 +296,20 @@ pub fn validate_rendered_trace_json(body: &str) -> Result<(), String> {
         require_string_field(step_object, "from_state_id")?;
         require_string_field(step_object, "to_state_id")?;
         require_number_field(step_object, "depth")?;
+        if let Some(path) = step_object.get("path") {
+            if !matches!(path, crate::support::json::JsonValue::Null) {
+                let path_object = require_object(path, "trace.steps[].path")?;
+                for decision in require_array_field(path_object, "decisions")? {
+                    let decision_object =
+                        require_object(decision, "trace.steps[].path.decisions[]")?;
+                    require_string_field(decision_object, "decision_id")?;
+                    require_string_field(decision_object, "action_id")?;
+                    require_string_field(decision_object, "kind")?;
+                    require_string_field(decision_object, "label")?;
+                    require_string_field(decision_object, "outcome")?;
+                }
+            }
+        }
     }
     Ok(())
 }
@@ -358,6 +391,66 @@ fn render_completed_text(result: &ExplicitRunResult) -> String {
         }
     }
     out
+}
+
+fn render_path_json(path: &Path) -> String {
+    let mut out = String::from("{\"decisions\":[");
+    for (index, decision) in path.decisions.iter().enumerate() {
+        if index > 0 {
+            out.push(',');
+        }
+        out.push('{');
+        out.push_str(&format!(
+            "\"decision_id\":\"{}\"",
+            escape_json(&decision.decision_id())
+        ));
+        out.push_str(&format!(
+            ",\"action_id\":\"{}\"",
+            escape_json(&decision.point.action_id)
+        ));
+        out.push_str(&format!(
+            ",\"kind\":\"{}\"",
+            match decision.point.kind {
+                DecisionKind::Guard => "guard",
+                DecisionKind::StateUpdate => "state_update",
+            }
+        ));
+        out.push_str(&format!(
+            ",\"label\":\"{}\"",
+            escape_json(&decision.point.label)
+        ));
+        if let Some(field) = &decision.point.field {
+            out.push_str(&format!(",\"field\":\"{}\"", escape_json(field)));
+        } else {
+            out.push_str(",\"field\":null");
+        }
+        append_string_array(&mut out, "reads", &decision.point.reads);
+        append_string_array(&mut out, "writes", &decision.point.writes);
+        append_string_array(&mut out, "path_tags", &decision.point.path_tags);
+        out.push_str(&format!(
+            ",\"outcome\":\"{}\"",
+            match decision.outcome {
+                DecisionOutcome::GuardTrue => "guard_true",
+                DecisionOutcome::GuardFalse => "guard_false",
+                DecisionOutcome::UpdateApplied => "update_applied",
+            }
+        ));
+        out.push('}');
+    }
+    out.push_str("]}");
+    out
+}
+
+fn append_string_array(out: &mut String, key: &str, values: &[String]) {
+    out.push_str(&format!(",\"{}\":", key));
+    out.push('[');
+    for (index, value) in values.iter().enumerate() {
+        if index > 0 {
+            out.push(',');
+        }
+        out.push_str(&format!("\"{}\"", escape_json(value)));
+    }
+    out.push(']');
 }
 
 fn render_error_text(error: &CheckErrorEnvelope) -> String {
@@ -741,6 +834,7 @@ mod tests {
                     depth: 1,
                     state_before: BTreeMap::from([("x".to_string(), crate::ir::Value::UInt(0))]),
                     state_after: BTreeMap::from([("x".to_string(), crate::ir::Value::UInt(2))]),
+                    path: None,
                     note: None,
                 }],
             }),
@@ -823,6 +917,7 @@ mod tests {
                 depth: 1,
                 state_before: BTreeMap::new(),
                 state_after: BTreeMap::new(),
+                path: None,
                 note: None,
             }],
         };

--- a/packages/valid/src/ir/action.rs
+++ b/packages/valid/src/ir/action.rs
@@ -1,4 +1,4 @@
-use crate::ir::expr::ExprIr;
+use crate::ir::{expr::ExprIr, Path};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ActionIr {
@@ -15,4 +15,14 @@ pub struct ActionIr {
 pub struct UpdateIr {
     pub field: String,
     pub value: ExprIr,
+}
+
+impl ActionIr {
+    pub fn decision_path(&self) -> Path {
+        Path::from_action(self, true)
+    }
+
+    pub fn decision_path_for_guard(&self, guard_enabled: bool) -> Path {
+        Path::from_action(self, guard_enabled)
+    }
 }

--- a/packages/valid/src/ir/decision.rs
+++ b/packages/valid/src/ir/decision.rs
@@ -1,0 +1,58 @@
+use std::collections::BTreeSet;
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub enum DecisionKind {
+    Guard,
+    StateUpdate,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub enum DecisionOutcome {
+    GuardTrue,
+    GuardFalse,
+    UpdateApplied,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DecisionPoint {
+    pub decision_id: String,
+    pub action_id: String,
+    pub kind: DecisionKind,
+    pub label: String,
+    pub field: Option<String>,
+    pub reads: Vec<String>,
+    pub writes: Vec<String>,
+    pub path_tags: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Decision {
+    pub point: DecisionPoint,
+    pub outcome: DecisionOutcome,
+}
+
+impl DecisionPoint {
+    pub fn legacy_path_tags(&self) -> Vec<String> {
+        let tags = self
+            .path_tags
+            .iter()
+            .filter(|tag| !tag.is_empty())
+            .cloned()
+            .collect::<BTreeSet<_>>();
+        if tags.is_empty() {
+            vec!["transition_path".to_string()]
+        } else {
+            tags.into_iter().collect()
+        }
+    }
+}
+
+impl Decision {
+    pub fn decision_id(&self) -> String {
+        match self.outcome {
+            DecisionOutcome::GuardTrue => format!("{}:true", self.point.decision_id),
+            DecisionOutcome::GuardFalse => format!("{}:false", self.point.decision_id),
+            DecisionOutcome::UpdateApplied => self.point.decision_id.clone(),
+        }
+    }
+}

--- a/packages/valid/src/ir/mod.rs
+++ b/packages/valid/src/ir/mod.rs
@@ -1,13 +1,17 @@
 //! Canonical intermediate representations shared across backends.
 
 pub mod action;
+pub mod decision;
 pub mod expr;
 pub mod model;
+pub mod path;
 pub mod property;
 pub mod value;
 
 pub use action::{ActionIr, UpdateIr};
+pub use decision::{Decision, DecisionKind, DecisionOutcome, DecisionPoint};
 pub use expr::{BinaryOp, ExprIr, UnaryOp};
 pub use model::{FieldId, FieldType, InitAssignment, ModelIr, PropertyId, SourceSpan, StateField};
+pub use path::{build_path_from_parts, decision_path_tags, infer_decision_path_tags, Path};
 pub use property::{PropertyIr, PropertyKind};
 pub use value::Value;

--- a/packages/valid/src/ir/path.rs
+++ b/packages/valid/src/ir/path.rs
@@ -1,0 +1,237 @@
+use std::collections::BTreeSet;
+
+use crate::ir::{
+    ActionIr, Decision, DecisionKind, DecisionOutcome, DecisionPoint, ExprIr, UpdateIr,
+};
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct Path {
+    pub decisions: Vec<Decision>,
+}
+
+impl Path {
+    pub fn new(decisions: Vec<Decision>) -> Self {
+        Self { decisions }
+    }
+
+    pub fn from_action(action: &ActionIr, guard_enabled: bool) -> Self {
+        build_path_from_parts(
+            &action.action_id,
+            &action.reads,
+            &action.writes,
+            action.path_tags.clone(),
+            Some(render_expr_label(&action.guard)),
+            action
+                .updates
+                .iter()
+                .map(|update| (update.field.clone(), render_update_label(update)))
+                .collect(),
+            guard_enabled,
+        )
+    }
+
+    pub fn from_legacy_tags(tags: Vec<String>) -> Self {
+        let tags = normalize_path_tags(tags);
+        Self {
+            decisions: vec![Decision {
+                point: DecisionPoint {
+                    decision_id: "legacy#path".to_string(),
+                    action_id: "legacy".to_string(),
+                    kind: DecisionKind::Guard,
+                    label: "legacy path".to_string(),
+                    field: None,
+                    reads: Vec::new(),
+                    writes: Vec::new(),
+                    path_tags: tags,
+                },
+                outcome: DecisionOutcome::GuardTrue,
+            }],
+        }
+    }
+
+    pub fn extend(&mut self, other: Path) {
+        self.decisions.extend(other.decisions);
+    }
+
+    pub fn legacy_path_tags(&self) -> Vec<String> {
+        let tags = self
+            .decisions
+            .iter()
+            .flat_map(|decision| decision.point.legacy_path_tags())
+            .collect::<BTreeSet<_>>();
+        if tags.is_empty() {
+            vec!["transition_path".to_string()]
+        } else {
+            tags.into_iter().collect()
+        }
+    }
+
+    pub fn decision_ids(&self) -> Vec<String> {
+        self.decisions.iter().map(Decision::decision_id).collect()
+    }
+}
+
+pub fn build_path_from_parts(
+    action_id: &str,
+    reads: &[String],
+    writes: &[String],
+    path_tags: Vec<String>,
+    guard_label: Option<String>,
+    updates: Vec<(String, String)>,
+    guard_enabled: bool,
+) -> Path {
+    let path_tags = normalize_path_tags(path_tags);
+    let mut decisions = Vec::new();
+    decisions.push(Decision {
+        point: DecisionPoint {
+            decision_id: format!("{action_id}#guard"),
+            action_id: action_id.to_string(),
+            kind: DecisionKind::Guard,
+            label: guard_label.unwrap_or_else(|| format!("{action_id} transition")),
+            field: None,
+            reads: reads.to_vec(),
+            writes: writes.to_vec(),
+            path_tags: path_tags.clone(),
+        },
+        outcome: if guard_enabled {
+            DecisionOutcome::GuardTrue
+        } else {
+            DecisionOutcome::GuardFalse
+        },
+    });
+    if guard_enabled {
+        for (field, label) in updates {
+            decisions.push(Decision {
+                point: DecisionPoint {
+                    decision_id: format!("{action_id}#update:{field}"),
+                    action_id: action_id.to_string(),
+                    kind: DecisionKind::StateUpdate,
+                    label,
+                    field: Some(field),
+                    reads: reads.to_vec(),
+                    writes: writes.to_vec(),
+                    path_tags: path_tags.clone(),
+                },
+                outcome: DecisionOutcome::UpdateApplied,
+            });
+        }
+    }
+    if decisions.is_empty() {
+        return Path {
+            decisions: vec![Decision {
+                point: DecisionPoint {
+                    decision_id: format!("{action_id}#path"),
+                    action_id: action_id.to_string(),
+                    kind: DecisionKind::Guard,
+                    label: "legacy path".to_string(),
+                    field: None,
+                    reads: reads.to_vec(),
+                    writes: writes.to_vec(),
+                    path_tags,
+                },
+                outcome: DecisionOutcome::GuardTrue,
+            }],
+        };
+    }
+    Path { decisions }
+}
+
+pub fn infer_decision_path_tags<'a, RI, WI>(
+    action_id: &str,
+    reads: RI,
+    writes: WI,
+    guard: Option<&str>,
+    effect: Option<&str>,
+) -> Vec<String>
+where
+    RI: IntoIterator<Item = &'a str>,
+    WI: IntoIterator<Item = &'a str>,
+{
+    let reads = reads.into_iter().collect::<Vec<_>>();
+    let writes = writes.into_iter().collect::<Vec<_>>();
+    let mut tags = BTreeSet::new();
+    if guard.is_some() {
+        tags.insert("guard_path".to_string());
+    }
+    if !reads.is_empty() {
+        tags.insert("read_path".to_string());
+    }
+    if !writes.is_empty() {
+        tags.insert("write_path".to_string());
+    }
+    let mut text = action_id.to_ascii_lowercase();
+    for part in &reads {
+        text.push(' ');
+        text.push_str(&part.to_ascii_lowercase());
+    }
+    for part in &writes {
+        text.push(' ');
+        text.push_str(&part.to_ascii_lowercase());
+    }
+    if let Some(guard) = guard {
+        text.push(' ');
+        text.push_str(&guard.to_ascii_lowercase());
+    }
+    if let Some(effect) = effect {
+        text.push(' ');
+        text.push_str(&effect.to_ascii_lowercase());
+    }
+    for (needle, tag) in [
+        ("allow", "allow_path"),
+        ("deny", "deny_path"),
+        ("boundary", "boundary_path"),
+        ("exception", "exception_path"),
+        ("session", "session_path"),
+        ("lock", "state_gate_path"),
+    ] {
+        if text.contains(needle) {
+            tags.insert(tag.to_string());
+        }
+    }
+    if tags.is_empty() {
+        tags.insert("transition_path".to_string());
+    }
+    tags.into_iter().collect()
+}
+
+pub fn decision_path_tags<'a, RI, WI>(
+    explicit_tags: &[&str],
+    action_id: &str,
+    reads: RI,
+    writes: WI,
+    guard: Option<&str>,
+    effect: Option<&str>,
+) -> Vec<String>
+where
+    RI: IntoIterator<Item = &'a str>,
+    WI: IntoIterator<Item = &'a str>,
+{
+    let mut tags = explicit_tags
+        .iter()
+        .map(|tag| tag.to_string())
+        .collect::<BTreeSet<_>>();
+    tags.extend(infer_decision_path_tags(
+        action_id, reads, writes, guard, effect,
+    ));
+    tags.into_iter().collect()
+}
+
+fn normalize_path_tags(tags: Vec<String>) -> Vec<String> {
+    let tags = tags
+        .into_iter()
+        .filter(|tag| !tag.is_empty())
+        .collect::<BTreeSet<_>>();
+    if tags.is_empty() {
+        vec!["transition_path".to_string()]
+    } else {
+        tags.into_iter().collect()
+    }
+}
+
+fn render_expr_label(expr: &ExprIr) -> String {
+    format!("{expr:?}")
+}
+
+fn render_update_label(update: &UpdateIr) -> String {
+    format!("{} = {:?}", update.field, update.value)
+}

--- a/packages/valid/src/modeling/mod.rs
+++ b/packages/valid/src/modeling/mod.rs
@@ -22,8 +22,10 @@ use crate::{
     },
     evidence::{EvidenceKind, EvidenceTrace, TraceStep},
     ir::{
-        ActionIr, BinaryOp, ExprIr, FieldType, InitAssignment, ModelIr, PropertyIr, SourceSpan,
-        StateField, UnaryOp, UpdateIr, Value,
+        build_path_from_parts, decision_path_tags as ir_decision_path_tags,
+        infer_decision_path_tags as ir_infer_decision_path_tags, ActionIr, BinaryOp, ExprIr,
+        FieldType, InitAssignment, ModelIr, Path, PropertyIr, SourceSpan, StateField, UnaryOp,
+        UpdateIr, Value,
     },
     solver::{run_with_adapter, AdapterConfig},
     support::hash::stable_hash_hex,
@@ -715,51 +717,7 @@ where
     RI: IntoIterator<Item = &'a str>,
     WI: IntoIterator<Item = &'a str>,
 {
-    let reads = reads.into_iter().collect::<Vec<_>>();
-    let writes = writes.into_iter().collect::<Vec<_>>();
-    let mut tags = BTreeSet::new();
-    if guard.is_some() {
-        tags.insert("guard_path".to_string());
-    }
-    if !reads.is_empty() {
-        tags.insert("read_path".to_string());
-    }
-    if !writes.is_empty() {
-        tags.insert("write_path".to_string());
-    }
-    let mut text = action_id.to_ascii_lowercase();
-    for part in &reads {
-        text.push(' ');
-        text.push_str(&part.to_ascii_lowercase());
-    }
-    for part in &writes {
-        text.push(' ');
-        text.push_str(&part.to_ascii_lowercase());
-    }
-    if let Some(guard) = guard {
-        text.push(' ');
-        text.push_str(&guard.to_ascii_lowercase());
-    }
-    if let Some(effect) = effect {
-        text.push(' ');
-        text.push_str(&effect.to_ascii_lowercase());
-    }
-    for (needle, tag) in [
-        ("allow", "allow_path"),
-        ("deny", "deny_path"),
-        ("boundary", "boundary_path"),
-        ("exception", "exception_path"),
-        ("session", "session_path"),
-        ("lock", "state_gate_path"),
-    ] {
-        if text.contains(needle) {
-            tags.insert(tag.to_string());
-        }
-    }
-    if tags.is_empty() {
-        tags.insert("transition_path".to_string());
-    }
-    tags.into_iter().collect()
+    ir_infer_decision_path_tags(action_id, reads, writes, guard, effect)
 }
 
 pub fn decision_path_tags<'a, RI, WI>(
@@ -774,14 +732,7 @@ where
     RI: IntoIterator<Item = &'a str>,
     WI: IntoIterator<Item = &'a str>,
 {
-    let mut tags = explicit_tags
-        .iter()
-        .map(|tag| tag.to_string())
-        .collect::<BTreeSet<_>>();
-    tags.extend(infer_decision_path_tags(
-        action_id, reads, writes, guard, effect,
-    ));
-    tags.into_iter().collect()
+    ir_decision_path_tags(explicit_tags, action_id, reads, writes, guard, effect)
 }
 
 pub trait StateSpec: ModelingState {
@@ -1001,25 +952,56 @@ fn collect_solver_subset_reasons_from_expr(expr: &ExprIr, reasons: &mut BTreeSet
 }
 
 pub fn machine_transition_tags_for_action<M: ModelSpec>(action_id: &str) -> Vec<String> {
-    let mut tags = BTreeSet::new();
+    machine_transition_path_for_action::<M>(action_id, true).legacy_path_tags()
+}
+
+pub fn machine_transition_path_for_action<M: ModelSpec>(
+    action_id: &str,
+    guard_enabled: bool,
+) -> Path {
+    let mut path = Path::default();
     for transition in machine_transition_ir::<M>()
         .into_iter()
         .filter(|transition| transition.action_id == action_id)
     {
-        tags.extend(decision_path_tags(
-            &transition.path_tags,
+        path.extend(build_path_from_parts(
             transition.action_id,
-            transition.reads.iter().copied(),
-            transition.writes.iter().copied(),
-            transition.guard,
-            transition.effect,
+            &transition
+                .reads
+                .iter()
+                .map(|item| item.to_string())
+                .collect::<Vec<_>>(),
+            &transition
+                .writes
+                .iter()
+                .map(|item| item.to_string())
+                .collect::<Vec<_>>(),
+            decision_path_tags(
+                &transition.path_tags,
+                transition.action_id,
+                transition.reads.iter().copied(),
+                transition.writes.iter().copied(),
+                transition.guard,
+                transition.effect,
+            ),
+            transition.guard.map(str::to_string),
+            transition
+                .updates
+                .iter()
+                .map(|update| {
+                    (
+                        update.field.to_string(),
+                        update
+                            .expr
+                            .map(str::to_string)
+                            .unwrap_or_else(|| update.field.to_string()),
+                    )
+                })
+                .collect(),
+            guard_enabled,
         ));
     }
-    if tags.is_empty() {
-        vec!["transition_path".to_string()]
-    } else {
-        tags.into_iter().collect()
-    }
+    path
 }
 
 fn machine_capability_reasons<M: VerifiedMachine>(error: &str) -> Vec<String> {
@@ -1753,8 +1735,19 @@ pub fn collect_machine_coverage<M: VerifiedMachine>() -> CoverageReport {
         .into_iter()
         .map(|action| action.action_id())
         .collect::<BTreeSet<_>>();
+    let total_decisions = total_actions
+        .iter()
+        .flat_map(|action_id| {
+            machine_transition_path_for_action::<M>(action_id, true)
+                .decision_ids()
+                .into_iter()
+                .chain(machine_transition_path_for_action::<M>(action_id, false).decision_ids())
+        })
+        .collect::<BTreeSet<_>>();
     let mut covered_actions = BTreeSet::new();
+    let mut covered_decisions = BTreeSet::new();
     let mut action_execution_counts = BTreeMap::new();
+    let mut decision_counts = BTreeMap::new();
     let mut guard_true_actions = BTreeSet::new();
     let mut guard_false_actions = BTreeSet::new();
     let mut guard_true_counts = BTreeMap::new();
@@ -1762,16 +1755,35 @@ pub fn collect_machine_coverage<M: VerifiedMachine>() -> CoverageReport {
     let mut path_tag_counts = BTreeMap::new();
     let mut depth_histogram = BTreeMap::new();
     let mut repeated_state_count = 0usize;
-    let transition_ir = machine_transition_ir::<M>();
 
     for node in &exploration.nodes {
         *depth_histogram.entry(node.depth).or_insert(0) += 1;
         for action in M::Action::all() {
             let next_states = M::step(&node.state, &action);
             if next_states.is_empty() {
+                for decision_id in
+                    machine_transition_path_for_action::<M>(&action.action_id(), false)
+                        .decisions
+                        .into_iter()
+                        .take(1)
+                        .map(|decision| decision.decision_id())
+                {
+                    covered_decisions.insert(decision_id.clone());
+                    *decision_counts.entry(decision_id).or_insert(0) += 1;
+                }
                 guard_false_actions.insert(action.action_id());
                 *guard_false_counts.entry(action.action_id()).or_insert(0) += 1;
             } else {
+                for decision_id in
+                    machine_transition_path_for_action::<M>(&action.action_id(), true)
+                        .decisions
+                        .into_iter()
+                        .take(1)
+                        .map(|decision| decision.decision_id())
+                {
+                    covered_decisions.insert(decision_id.clone());
+                    *decision_counts.entry(decision_id).or_insert(0) += 1;
+                }
                 guard_true_actions.insert(action.action_id());
                 *guard_true_counts.entry(action.action_id()).or_insert(0) += 1;
             }
@@ -1782,20 +1794,19 @@ pub fn collect_machine_coverage<M: VerifiedMachine>() -> CoverageReport {
         let action_id = edge.action.action_id();
         covered_actions.insert(action_id.clone());
         *action_execution_counts.entry(action_id).or_insert(0) += 1;
-        if let Some(transition) = transition_ir
-            .iter()
-            .find(|transition| transition.action_id == edge.action.action_id())
+        for decision_id in machine_transition_path_for_action::<M>(&edge.action.action_id(), true)
+            .decisions
+            .into_iter()
+            .skip(1)
+            .map(|decision| decision.decision_id())
         {
-            for tag in decision_path_tags(
-                &transition.path_tags,
-                transition.action_id,
-                transition.reads.iter().copied(),
-                transition.writes.iter().copied(),
-                transition.guard,
-                transition.effect,
-            ) {
-                *path_tag_counts.entry(tag).or_insert(0) += 1;
-            }
+            covered_decisions.insert(decision_id.clone());
+            *decision_counts.entry(decision_id).or_insert(0) += 1;
+        }
+        for tag in machine_transition_path_for_action::<M>(&edge.action.action_id(), true)
+            .legacy_path_tags()
+        {
+            *path_tag_counts.entry(tag).or_insert(0) += 1;
         }
         if edge.to_index <= edge.from_index {
             repeated_state_count += 1;
@@ -1806,6 +1817,11 @@ pub fn collect_machine_coverage<M: VerifiedMachine>() -> CoverageReport {
         100
     } else {
         ((covered_actions.len() * 100) / total_actions.len()) as u32
+    };
+    let decision_coverage_percent = if total_decisions.is_empty() {
+        100
+    } else {
+        ((covered_decisions.len() * 100) / total_decisions.len()) as u32
     };
     let fully_covered_guards = total_actions
         .iter()
@@ -1837,10 +1853,14 @@ pub fn collect_machine_coverage<M: VerifiedMachine>() -> CoverageReport {
         schema_version: "1.0.0".to_string(),
         model_id: M::model_id().to_string(),
         transition_coverage_percent,
+        decision_coverage_percent,
         guard_full_coverage_percent,
         covered_actions,
+        covered_decisions,
         total_actions,
+        total_decisions,
         action_execution_counts,
+        decision_counts,
         visited_state_count: exploration.nodes.len(),
         repeated_state_count,
         max_depth_observed: exploration
@@ -1894,6 +1914,7 @@ pub fn explain_machine<M: VerifiedMachine>(request_id: &str) -> Result<ExplainRe
         .find(|transition| transition.action_id == action_id);
     let mut action_reads = Vec::new();
     let mut action_writes = Vec::new();
+    let mut decision_path = failure_step.path.clone().unwrap_or_default();
     let mut action_path_tags = Vec::new();
     let mut write_overlap_fields = Vec::new();
     let mut candidate_causes = Vec::new();
@@ -1951,14 +1972,8 @@ pub fn explain_machine<M: VerifiedMachine>(request_id: &str) -> Result<ExplainRe
             .filter(|field| transition.writes.contains(&field.as_str()))
             .cloned()
             .collect();
-        let path_tags = decision_path_tags(
-            &transition.path_tags,
-            transition.action_id,
-            transition.reads.iter().copied(),
-            transition.writes.iter().copied(),
-            transition.guard,
-            transition.effect,
-        );
+        decision_path = machine_transition_path_for_action::<M>(transition.action_id, true);
+        let path_tags = decision_path.legacy_path_tags();
         action_path_tags = path_tags.clone();
         if !path_tags.is_empty() {
             candidate_causes.push(ExplainCandidateCause {
@@ -2021,6 +2036,7 @@ pub fn explain_machine<M: VerifiedMachine>(request_id: &str) -> Result<ExplainRe
         property_id: trace.property_id,
         failure_step_index: failure_step.index,
         failing_action_id: Some(action_id.clone()),
+        decision_path,
         failing_action_reads: action_reads,
         failing_action_writes: action_writes,
         failing_action_path_tags: action_path_tags,
@@ -2089,6 +2105,10 @@ pub fn build_machine_test_vectors_for_property<M: VerifiedMachine>(
                 focus_field: None,
                 expected_guard_enabled: Some(true),
                 expected_property_holds: Some(true),
+                expected_path: machine_transition_path_for_action::<M>(
+                    &edge.action.action_id(),
+                    true,
+                ),
                 expected_path_tags: machine_transition_tags_for_action::<M>(
                     &edge.action.action_id(),
                 ),
@@ -2417,10 +2437,20 @@ fn build_machine_vector_for_node<M: VerifiedMachine>(
         .join(",");
     let property = find_property::<M>(property_id);
     let property_holds = (property.holds)(&nodes.get(end_index)?.state);
-    let expected_path_tags = focus_action_id
+    let expected_path = focus_action_id
         .as_deref()
-        .map(machine_transition_tags_for_action::<M>)
+        .map(|action_id| {
+            machine_transition_path_for_action::<M>(
+                action_id,
+                expected_guard_enabled.unwrap_or(true),
+            )
+        })
         .unwrap_or_default();
+    let expected_path_tags = if expected_path.decisions.is_empty() {
+        Vec::new()
+    } else {
+        expected_path.legacy_path_tags()
+    };
     Some(TestVector {
         schema_version: "1.0.0".to_string(),
         vector_id: format!(
@@ -2465,6 +2495,7 @@ fn build_machine_vector_for_node<M: VerifiedMachine>(
         focus_field,
         expected_guard_enabled,
         expected_property_holds: Some(property_holds),
+        expected_path,
         expected_path_tags,
         notes,
         replay_target: None,
@@ -3502,7 +3533,7 @@ pub fn replay_machine_actions<M: VerifiedMachine>(
         &'static str,
         Option<bool>,
         bool,
-        Vec<String>,
+        Path,
     ),
     String,
 > {
@@ -3533,16 +3564,21 @@ pub fn replay_machine_actions<M: VerifiedMachine>(
             .unwrap_or(false)
     });
     let property_holds = (property.holds)(&state);
-    let transition_ir = machine_transition_ir::<M>();
-    let mut path_tags = BTreeSet::new();
+    let mut path = Path::default();
     for action_id in action_ids {
-        for transition in transition_ir
-            .iter()
-            .filter(|transition| transition.action_id == action_id.as_str())
-        {
-            for tag in &transition.path_tags {
-                path_tags.insert((*tag).to_string());
-            }
+        path.extend(machine_transition_path_for_action::<M>(action_id, true));
+    }
+    if let Some(action_id) = focus_action_id {
+        let focus_is_already_last = action_ids.last().map(String::as_str) == Some(action_id);
+        if !focus_is_already_last {
+            let guard_enabled = focus_action_enabled.unwrap_or(false);
+            path.extend(Path::new(
+                machine_transition_path_for_action::<M>(action_id, guard_enabled)
+                    .decisions
+                    .into_iter()
+                    .take(1)
+                    .collect(),
+            ));
         }
     }
     Ok((
@@ -3550,7 +3586,7 @@ pub fn replay_machine_actions<M: VerifiedMachine>(
         property.property_id,
         focus_action_enabled,
         property_holds,
-        path_tags.into_iter().collect(),
+        path,
     ))
 }
 
@@ -3712,6 +3748,10 @@ fn build_evidence_trace<M: VerifiedMachine>(
             depth: (index + 1) as u32,
             state_before: step.state_before.snapshot(),
             state_after: step.state_after.snapshot(),
+            path: Some(machine_transition_path_for_action::<M>(
+                &step.action.action_id(),
+                true,
+            )),
             note: None,
         })
         .collect::<Vec<_>>();

--- a/packages/valid/src/registry.rs
+++ b/packages/valid/src/registry.rs
@@ -746,7 +746,7 @@ fn replay_machine<M: VerifiedMachine>(
     action_ids: &[String],
     focus_action_id: Option<&str>,
 ) -> Result<String, String> {
-    let (terminal_state, property_id, focus_action_enabled, property_holds, path_tags) =
+    let (terminal_state, property_id, focus_action_enabled, property_holds, path) =
         replay_machine_actions::<M>(property_id, action_ids, focus_action_id)?;
     Ok(render_replay_json(
         property_id,
@@ -755,7 +755,7 @@ fn replay_machine<M: VerifiedMachine>(
         focus_action_id,
         focus_action_enabled,
         Some(property_holds),
-        &path_tags,
+        &path,
     ))
 }
 

--- a/packages/valid/src/reporter/mod.rs
+++ b/packages/valid/src/reporter/mod.rs
@@ -872,6 +872,7 @@ mod tests {
                 depth: 1,
                 state_before: BTreeMap::from([("x".to_string(), Value::UInt(0))]),
                 state_after: BTreeMap::from([("x".to_string(), Value::UInt(2))]),
+                path: None,
                 note: None,
             }],
         };

--- a/packages/valid/src/solver/mod.rs
+++ b/packages/valid/src/solver/mod.rs
@@ -715,6 +715,7 @@ impl SolverAdapter for CommandSolverAdapter {
                             depth: action_ids.len() as u32,
                             state_before: initial.as_named_map(model),
                             state_after: terminal.as_named_map(model),
+                            path: None,
                             note: Some("normalized from command adapter".to_string()),
                         }],
                     })
@@ -775,6 +776,7 @@ fn normalize_protocol_result(
                 depth: protocol.actions.len() as u32,
                 state_before: initial.as_named_map(model),
                 state_after: terminal.as_named_map(model),
+                path: None,
                 note: Some("normalized from command adapter".to_string()),
             }],
         })

--- a/packages/valid/src/testgen/mod.rs
+++ b/packages/valid/src/testgen/mod.rs
@@ -4,7 +4,7 @@ use std::collections::{BTreeMap, BTreeSet, HashSet, VecDeque};
 
 use crate::{
     evidence::EvidenceTrace,
-    ir::{ModelIr, PropertyKind, Value},
+    ir::{DecisionKind, DecisionOutcome, ModelIr, Path, PropertyKind, Value},
     kernel::{
         eval::eval_expr,
         replay::replay_actions,
@@ -40,6 +40,7 @@ pub struct TestVector {
     pub focus_field: Option<String>,
     pub expected_guard_enabled: Option<bool>,
     pub expected_property_holds: Option<bool>,
+    pub expected_path: Path,
     pub expected_path_tags: Vec<String>,
     pub notes: Vec<String>,
     pub replay_target: Option<ReplayTarget>,
@@ -96,6 +97,8 @@ pub fn build_counterexample_vector(trace: &EvidenceTrace) -> Result<TestVector, 
         .iter()
         .map(|step| format!("{:?}", step.state_after))
         .collect::<Vec<_>>();
+    let expected_path = trace_path(trace);
+    let expected_path_tags = path_tags_or_empty(&expected_path);
     Ok(TestVector {
         schema_version: "1.0.0".to_string(),
         vector_id: trace.evidence_id.replace("ev-", "vec-"),
@@ -115,13 +118,8 @@ pub fn build_counterexample_vector(trace: &EvidenceTrace) -> Result<TestVector, 
         focus_field: None,
         expected_guard_enabled: None,
         expected_property_holds: Some(false),
-        expected_path_tags: trace
-            .steps
-            .iter()
-            .filter_map(|step| step.note.as_ref())
-            .filter_map(|note| note.strip_prefix("path_tag:"))
-            .map(str::to_string)
-            .collect(),
+        expected_path,
+        expected_path_tags,
         notes: Vec::new(),
         replay_target: None,
     })
@@ -332,6 +330,18 @@ fn synthetic_trace_from_states(
                         (field.name.clone(), after.values[field_index].clone())
                     })
                     .collect::<BTreeMap<_, _>>(),
+                path: model
+                    .actions
+                    .iter()
+                    .find(|action| {
+                        action.action_id == *action_id
+                            && apply_action_transition(model, before, action)
+                                .ok()
+                                .flatten()
+                                .map(|next| next == **after)
+                                .unwrap_or(false)
+                    })
+                    .map(|action| action.decision_path()),
                 note: Some(if transitions.len() == 1 {
                     "synthetic witness from initial state".to_string()
                 } else {
@@ -506,6 +516,12 @@ pub fn render_rust_test(vector: &TestVector) -> String {
     for tag in &vector.expected_path_tags {
         out.push_str(&format!("    expected_path_tags.push({tag:?});\n"));
     }
+    out.push_str("    let mut expected_decision_ids = Vec::new();\n");
+    for decision_id in vector.expected_path.decision_ids() {
+        out.push_str(&format!(
+            "    expected_decision_ids.push({decision_id:?});\n"
+        ));
+    }
     if let Some(target) = &vector.replay_target {
         out.push_str(&format!("    let replay_runner = {:?};\n", target.runner));
         out.push_str("    let mut replay_args = Vec::new();\n");
@@ -523,7 +539,7 @@ pub fn render_rust_test(vector: &TestVector) -> String {
         out.push_str("        .expect(\"generated replay command should execute\");\n");
         out.push_str("    assert!(output.status.success(), \"replay failed: {}\", String::from_utf8_lossy(&output.stderr));\n");
         out.push_str("    let stdout = String::from_utf8(output.stdout).expect(\"replay output must be utf-8\");\n");
-        out.push_str("    valid::testgen::assert_replay_output_json(&stdout, &actions, &expected_states, property_id, focus_action_id, expected_guard_enabled, expected_property_holds, &expected_path_tags);\n");
+        out.push_str("    valid::testgen::assert_replay_output_json(&stdout, &actions, &expected_states, property_id, focus_action_id, expected_guard_enabled, expected_property_holds, &expected_path_tags, &expected_decision_ids);\n");
     }
     out.push_str("    assert!(!vector_id.is_empty());\n");
     out.push_str("    assert!(!property_id.is_empty());\n");
@@ -561,6 +577,7 @@ pub fn assert_replay_output_json(
     expected_guard_enabled: Option<bool>,
     expected_property_holds: Option<bool>,
     expected_path_tags: &[&str],
+    expected_decision_ids: &[&str],
 ) {
     let normalized = body.trim();
     assert!(
@@ -607,6 +624,12 @@ pub fn assert_replay_output_json(
             "replay missing path tag `{tag}`: {normalized}"
         );
     }
+    for decision_id in expected_decision_ids {
+        assert!(
+            normalized.contains(&format!("\"decision_id\":\"{decision_id}\"")),
+            "replay missing decision `{decision_id}`: {normalized}"
+        );
+    }
 }
 
 pub fn render_replay_json(
@@ -616,7 +639,7 @@ pub fn render_replay_json(
     focus_action_id: Option<&str>,
     focus_action_enabled: Option<bool>,
     property_holds: Option<bool>,
-    path_tags: &[String],
+    path: &Path,
 ) -> String {
     let actions = action_ids
         .iter()
@@ -632,22 +655,63 @@ pub fn render_replay_json(
     let property_holds = property_holds
         .map(|value| value.to_string())
         .unwrap_or_else(|| "null".to_string());
-    let path_tags = path_tags
+    let path_tags = path
+        .legacy_path_tags()
         .iter()
         .map(|tag| format!("\"{tag}\""))
         .collect::<Vec<_>>()
         .join(",");
     let terminal_state = format!("{terminal_state:?}");
     format!(
-        "{{\"schema_version\":\"1.0.0\",\"status\":\"ok\",\"property_id\":\"{}\",\"replayed_actions\":[{}],\"terminal_state\":{:?},\"focus_action_id\":{},\"focus_action_enabled\":{},\"property_holds\":{},\"path_tags\":[{}]}}",
+        "{{\"schema_version\":\"1.0.0\",\"status\":\"ok\",\"property_id\":\"{}\",\"replayed_actions\":[{}],\"terminal_state\":{:?},\"focus_action_id\":{},\"focus_action_enabled\":{},\"property_holds\":{},\"path\":{},\"path_tags\":[{}]}}",
         property_id,
         actions,
         terminal_state,
         focus_action_id,
         focus_action_enabled,
         property_holds,
+        render_path_json(path),
         path_tags
     )
+}
+
+pub fn replay_path_for_model(
+    model: &ModelIr,
+    action_ids: &[String],
+    focus_action_id: Option<&str>,
+    focus_action_enabled: Option<bool>,
+) -> Path {
+    let mut path = Path::default();
+    for action_id in action_ids {
+        if let Some(action) = model
+            .actions
+            .iter()
+            .find(|action| action.action_id == *action_id)
+        {
+            path.extend(action.decision_path());
+        }
+    }
+    if let Some(action_id) = focus_action_id {
+        let focus_is_already_last = action_ids.last().map(String::as_str) == Some(action_id);
+        if !focus_is_already_last {
+            if let Some(action) = model
+                .actions
+                .iter()
+                .find(|action| action.action_id == action_id)
+            {
+                let guard_enabled = focus_action_enabled.unwrap_or(false);
+                path.extend(Path::new(
+                    action
+                        .decision_path_for_guard(guard_enabled)
+                        .decisions
+                        .into_iter()
+                        .take(1)
+                        .collect(),
+                ));
+            }
+        }
+    }
+    path
 }
 
 pub fn generated_test_output_path(vector: &TestVector) -> String {
@@ -669,6 +733,7 @@ pub fn write_generated_test_files(vectors: &[TestVector]) -> Result<Vec<String>,
 struct ModelNode {
     state: MachineState,
     parent: Option<usize>,
+    via_action_index: Option<usize>,
     via_action_id: Option<String>,
     via_action_label: Option<String>,
 }
@@ -690,6 +755,7 @@ fn explore_model(model: &ModelIr) -> Result<ModelExploration, String> {
     let mut nodes = vec![ModelNode {
         state: initial.clone(),
         parent: None,
+        via_action_index: None,
         via_action_id: None,
         via_action_label: None,
     }];
@@ -710,6 +776,7 @@ fn explore_model(model: &ModelIr) -> Result<ModelExploration, String> {
                 nodes.push(ModelNode {
                     state: next_state,
                     parent: Some(node_index),
+                    via_action_index: Some(action_index),
                     via_action_id: Some(action.action_id.clone()),
                     via_action_label: Some(action.label.clone()),
                 });
@@ -766,13 +833,13 @@ fn build_model_guard_vectors(
                 Some(action.action_id.clone()),
                 None,
                 Some(true),
-                action.path_tags.clone(),
+                action.decision_path(),
                 {
                     let mut notes = vec![format!("guard_true:{:?}", action.guard)];
                     notes.extend(
                         action
-                            .path_tags
-                            .clone()
+                            .decision_path()
+                            .legacy_path_tags()
                             .into_iter()
                             .map(|tag| format!("path_tag:{tag}")),
                     );
@@ -811,13 +878,13 @@ fn build_model_guard_vectors(
                 Some(action.action_id.clone()),
                 None,
                 Some(false),
-                action.path_tags.clone(),
+                action.decision_path_for_guard(false),
                 {
                     let mut notes = vec![format!("guard_false:{:?}", action.guard)];
                     notes.extend(
                         action
-                            .path_tags
-                            .clone()
+                            .decision_path_for_guard(false)
+                            .legacy_path_tags()
                             .into_iter()
                             .map(|tag| format!("path_tag:{tag}")),
                     );
@@ -849,11 +916,8 @@ fn build_model_path_vectors(model: &ModelIr, property_id: &str) -> Result<Vec<Te
     let mut seen = BTreeSet::new();
 
     for (action_index, action) in model.actions.iter().enumerate() {
-        let tags = if action.path_tags.is_empty() {
-            vec!["transition_path".to_string()]
-        } else {
-            action.path_tags.clone()
-        };
+        let action_path = action.decision_path();
+        let tags = action_path.legacy_path_tags();
         let Some((_, edge)) =
             exploration
                 .edges_by_node
@@ -879,7 +943,7 @@ fn build_model_path_vectors(model: &ModelIr, property_id: &str) -> Result<Vec<Te
                 Some(action.action_id.clone()),
                 None,
                 Some(true),
-                vec![tag.clone()],
+                Path::from_legacy_tags(vec![tag.clone()]),
                 vec![format!("path_tag:{tag}")],
             ) {
                 let signature = (
@@ -935,7 +999,7 @@ fn build_model_boundary_vectors(
                     None,
                     Some(field.name.clone()),
                     None,
-                    Vec::new(),
+                    Path::default(),
                     vec![format!("boundary_target:{target}")],
                 ) {
                     let signature = (
@@ -994,7 +1058,7 @@ fn build_model_random_vectors(
                 None,
                 None,
                 None,
-                Vec::new(),
+                Path::default(),
                 vec!["deterministic_randomized_sample".to_string()],
             )?;
             vector.seed = Some(seed.bytes().fold(0u64, |acc, byte| {
@@ -1015,7 +1079,7 @@ fn build_model_vector_for_node(
     focus_action_id: Option<String>,
     focus_field: Option<String>,
     expected_guard_enabled: Option<bool>,
-    expected_path_tags: Vec<String>,
+    expected_path: Path,
     notes: Vec<String>,
 ) -> Option<TestVector> {
     let steps = build_model_path(model, nodes, end_index);
@@ -1049,6 +1113,12 @@ fn build_model_vector_for_node(
         .properties
         .iter()
         .find(|property| property.property_id == property_id)?;
+    let mut expected_path = expected_path;
+    if expected_path.decisions.is_empty() {
+        for step in &steps {
+            expected_path.extend(step.path.clone());
+        }
+    }
     let property_holds = matches!(
         eval_expr(model, &nodes.get(end_index)?.state, &property.expr).ok(),
         Some(Value::Bool(true))
@@ -1085,7 +1155,8 @@ fn build_model_vector_for_node(
         focus_field,
         expected_guard_enabled,
         expected_property_holds: Some(property_holds),
-        expected_path_tags,
+        expected_path_tags: path_tags_or_empty(&expected_path),
+        expected_path,
         notes,
         replay_target: None,
     })
@@ -1095,6 +1166,7 @@ struct ModelPathStep {
     action_id: String,
     action_label: String,
     state_after: BTreeMap<String, Value>,
+    path: Path,
 }
 
 fn build_model_path(model: &ModelIr, nodes: &[ModelNode], end_index: usize) -> Vec<ModelPathStep> {
@@ -1110,6 +1182,10 @@ fn build_model_path(model: &ModelIr, nodes: &[ModelNode], end_index: usize) -> V
         .windows(2)
         .map(|pair| {
             let after = &nodes[pair[1]];
+            let action = after
+                .via_action_index
+                .and_then(|action_index| model.actions.get(action_index))
+                .expect("non-root node must have an action index");
             ModelPathStep {
                 action_id: after
                     .via_action_id
@@ -1120,9 +1196,106 @@ fn build_model_path(model: &ModelIr, nodes: &[ModelNode], end_index: usize) -> V
                     .clone()
                     .expect("non-root node must have an action label"),
                 state_after: after.state.as_named_map(model),
+                path: action.decision_path(),
             }
         })
         .collect()
+}
+
+fn trace_path(trace: &EvidenceTrace) -> Path {
+    let mut path = Path::default();
+    for step in &trace.steps {
+        if let Some(step_path) = &step.path {
+            path.extend(step_path.clone());
+        }
+    }
+    if path.decisions.is_empty() {
+        let fallback = trace
+            .steps
+            .iter()
+            .filter_map(|step| step.note.as_ref())
+            .filter_map(|note| note.strip_prefix("path_tag:"))
+            .map(str::to_string)
+            .collect::<Vec<_>>();
+        if !fallback.is_empty() {
+            return Path::from_legacy_tags(fallback);
+        }
+    }
+    path
+}
+
+fn path_tags_or_empty(path: &Path) -> Vec<String> {
+    if path.decisions.is_empty() {
+        Vec::new()
+    } else {
+        path.legacy_path_tags()
+    }
+}
+
+fn render_path_json(path: &Path) -> String {
+    let mut out = String::from("{\"decisions\":[");
+    for (index, decision) in path.decisions.iter().enumerate() {
+        if index > 0 {
+            out.push(',');
+        }
+        out.push('{');
+        out.push_str(&format!("\"decision_id\":\"{}\"", decision.decision_id()));
+        out.push_str(&format!(",\"action_id\":\"{}\"", decision.point.action_id));
+        out.push_str(&format!(
+            ",\"kind\":\"{}\"",
+            match decision.point.kind {
+                DecisionKind::Guard => "guard",
+                DecisionKind::StateUpdate => "state_update",
+            }
+        ));
+        out.push_str(&format!(",\"label\":{:?}", decision.point.label));
+        if let Some(field) = &decision.point.field {
+            out.push_str(&format!(",\"field\":{:?}", field));
+        } else {
+            out.push_str(",\"field\":null");
+        }
+        out.push_str(&format!(
+            ",\"reads\":[{}]",
+            decision
+                .point
+                .reads
+                .iter()
+                .map(|value| format!("{value:?}"))
+                .collect::<Vec<_>>()
+                .join(",")
+        ));
+        out.push_str(&format!(
+            ",\"writes\":[{}]",
+            decision
+                .point
+                .writes
+                .iter()
+                .map(|value| format!("{value:?}"))
+                .collect::<Vec<_>>()
+                .join(",")
+        ));
+        out.push_str(&format!(
+            ",\"path_tags\":[{}]",
+            decision
+                .point
+                .path_tags
+                .iter()
+                .map(|value| format!("{value:?}"))
+                .collect::<Vec<_>>()
+                .join(",")
+        ));
+        out.push_str(&format!(
+            ",\"outcome\":\"{}\"",
+            match decision.outcome {
+                DecisionOutcome::GuardTrue => "guard_true",
+                DecisionOutcome::GuardFalse => "guard_false",
+                DecisionOutcome::UpdateApplied => "update_applied",
+            }
+        ));
+        out.push('}');
+    }
+    out.push_str("]}");
+    out
 }
 
 #[cfg(test)]
@@ -1162,6 +1335,7 @@ mod tests {
                     depth: (index + 1) as u32,
                     state_before: before,
                     state_after: after,
+                    path: None,
                     note: None,
                 }
             })
@@ -1253,6 +1427,7 @@ mod tests {
                 depth: 1,
                 state_before: BTreeMap::from([("x".to_string(), Value::UInt(0))]),
                 state_after: BTreeMap::from([("x".to_string(), Value::UInt(1))]),
+                path: None,
                 note: None,
             }],
         };


### PR DESCRIPTION
## Summary
- add DecisionPoint / Decision / Path IR and document the compatibility design
- thread structured path data through evidence traces, coverage, explain, replay, and testgen
- preserve legacy `path_tags` outputs while adding decision-based coverage and structured explain data

## Testing
- cargo test

Closes #13