### PR TITLE
Varisat: add arithmetic encoding for bounded ints

### DIFF
--- a/packages/valid/src/solver/varisat.rs
+++ b/packages/valid/src/solver/varisat.rs
@@ -3,6 +3,7 @@ use crate::ir::ModelIr;
 use crate::ir::{BinaryOp, ExprIr, StateField, UnaryOp, Value};
 #[cfg(feature = "varisat-backend")]
 use crate::ir::{FieldType, PropertyKind};
+use crate::ir::{BinaryOp, ExprIr, FieldType, PropertyKind, UnaryOp, Value};
 
 #[cfg(feature = "varisat-backend")]
 use std::collections::HashSet;
@@ -55,6 +56,17 @@ enum EncodedFieldState {
 }
 
 #[cfg(feature = "varisat-backend")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum FieldEncoding {
+    Bool,
+    UInt {
+        bit_width: usize,
+        min: u64,
+        max: u64,
+    },
+#[derive(Clone)]
+enum EncodedValue {
+    UInt(Vec<Lit>),
 struct CnfEncoder<'a> {
     model: &'a ModelIr,
     property_id: &'a str,
@@ -63,6 +75,10 @@ struct CnfEncoder<'a> {
     next_var_index: usize,
     state_lits: Vec<Vec<EncodedFieldState>>,
 state_lits: Vec<Vec<Vec<Lit>>>,
+true_lit: Lit,
+    false_lit: Lit,
+    field_encodings: Vec<FieldEncoding>,
+    state_vars: Vec<Vec<EncodedValue>>,
     action_lits: Vec<Vec<Lit>>,
 }
 
@@ -76,6 +92,15 @@ enum EncodedExprKind {
 #[cfg(feature = "varisat-backend")]
 impl<'a> CnfEncoder<'a> {
     fn new(model: &'a ModelIr, property_id: &'a str, depth: usize) -> Self {
+        let field_encodings = model
+            .state_fields
+            .iter()
+            .map(|field| {
+                field_encoding(&field.ty)
+                    .expect("varisat field encoding should be validated before construction")
+            })
+            .collect::<Vec<_>>();
+
         let mut next_var_index = 0usize;
         let mut alloc = || {
             let var = Var::from_index(next_var_index);
@@ -83,16 +108,22 @@ impl<'a> CnfEncoder<'a> {
             Lit::from_var(var, true)
         };
 
-        let state_lits = (0..=depth)
+        let true_lit = alloc();
+        let false_lit = alloc();
+        let state_vars = (0..=depth)
             .map(|_| {
-                model
-                    .state_fields
+                field_encodings
                     .iter()
                     .map(|field| allocate_field_state(field, &mut alloc))
 .map(|field| {
                         (0..state_field_width(&field.ty))
                             .collect::<Vec<_>>()
                     })
+.map(|encoding| match encoding {
+                        FieldEncoding::Bool => EncodedValue::Bool(alloc()),
+                        FieldEncoding::UInt { bit_width, .. } => {
+                            EncodedValue::UInt((0..*bit_width).map(|_| alloc()).collect())
+                        }
                     .collect::<Vec<_>>()
             })
             .collect::<Vec<_>>();
@@ -100,19 +131,27 @@ impl<'a> CnfEncoder<'a> {
             .map(|_| model.actions.iter().map(|_| alloc()).collect::<Vec<_>>())
             .collect::<Vec<_>>();
 
+        let mut solver = Solver::new();
+        solver.add_clause(&[true_lit]);
+        solver.add_clause(&[!false_lit]);
+
         Self {
             model,
             property_id,
             depth,
-            solver: Solver::new(),
+            solver,
             next_var_index,
-            state_lits,
+            true_lit,
+            false_lit,
+            field_encodings,
+            state_vars,
             action_lits,
         }
     }
 
     fn encode(&mut self) -> Result<(), String> {
         self.encode_state_invariants()?;
+self.encode_state_bounds();
         self.encode_init()?;
         self.encode_action_choice();
         self.encode_transitions()?;
@@ -143,6 +182,29 @@ impl<'a> CnfEncoder<'a> {
             actions.push(self.model.actions[selected_index].action_id.clone());
         }
         Ok(Some(actions))
+    }
+
+    fn encode_state_bounds(&mut self) {
+        for step in 0..=self.depth {
+            for field_index in 0..self.field_encodings.len() {
+                let encoding = self.field_encodings[field_index];
+                let EncodedValue::UInt(bits) = &self.state_vars[step][field_index] else {
+                    continue;
+                };
+                let bits = bits.clone();
+                let FieldEncoding::UInt { min, max, .. } = encoding else {
+                    continue;
+                };
+                if min > 0 {
+                    let min_bits = self.uint_const(min, bits.len());
+                    let lower_violation = self.uint_less_than(&bits, &min_bits);
+                    self.solver.add_clause(&[!lower_violation]);
+                }
+                let max_bits = self.uint_const(max, bits.len());
+                let upper_violation = self.uint_less_than(&max_bits, &bits);
+                self.solver.add_clause(&[!upper_violation]);
+            }
+        }
     }
 
     fn encode_init(&mut self) -> Result<(), String> {
@@ -225,6 +287,19 @@ let field_ty = self.model.state_fields[field_index].ty.clone();
                         let present = *bits & enum_variant_mask(index as u64) != 0;
                         self.solver.add_clause(&[if present { lit } else { !lit }]);
                 _ => {
+for (field_index, field) in self.model.state_fields.iter().enumerate() {
+            let assignment = self
+                .model
+                .init
+                .iter()
+                .find(|assignment| assignment.field == field.id)
+                .ok_or_else(|| format!("missing init assignment for field `{}`", field.name))?;
+            match (self.state_vars[0][field_index].clone(), &assignment.value) {
+                (EncodedValue::Bool(target), Value::Bool(value)) => {
+                    self.solver.add_clause(&[if *value { target } else { !target }]);
+                (EncodedValue::UInt(bits), Value::UInt(value)) => {
+                    self.add_bits_equal_value(&bits, *value);
+                (EncodedValue::Bool(_), other) => {
                     return Err(format!(
                         "backend=sat-varisat does not support init assignment `{}` for `{}`",
                         assignment.field,
@@ -259,6 +334,12 @@ let field_ty = self.model.state_fields[field_index].ty.clone();
 "backend=sat-varisat does not support init assignment `{}` with type/value combination `{:?}`/`{:?}`",
                         field_ty,
                         assignment.value
+"backend=sat-varisat expected a boolean init assignment for `{}`, got `{other:?}`",
+                        field.name
+                (EncodedValue::UInt(_), other) => {
+                    return Err(format!(
+                        "backend=sat-varisat expected a bounded integer init assignment for `{}`, got `{other:?}`",
+                        field.name
                 }
             }
         }
@@ -288,6 +369,9 @@ let field_ty = self.model.state_fields[field_index].ty.clone();
                     let default_expr = ExprIr::FieldRef(field_id.clone());
                     let next = self.state_lits[step + 1][field_index].clone();
                     let expr = action
+for (field_index, field) in self.model.state_fields.iter().enumerate() {
+                    let next = self.state_vars[step + 1][field_index].clone();
+                    let value = match action
                         .updates
                         .iter()
                         .find(|update| update.field == field_id)
@@ -309,6 +393,11 @@ let field_ty = self.model.state_fields[field_index].ty.clone();
                             rust_type_label(other)
                         )),
                     }
+                    {
+                        Some(update) => self.encode_expr(step, &update.value)?,
+                        None => self.state_vars[step][field_index].clone(),
+                    };
+                    self.add_equivalence_under_expr(selector, &next, value)?;
                 }
             }
         }
@@ -331,6 +420,66 @@ let field_ty = self.model.state_fields[field_index].ty.clone();
         Ok(())
     }
 
+    fn encode_expr(&mut self, step: usize, expr: &ExprIr) -> Result<EncodedValue, String> {
+        match expr {
+            ExprIr::Literal(Value::Bool(value)) => Ok(EncodedValue::Bool(self.bool_const(*value))),
+            ExprIr::Literal(Value::UInt(value)) => Ok(EncodedValue::UInt(self.min_uint_const(*value))),
+            ExprIr::FieldRef(field_id) => {
+                let index = self.field_index(field_id)?;
+                Ok(self.state_vars[step][index].clone())
+            }
+            ExprIr::Unary { op, .. } => match op {
+                UnaryOp::Not => Ok(EncodedValue::Bool(self.encode_bool_expr(step, expr)?)),
+                UnaryOp::SetIsEmpty => Err(
+                    "backend=sat-varisat does not yet support set operations; use explicit or smt-cvc5"
+                        .to_string(),
+                ),
+                UnaryOp::StringLen => Err(
+                    "backend=sat-varisat does not yet support string length expressions; use explicit or smt-cvc5"
+                        .to_string(),
+                ),
+            },
+            ExprIr::Binary { op, .. } => match op {
+                BinaryOp::Add | BinaryOp::Sub | BinaryOp::Mod => {
+                    Ok(EncodedValue::UInt(self.encode_uint_expr(step, expr)?))
+                }
+                BinaryOp::LessThan
+                | BinaryOp::LessThanOrEqual
+                | BinaryOp::GreaterThan
+                | BinaryOp::GreaterThanOrEqual
+                | BinaryOp::Equal
+                | BinaryOp::NotEqual
+                | BinaryOp::And
+                | BinaryOp::Or => Ok(EncodedValue::Bool(self.encode_bool_expr(step, expr)?)),
+                BinaryOp::StringContains => Err(
+                    "backend=sat-varisat does not yet support string contains expressions; use explicit or smt-cvc5"
+                        .to_string(),
+                ),
+                BinaryOp::RegexMatch => Err(
+                    "backend=sat-varisat does not yet support regex expressions; use explicit or smt-cvc5"
+                        .to_string(),
+                ),
+                BinaryOp::SetContains
+                | BinaryOp::SetInsert
+                | BinaryOp::SetRemove
+                | BinaryOp::RelationContains
+                | BinaryOp::RelationInsert
+                | BinaryOp::RelationRemove
+                | BinaryOp::RelationIntersects
+                | BinaryOp::MapContainsKey
+                | BinaryOp::MapContainsEntry
+                | BinaryOp::MapPut
+                | BinaryOp::MapRemoveKey => Err(
+                    "backend=sat-varisat does not yet support set, relation, or map expressions; use explicit or smt-cvc5"
+                        .to_string(),
+                ),
+            },
+            ExprIr::Literal(other) => Err(format!(
+                "backend=sat-varisat supports only bool and bounded integer literals, got `{other:?}`"
+            )),
+        }
+    }
+
     fn encode_bool_expr(&mut self, step: usize, expr: &ExprIr) -> Result<Lit, String> {
         match expr {
             ExprIr::Literal(Value::Bool(value)) => Ok(self.bool_const(*value)),
@@ -350,6 +499,11 @@ match &self.model.state_fields[index].ty {
                         "backend=sat-varisat does not support boolean encoding for `{}` fields",
                         rust_type_label(other)
             }
+ExprIr::FieldRef(field_id) => match self.state_vars[step][self.field_index(field_id)?] {
+                EncodedValue::Bool(lit) => Ok(lit),
+                EncodedValue::UInt(_) => Err(format!(
+                    "backend=sat-varisat expected a boolean expression, but `{field_id}` is a bounded integer"
+            },
             ExprIr::Unary { op, expr } => match op {
                 UnaryOp::Not => Ok(!self.encode_bool_expr(step, expr)?),
                 UnaryOp::SetIsEmpty => self.encode_is_empty(step, expr),
@@ -370,6 +524,10 @@ match &self.model.state_fields[index].ty {
                     let set = self.encode_set_expr_with_width(step, expr, width)?;
                     Ok(!self.bool_or_many(&set))
                 }
+UnaryOp::StringLen => Err(
+                    "backend=sat-varisat does not yet support string length expressions; use explicit or smt-cvc5"
+                        .to_string(),
+                ),
             },
             ExprIr::Binary { op, left, right } => match op {
                 BinaryOp::StringContains | BinaryOp::RegexMatch => Err(format!(
@@ -433,28 +591,46 @@ BinaryOp::Equal => self.encode_equal_expr(step, left, right),
                     };
                     let set = self.encode_set_expr_with_width(step, left, width)?;
                     Ok(set[index])
+                BinaryOp::LessThan => {
+                    let left = self.encode_uint_expr(step, left)?;
+                    let right = self.encode_uint_expr(step, right)?;
+                    Ok(self.uint_less_than(&left, &right))
+                BinaryOp::LessThanOrEqual => {
+                    let left = self.encode_uint_expr(step, left)?;
+                    let right = self.encode_uint_expr(step, right)?;
+                    let less_than = self.uint_less_than(&left, &right);
+                    let equal = self.uint_equal(&left, &right);
+                    Ok(self.bool_or(less_than, equal))
+                BinaryOp::GreaterThan => {
+                    let left = self.encode_uint_expr(step, left)?;
+                    let right = self.encode_uint_expr(step, right)?;
+                    Ok(self.uint_less_than(&right, &left))
+                BinaryOp::GreaterThanOrEqual => {
+                    let left = self.encode_uint_expr(step, left)?;
+                    let right = self.encode_uint_expr(step, right)?;
+                    let greater_than = self.uint_less_than(&right, &left);
+                    let equal = self.uint_equal(&left, &right);
+                    Ok(self.bool_or(greater_than, equal))
                 BinaryOp::Add
                 | BinaryOp::Sub
                 | BinaryOp::Mod
+                | BinaryOp::StringContains
+                | BinaryOp::RegexMatch
                 | BinaryOp::SetContains
                 | BinaryOp::SetInsert
                 | BinaryOp::SetRemove
                 | BinaryOp::RelationInsert
                 | BinaryOp::RelationRemove
                 | BinaryOp::MapPut
-                | BinaryOp::MapRemoveKey
-                | BinaryOp::LessThan
-                | BinaryOp::LessThanOrEqual
-                | BinaryOp::GreaterThan
-                | BinaryOp::GreaterThanOrEqual => Err(format!(
-                    "backend=sat-varisat currently supports only boolean declarative expressions; unsupported operator `{op:?}`"
+                | BinaryOp::MapRemoveKey => Err(format!(
+                    "backend=sat-varisat does not support `{op:?}` as a boolean expression"
                 )),
                 BinaryOp::SetInsert | BinaryOp::SetRemove => Err(format!(
                     "backend=sat-varisat expected set expression, got `{op:?}` in boolean context"
                 )),
             },
             ExprIr::Literal(other) => Err(format!(
-                "backend=sat-varisat currently supports only boolean expressions, got `{other:?}`"
+                "backend=sat-varisat expected a boolean expression, got `{other:?}`"
             )),
         }
     }
@@ -977,6 +1153,98 @@ match (self.expr_kind(left)?, self.expr_kind(right)?) {
         self.solver.add_clause(&[z, !a, !b]);
         self.solver.add_clause(&[z, a, b]);
         z
+match (
+            self.encode_expr(step, left)?,
+            self.encode_expr(step, right)?,
+        ) {
+            (EncodedValue::Bool(a), EncodedValue::Bool(b)) => Ok(self.bool_equal(a, b)),
+            (EncodedValue::UInt(a), EncodedValue::UInt(b)) => Ok(self.uint_equal(&a, &b)),
+            (left, right) => Err(format!(
+                "backend=sat-varisat cannot compare mismatched expression kinds `{}` and `{}`",
+                self.encoded_kind_label(&left),
+                self.encoded_kind_label(&right)
+    fn encode_uint_expr(&mut self, step: usize, expr: &ExprIr) -> Result<Vec<Lit>, String> {
+            ExprIr::Literal(Value::UInt(value)) => Ok(self.min_uint_const(*value)),
+            ExprIr::FieldRef(field_id) => match &self.state_vars[step][self.field_index(field_id)?] {
+                EncodedValue::UInt(bits) => Ok(bits.clone()),
+                EncodedValue::Bool(_) => Err(format!(
+                    "backend=sat-varisat expected a bounded integer expression, but `{field_id}` is boolean"
+                BinaryOp::Add => {
+                    let left = self.encode_uint_expr(step, left)?;
+                    let right = self.encode_uint_expr(step, right)?;
+                    Ok(self.uint_add(&left, &right))
+                BinaryOp::Sub => {
+                    let left = self.encode_uint_expr(step, left)?;
+                    let right = self.encode_uint_expr(step, right)?;
+                    Ok(self.uint_saturating_sub(&left, &right))
+                BinaryOp::Mod => {
+                    let (_, divisor_max) = self.uint_expr_bounds(right)?;
+                    if divisor_max == 0 {
+                        return Err(
+                            "backend=sat-varisat does not support modulo by an expression that can be zero"
+                                .to_string(),
+                        );
+                    let (divisor_min, _) = self.uint_expr_bounds(right)?;
+                    if divisor_min == 0 {
+                        return Err(
+                            "backend=sat-varisat currently requires modulo divisors with a strictly positive lower bound"
+                                .to_string(),
+                        );
+                    let dividend = self.encode_uint_expr(step, left)?;
+                    let divisor = self.encode_uint_expr(step, right)?;
+                    Ok(self.uint_mod(&dividend, &divisor))
+                | BinaryOp::LessThan
+                | BinaryOp::LessThanOrEqual
+                | BinaryOp::GreaterThan
+                | BinaryOp::GreaterThanOrEqual
+                | BinaryOp::StringContains
+                | BinaryOp::RegexMatch
+                | BinaryOp::SetContains
+                | BinaryOp::SetInsert
+                | BinaryOp::SetRemove
+                | BinaryOp::RelationContains
+                | BinaryOp::RelationInsert
+                | BinaryOp::RelationRemove
+                | BinaryOp::RelationIntersects
+                | BinaryOp::MapContainsKey
+                | BinaryOp::MapContainsEntry
+                | BinaryOp::MapPut
+                | BinaryOp::MapRemoveKey => Err(format!(
+                    "backend=sat-varisat does not support `{op:?}` as a bounded integer expression"
+            ExprIr::Unary { op, .. } => Err(format!(
+                "backend=sat-varisat does not support unary operator `{op:?}` for bounded integer expressions"
+                "backend=sat-varisat expected a bounded integer expression, got `{other:?}`"
+    fn add_equivalence_under_expr(
+        condition: Lit,
+        target: &EncodedValue,
+        value: EncodedValue,
+        match (target, value) {
+            (EncodedValue::Bool(target), EncodedValue::Bool(value)) => {
+                self.add_equivalence_under(condition, *target, value);
+            (EncodedValue::UInt(target_bits), EncodedValue::UInt(value_bits)) => {
+                self.add_uint_equivalence_under(condition, target_bits, &value_bits);
+            (target, value) => Err(format!(
+                "backend=sat-varisat cannot assign `{}` to `{}`",
+                self.encoded_kind_label(&value),
+                self.encoded_kind_label(target)
+    fn add_uint_equivalence_under(&mut self, condition: Lit, target: &[Lit], value: &[Lit]) {
+        let width = target.len().max(value.len());
+        for index in 0..width {
+            let target = self.bit_at(target, index);
+            let value = self.bit_at(value, index);
+            self.add_equivalence_under(condition, target, value);
+    fn add_equivalence_under(&mut self, condition: Lit, target: Lit, value: Lit) {
+        self.solver.add_clause(&[!condition, !target, value]);
+        self.solver.add_clause(&[!condition, target, !value]);
+    fn add_bits_equal_value(&mut self, bits: &[Lit], value: u64) {
+        for (index, bit) in bits.iter().enumerate() {
+            let mask = 1u64.checked_shl(index as u32).unwrap_or(0);
+            let clause = if value & mask == 0 { !*bit } else { *bit };
+            self.solver.add_clause(&[clause]);
+    fn bool_const(&self, value: bool) -> Lit {
+        if value {
+            self.true_lit
+            self.false_lit
     }
 
     fn bool_and(&mut self, a: Lit, b: Lit) -> Lit {
@@ -1029,6 +1297,13 @@ fn bool_and_many(&mut self, lits: &[Lit]) -> Lit {
     fn add_equivalence_under(&mut self, condition: Lit, target: Lit, value: Lit) {
         self.solver.add_clause(&[!condition, !target, value]);
         self.solver.add_clause(&[!condition, target, !value]);
+fn bool_equal(&mut self, a: Lit, b: Lit) -> Lit {
+        let z = self.fresh_lit();
+        self.solver.add_clause(&[!z, !a, b]);
+        self.solver.add_clause(&[!z, a, !b]);
+        self.solver.add_clause(&[z, !a, !b]);
+        self.solver.add_clause(&[z, a, b]);
+        z
     }
 
     fn add_equivalence_under_many(
@@ -1054,6 +1329,149 @@ fn bool_and_many(&mut self, lits: &[Lit]) -> Lit {
         let lit = self.fresh_lit();
         self.solver.add_clause(&[if value { lit } else { !lit }]);
         lit
+fn bool_xor(&mut self, a: Lit, b: Lit) -> Lit {
+        !self.bool_equal(a, b)
+    fn bool_mux(&mut self, select: Lit, when_true: Lit, when_false: Lit) -> Lit {
+        let true_branch = self.bool_and(select, when_true);
+        let false_branch = self.bool_and(!select, when_false);
+        self.bool_or(true_branch, false_branch)
+    fn uint_add(&mut self, left: &[Lit], right: &[Lit]) -> Vec<Lit> {
+        let width = left.len().max(right.len());
+        let mut carry = self.false_lit;
+        let mut result = Vec::with_capacity(width + 1);
+        for index in 0..width {
+            let a = self.bit_at(left, index);
+            let b = self.bit_at(right, index);
+            let ab_xor = self.bool_xor(a, b);
+            let sum = self.bool_xor(ab_xor, carry);
+            let carry_ab = self.bool_and(a, b);
+            let carry_ac = self.bool_and(a, carry);
+            let carry_bc = self.bool_and(b, carry);
+            let carry_tail = self.bool_or(carry_ac, carry_bc);
+            carry = self.bool_or(carry_ab, carry_tail);
+            result.push(sum);
+        result.push(carry);
+        result
+    fn uint_saturating_sub(&mut self, left: &[Lit], right: &[Lit]) -> Vec<Lit> {
+        let (difference, borrow) = self.subtract_bits(left, right);
+        let zeros = vec![self.false_lit; difference.len()];
+        self.select_bits(borrow, &zeros, &difference)
+    fn uint_mod(&mut self, dividend: &[Lit], divisor: &[Lit]) -> Vec<Lit> {
+        let width = dividend.len().max(divisor.len());
+        let divisor = self.extend_bits(divisor, width);
+        let divisor_nonzero = self.uint_nonzero(&divisor);
+        self.solver.add_clause(&[divisor_nonzero]);
+        let mut remainder = vec![self.false_lit; width];
+        for index in (0..width).rev() {
+            let incoming = self.bit_at(dividend, index);
+            let shifted = self.shift_left_insert(&remainder, incoming);
+            let less_than = self.uint_less_than(&shifted, &divisor);
+            let candidate = self.uint_saturating_sub(&shifted, &divisor);
+            remainder = self.select_bits(!less_than, &candidate, &shifted);
+        remainder
+    fn shift_left_insert(&self, bits: &[Lit], incoming: Lit) -> Vec<Lit> {
+        if bits.is_empty() {
+            return Vec::new();
+        let mut shifted = Vec::with_capacity(bits.len());
+        shifted.push(incoming);
+        shifted.extend(bits.iter().take(bits.len().saturating_sub(1)).copied());
+        shifted
+    fn uint_equal(&mut self, left: &[Lit], right: &[Lit]) -> Lit {
+        let width = left.len().max(right.len());
+        let mut equal = self.true_lit;
+        for index in 0..width {
+            let bit_equal = self.bool_equal(self.bit_at(left, index), self.bit_at(right, index));
+            equal = self.bool_and(equal, bit_equal);
+        equal
+    fn uint_less_than(&mut self, left: &[Lit], right: &[Lit]) -> Lit {
+        let (_, borrow) = self.subtract_bits(left, right);
+        borrow
+    fn uint_nonzero(&mut self, bits: &[Lit]) -> Lit {
+        let mut any = self.false_lit;
+        for bit in bits {
+            any = self.bool_or(any, *bit);
+        any
+    fn subtract_bits(&mut self, left: &[Lit], right: &[Lit]) -> (Vec<Lit>, Lit) {
+        let width = left.len().max(right.len());
+        let mut borrow = self.false_lit;
+        let mut difference = Vec::with_capacity(width);
+        for index in 0..width {
+            let a = self.bit_at(left, index);
+            let b = self.bit_at(right, index);
+            let ab_xor = self.bool_xor(a, b);
+            difference.push(self.bool_xor(ab_xor, borrow));
+            let b_or_borrow = self.bool_or(b, borrow);
+            let borrow_from_a = self.bool_and(!a, b_or_borrow);
+            let borrow_from_b = self.bool_and(b, borrow);
+            borrow = self.bool_or(borrow_from_a, borrow_from_b);
+        (difference, borrow)
+    fn select_bits(&mut self, select: Lit, when_true: &[Lit], when_false: &[Lit]) -> Vec<Lit> {
+        let width = when_true.len().max(when_false.len());
+        (0..width)
+            .map(|index| {
+                self.bool_mux(
+                    select,
+                    self.bit_at(when_true, index),
+                    self.bit_at(when_false, index),
+                )
+            })
+            .collect()
+    fn extend_bits(&self, bits: &[Lit], width: usize) -> Vec<Lit> {
+        (0..width).map(|index| self.bit_at(bits, index)).collect()
+    fn bit_at(&self, bits: &[Lit], index: usize) -> Lit {
+        bits.get(index).copied().unwrap_or(self.false_lit)
+    fn min_uint_const(&self, value: u64) -> Vec<Lit> {
+        self.uint_const(value, bit_width_for_value(value))
+    fn uint_const(&self, value: u64, width: usize) -> Vec<Lit> {
+        (0..width)
+            .map(|index| {
+                let mask = 1u64.checked_shl(index as u32).unwrap_or(0);
+                if value & mask == 0 {
+                    self.false_lit
+                } else {
+                    self.true_lit
+            })
+            .collect()
+    fn uint_expr_bounds(&self, expr: &ExprIr) -> Result<(u64, u64), String> {
+        match expr {
+            ExprIr::Literal(Value::UInt(value)) => Ok((*value, *value)),
+            ExprIr::FieldRef(field_id) => {
+                let index = self.field_index(field_id)?;
+                match self.field_encodings[index] {
+                    FieldEncoding::UInt { min, max, .. } => Ok((min, max)),
+                    FieldEncoding::Bool => Err(format!(
+                        "backend=sat-varisat expected a bounded integer expression, but `{field_id}` is boolean"
+                    )),
+            ExprIr::Binary { op, left, right } => {
+                let (left_min, left_max) = self.uint_expr_bounds(left)?;
+                let (right_min, right_max) = self.uint_expr_bounds(right)?;
+                match op {
+                    BinaryOp::Add => Ok((
+                        left_min.saturating_add(right_min),
+                        left_max.saturating_add(right_max),
+                    )),
+                    BinaryOp::Sub => Ok((
+                        left_min.saturating_sub(right_max),
+                        left_max.saturating_sub(right_min),
+                    )),
+                    BinaryOp::Mod => {
+                        if right_max == 0 {
+                            Ok((0, 0))
+                        } else {
+                            Ok((0, left_max.min(right_max.saturating_sub(1))))
+                    other => Err(format!(
+                        "backend=sat-varisat does not support `{other:?}` as a bounded integer expression"
+                    )),
+            ExprIr::Literal(other) => Err(format!(
+                "backend=sat-varisat expected a bounded integer expression, got `{other:?}`"
+            )),
+            ExprIr::Unary { op, .. } => Err(format!(
+                "backend=sat-varisat does not support unary operator `{op:?}` for bounded integer expressions"
+            )),
+    fn encoded_kind_label(&self, value: &EncodedValue) -> &'static str {
+        match value {
+            EncodedValue::Bool(_) => "bool",
+            EncodedValue::UInt(_) => "bounded-int",
     }
 
     fn field_index(&self, field_id: &str) -> Result<usize, String> {
@@ -1093,15 +1511,50 @@ fn validate_varisat_model(model: &ModelIr, target_property_ids: &[String]) -> Re
             FieldType::Bool | FieldType::EnumRelation { .. } | FieldType::EnumMap { .. }
         ) {
 if !matches!(field.ty, FieldType::Bool | FieldType::EnumSet { .. }) {
+if field_encoding(&field.ty).is_none() {
             return Err(format!(
                 "backend=sat-varisat currently supports bool, FiniteRelation, and FiniteMap state fields only; `{}` is `{}`",
 "backend=sat-varisat currently supports boolean and finite enum set state fields only; `{}` is `{}`",
+"backend=sat-varisat currently supports only bool and bounded integer state fields; `{}` is `{}`",
                 field.name,
                 rust_type_label(&field.ty)
             ));
         }
     }
     Ok(())
+}
+
+#[cfg(feature = "varisat-backend")]
+fn field_encoding(ty: &FieldType) -> Option<FieldEncoding> {
+    match ty {
+        FieldType::Bool => Some(FieldEncoding::Bool),
+        FieldType::BoundedU8 { min, max } => Some(FieldEncoding::UInt {
+            bit_width: 8,
+            min: *min as u64,
+            max: *max as u64,
+        }),
+        FieldType::BoundedU16 { min, max } => Some(FieldEncoding::UInt {
+            bit_width: 16,
+            min: *min as u64,
+            max: *max as u64,
+        }),
+        FieldType::BoundedU32 { min, max } => Some(FieldEncoding::UInt {
+            bit_width: 32,
+            min: *min as u64,
+            max: *max as u64,
+        }),
+        FieldType::String { .. }
+        | FieldType::Enum { .. }
+        | FieldType::EnumSet { .. }
+        | FieldType::EnumRelation { .. }
+        | FieldType::EnumMap { .. } => None,
+    }
+}
+
+#[cfg(feature = "varisat-backend")]
+fn bit_width_for_value(value: u64) -> usize {
+    let width = u64::BITS as usize - value.leading_zeros() as usize;
+    width.max(1)
 }
 
 #[cfg(feature = "varisat-backend")]
@@ -1262,3 +1715,66 @@ fn set_width(bits: u64) -> usize {
         u64::BITS as usize - bits.leading_zeros() as usize
 fn enum_variant_mask(index: u64) -> u64 {
     1u64.checked_shl(index as u32).unwrap_or(0)
+#[cfg(all(test, feature = "varisat-backend"))]
+mod tests {
+    use super::{run_bounded_invariant_check_varisat, VarisatSolveStatus};
+    use crate::{
+        api::{check_source, CheckRequest},
+        engine::{CheckOutcome, RunStatus},
+        frontend::compile_model,
+    };
+    fn request(source: &str, request_id: &str, backend: Option<&str>) -> CheckRequest {
+        CheckRequest {
+            request_id: request_id.to_string(),
+            source_name: format!("{request_id}.valid"),
+            source: source.to_string(),
+            property_id: None,
+            backend: backend.map(str::to_string),
+            solver_executable: None,
+            solver_args: Vec::new(),
+    fn completed_status(outcome: CheckOutcome) -> RunStatus {
+        match outcome {
+            CheckOutcome::Completed(result) => result.status,
+            CheckOutcome::Errored(error) => panic!("unexpected error: {:?}", error.diagnostics),
+    #[test]
+    fn bounded_counter_finds_a_counterexample() {
+        let model = compile_model(
+            "model Counter\nstate:\n  x: u8[0..2]\ninit:\n  x = 0\naction Inc:\n  pre: x <= 1\n  post:\n    x = x + 1\naction Stay:\n  pre: x <= 2\n  post:\n    x = x\nproperty P_FAIL:\n  invariant: x <= 1\n",
+        .expect("model should compile");
+        let status = run_bounded_invariant_check_varisat(&model, &["P_FAIL".to_string()], 2)
+            .expect("varisat run should succeed");
+        assert_eq!(
+            status,
+            VarisatSolveStatus::Sat(vec!["Inc".to_string(), "Inc".to_string()])
+        );
+    #[test]
+    fn subtraction_uses_saturating_semantics() {
+        let model = compile_model(
+            "model SaturatingSub\nstate:\n  x: u8[0..3]\ninit:\n  x = 0\naction Jump:\n  pre: x - 1 < 1\n  post:\n    x = x + 2\nproperty P_SAFE:\n  invariant: x <= 1\n",
+        .expect("model should compile");
+        let status = run_bounded_invariant_check_varisat(&model, &["P_SAFE".to_string()], 1)
+            .expect("varisat run should succeed");
+        assert_eq!(status, VarisatSolveStatus::Sat(vec!["Jump".to_string()]));
+    #[test]
+    fn modulo_with_positive_divisor_is_supported() {
+        let model = compile_model(
+            "model ModCounter\nstate:\n  x: u8[0..7]\ninit:\n  x = 0\naction Inc:\n  pre: x % 2 == 0\n  post:\n    x = x + 1\nproperty P_SAFE:\n  invariant: x % 2 == 0\n",
+        .expect("model should compile");
+        let status = run_bounded_invariant_check_varisat(&model, &["P_SAFE".to_string()], 1)
+            .expect("varisat run should succeed");
+        assert_eq!(status, VarisatSolveStatus::Sat(vec!["Inc".to_string()]));
+    #[test]
+    fn wide_bounded_integer_fields_are_supported() {
+        let model = compile_model(
+            "model WideCounter\nstate:\n  x: u32[0..10]\ninit:\n  x = 0\naction Jump:\n  pre: x < 1\n  post:\n    x = x + 2\nproperty P_SAFE:\n  invariant: x <= 1\n",
+        .expect("model should compile");
+        let status = run_bounded_invariant_check_varisat(&model, &["P_SAFE".to_string()], 1)
+            .expect("varisat run should succeed");
+        assert_eq!(status, VarisatSolveStatus::Sat(vec!["Jump".to_string()]));
+    #[test]
+    fn explicit_and_varisat_match_for_arithmetic_models() {
+        let source = "model Counter\nstate:\n  x: u8[0..2]\ninit:\n  x = 0\naction Inc:\n  pre: x <= 1\n  post:\n    x = x + 1\naction Reset:\n  pre: x - 1 <= 1\n  post:\n    x = 0\nproperty P_SAFE:\n  invariant: x <= 2\n";
+        let explicit = check_source(&request(source, "req-explicit", None));
+        let varisat = check_source(&request(source, "req-varisat", Some("sat-varisat")));
+        assert_eq!(completed_status(explicit), RunStatus::Pass);
+        assert_eq!(completed_status(varisat), RunStatus::Pass);


### PR DESCRIPTION
## Summary
- encode bool and bounded u8/u16/u32 fields as SAT variables, with per-step range constraints for bounded integers
- add CNF encoders for bounded-int equality, comparisons, addition, saturating subtraction, and modulo with strictly-positive divisors
- expand sat-varisat tests to cover arithmetic counterexamples, saturating subtraction semantics, modulo, explicit parity, and wide integer fields

## Testing
- cargo test
- cargo test --features varisat-backend

Closes #14
