### PR TITLE
Expose valid via an MCP stdio server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,6 +30,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
 
 [[package]]
+name = "itoa"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+
+[[package]]
 name = "leb128"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -169,6 +175,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_json"
+version = "1.0.149"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+dependencies = [
+ "itoa 1.0.17",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -245,6 +264,8 @@ name = "valid"
 version = "0.1.0"
 dependencies = [
  "regex",
+ "serde",
+ "serde_json",
  "valid_derive",
  "varisat",
 ]
@@ -260,7 +281,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebe609851d1e9196674ac295f656bd8601200a1077343d22b345013497807caf"
 dependencies = [
  "anyhow",
- "itoa",
+ "itoa 0.4.8",
  "leb128",
  "log",
  "ordered-float",
@@ -300,7 +321,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d1dee4e21be1f04c0a939f7ae710cced47233a578de08a1b3c7d50848402636"
 dependencies = [
  "anyhow",
- "itoa",
+ "itoa 0.4.8",
  "thiserror",
  "varisat-formula",
 ]
@@ -339,3 +360,9 @@ name = "vec_mut_scan"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ed610a8d5e63d9c0e31300e8fdb55104c5f21e422743a9dc74848fa8317fd2"
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,10 @@ path = "packages/valid/src/bin/valid.rs"
 name = "cargo-valid"
 path = "packages/valid/src/bin/cargo-valid.rs"
 
+[[bin]]
+name = "valid-mcp"
+path = "packages/valid/src/bin/valid-mcp.rs"
+
 [[example]]
 name = "practical_use_cases_registry"
 path = "benchmarks/registries/practical_use_cases_registry.rs"
@@ -37,4 +41,6 @@ path = "benchmarks/registries/iam_enterprise_registry.rs"
 [dependencies]
 valid_derive = { path = "packages/valid_derive" }
 regex = "1"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 varisat = { version = "0.2", optional = true }

--- a/README.md
+++ b/README.md
@@ -144,6 +144,65 @@ cargo run --bin valid -- verify tests/fixtures/models/failing_counter.valid
 cargo run --bin valid -- explain tests/fixtures/models/failing_counter.valid
 ```
 
+## MCP Server
+
+`valid-mcp` exposes `valid` over MCP stdio so Claude Code, Claude Desktop, and
+other MCP clients can call it as tools.
+
+Available tools:
+
+- `valid_inspect`
+- `valid_check`
+- `valid_explain`
+- `valid_coverage`
+- `valid_testgen`
+- `valid_replay`
+- `valid_contract_snapshot`
+- `valid_contract_check`
+- `valid_list_models`
+- `valid_graph`
+- `valid_lint`
+
+Build or install it:
+
+```sh
+cargo build --bin valid-mcp
+# or
+cargo install --path . --features varisat-backend
+```
+
+### DSL Mode
+
+Use this when the source of truth is a `.valid` file.
+
+```sh
+claude mcp add valid-dsl -- /absolute/path/to/valid-mcp --model-file /absolute/path/to/model.valid
+```
+
+If you do not pin `--model-file` at startup, pass `model_file` or `source` in
+each tool call.
+
+### Registry Mode
+
+Use this when the source of truth is a Rust registry binary.
+
+```sh
+cargo build --example valid_models
+claude mcp add valid-registry -- /absolute/path/to/valid-mcp --registry-binary /absolute/path/to/target/debug/examples/valid_models
+```
+
+When `--registry-binary` is configured at startup, tool calls only need
+`model_name`. Without it, pass `registry_binary` and `model_name` per call.
+
+`valid_contract_snapshot` and `valid_contract_check` can operate on one
+registry model when `model_name` is provided, or on the full registry when it
+is omitted.
+
+Configuration templates live at:
+
+- [docs/mcp/claude_desktop_config.json](/Users/tatsuhiko/.codex/worktrees/eb0d/valid/docs/mcp/claude_desktop_config.json)
+- [docs/mcp/claude_code.mcp.json](/Users/tatsuhiko/.codex/worktrees/eb0d/valid/docs/mcp/claude_code.mcp.json)
+
 ## Mental Model
 
 There are two ways to use the repo today.

--- a/docs/mcp/claude_code.mcp.json
+++ b/docs/mcp/claude_code.mcp.json
@@ -1,0 +1,18 @@
+{
+  "mcpServers": {
+    "valid-dsl": {
+      "command": "${VALID_MCP_BIN}",
+      "args": [
+        "--model-file",
+        "${VALID_MODEL_FILE}"
+      ]
+    },
+    "valid-registry": {
+      "command": "${VALID_MCP_BIN}",
+      "args": [
+        "--registry-binary",
+        "${VALID_REGISTRY_BIN}"
+      ]
+    }
+  }
+}

--- a/docs/mcp/claude_desktop_config.json
+++ b/docs/mcp/claude_desktop_config.json
@@ -1,0 +1,20 @@
+{
+  "mcpServers": {
+    "valid-dsl": {
+      "command": "/absolute/path/to/valid-mcp",
+      "args": [
+        "--model-file",
+        "/absolute/path/to/model.valid"
+      ],
+      "env": {}
+    },
+    "valid-registry": {
+      "command": "/absolute/path/to/valid-mcp",
+      "args": [
+        "--registry-binary",
+        "/absolute/path/to/target/debug/examples/valid_models"
+      ],
+      "env": {}
+    }
+  }
+}

--- a/packages/valid/src/bin/valid-mcp.rs
+++ b/packages/valid/src/bin/valid-mcp.rs
@@ -1,0 +1,39 @@
+use std::{env, process};
+
+use valid::mcp::{serve_stdio, ServerConfig};
+
+fn main() {
+    let mut config = ServerConfig::default();
+    let mut args = env::args().skip(1);
+
+    while let Some(arg) = args.next() {
+        match arg.as_str() {
+            "--registry-binary" => {
+                config.default_registry_binary = Some(next_arg(&mut args, "--registry-binary"))
+            }
+            "--model-file" => config.default_model_file = Some(next_arg(&mut args, "--model-file")),
+            "--name" => config.server_name = next_arg(&mut args, "--name"),
+            "--help" | "-h" => usage_exit(0),
+            _ => usage_exit(3),
+        }
+    }
+
+    if let Err(message) = serve_stdio(config) {
+        eprintln!("{message}");
+        process::exit(1);
+    }
+}
+
+fn next_arg(args: &mut impl Iterator<Item = String>, flag: &str) -> String {
+    args.next().unwrap_or_else(|| {
+        eprintln!("missing value for {flag}");
+        process::exit(3);
+    })
+}
+
+fn usage_exit(code: i32) -> ! {
+    eprintln!(
+        "usage: valid-mcp [--registry-binary <path>] [--model-file <path>] [--name <server-name>]"
+    );
+    process::exit(code);
+}

--- a/packages/valid/src/lib.rs
+++ b/packages/valid/src/lib.rs
@@ -11,6 +11,7 @@ pub mod evidence;
 pub mod frontend;
 pub mod ir;
 pub mod kernel;
+pub mod mcp;
 pub mod modeling;
 pub mod orchestrator;
 pub mod project;

--- a/packages/valid/src/mcp/mod.rs
+++ b/packages/valid/src/mcp/mod.rs
@@ -1,0 +1,1593 @@
+use std::{
+    collections::BTreeSet,
+    fs,
+    io::{self, BufRead, Write},
+    process::Command,
+};
+
+use serde::Deserialize;
+use serde_json::{json, Value};
+
+use crate::{
+    api::{
+        check_source, compile_source, explain_source, inspect_source, lint_source,
+        render_explain_json, render_inspect_json, render_lint_json, testgen_source, CheckRequest,
+        InspectRequest, TestgenRequest,
+    },
+    bundled_models::list_bundled_models,
+    contract::{compare_snapshot, parse_lock_file, snapshot_model},
+    coverage::{collect_coverage, render_coverage_json},
+    engine::CheckOutcome,
+    evidence::{render_diagnostics_json, render_outcome_json},
+    frontend::compile_model,
+    kernel::{eval::eval_expr, replay::replay_actions, transition::apply_action},
+    reporter::{
+        render_model_dot_with_view, render_model_mermaid_with_view, render_model_svg_with_view,
+        GraphView,
+    },
+    testgen::render_replay_json,
+};
+
+const SUPPORTED_PROTOCOL_VERSIONS: &[&str] =
+    &["2025-11-05", "2025-06-18", "2025-03-26", "2024-11-05"];
+
+#[derive(Debug, Clone)]
+pub struct ServerConfig {
+    pub server_name: String,
+    pub default_model_file: Option<String>,
+    pub default_registry_binary: Option<String>,
+}
+
+impl Default for ServerConfig {
+    fn default() -> Self {
+        Self {
+            server_name: "valid".to_string(),
+            default_model_file: std::env::var("VALID_MCP_MODEL_FILE").ok(),
+            default_registry_binary: std::env::var("VALID_MCP_REGISTRY_BINARY").ok(),
+        }
+    }
+}
+
+pub fn serve_stdio(config: ServerConfig) -> Result<(), String> {
+    let stdin = io::stdin();
+    let stdout = io::stdout();
+    let mut writer = stdout.lock();
+
+    for line in stdin.lock().lines() {
+        let line = line.map_err(|err| format!("failed to read stdin: {err}"))?;
+        if line.trim().is_empty() {
+            continue;
+        }
+
+        let incoming = match serde_json::from_str::<Value>(&line) {
+            Ok(value) => value,
+            Err(error) => {
+                write_message(
+                    &mut writer,
+                    &error_response(Value::Null, -32700, &format!("parse error: {error}")),
+                )?;
+                continue;
+            }
+        };
+
+        let maybe_response = if let Some(batch) = incoming.as_array() {
+            let responses = batch
+                .iter()
+                .filter_map(|message| handle_message(message, &config))
+                .collect::<Vec<_>>();
+            if responses.is_empty() {
+                None
+            } else {
+                Some(Value::Array(responses))
+            }
+        } else {
+            handle_message(&incoming, &config)
+        };
+
+        if let Some(response) = maybe_response {
+            write_message(&mut writer, &response)?;
+        }
+    }
+
+    Ok(())
+}
+
+fn write_message(writer: &mut impl Write, payload: &Value) -> Result<(), String> {
+    serde_json::to_writer(&mut *writer, payload)
+        .map_err(|err| format!("failed to encode response: {err}"))?;
+    writer
+        .write_all(b"\n")
+        .map_err(|err| format!("failed to write response: {err}"))?;
+    writer
+        .flush()
+        .map_err(|err| format!("failed to flush response: {err}"))
+}
+
+fn handle_message(message: &Value, config: &ServerConfig) -> Option<Value> {
+    let object = match message.as_object() {
+        Some(object) => object,
+        None => {
+            return Some(error_response(
+                Value::Null,
+                -32600,
+                "request must be an object",
+            ))
+        }
+    };
+
+    let jsonrpc = object
+        .get("jsonrpc")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    if jsonrpc != "2.0" {
+        return Some(error_response(
+            object.get("id").cloned().unwrap_or(Value::Null),
+            -32600,
+            "jsonrpc must be \"2.0\"",
+        ));
+    }
+
+    let method = match object.get("method").and_then(Value::as_str) {
+        Some(method) => method,
+        None => {
+            return Some(error_response(
+                object.get("id").cloned().unwrap_or(Value::Null),
+                -32600,
+                "method must be present",
+            ))
+        }
+    };
+
+    let id = object.get("id").cloned();
+    let params = object.get("params").cloned().unwrap_or(Value::Null);
+
+    if id.is_none() {
+        handle_notification(method);
+        return None;
+    }
+
+    let id = id.unwrap_or(Value::Null);
+    Some(match method {
+        "initialize" => response(id, initialize_result(config, &params)),
+        "ping" => response(id, json!({})),
+        "tools/list" => response(id, json!({ "tools": tool_definitions() })),
+        "tools/call" => match handle_tool_call(config, &params) {
+            Ok(result) => response(id, result.into_value()),
+            Err(error) => error_response(id, -32602, &error),
+        },
+        _ => error_response(id, -32601, &format!("method `{method}` is not supported")),
+    })
+}
+
+fn handle_notification(method: &str) {
+    if matches!(
+        method,
+        "notifications/initialized" | "notifications/cancelled"
+    ) {
+        return;
+    }
+}
+
+fn initialize_result(config: &ServerConfig, params: &Value) -> Value {
+    let requested_version = params
+        .get("protocolVersion")
+        .and_then(Value::as_str)
+        .unwrap_or(SUPPORTED_PROTOCOL_VERSIONS[0]);
+    let protocol_version = if SUPPORTED_PROTOCOL_VERSIONS.contains(&requested_version) {
+        requested_version
+    } else {
+        SUPPORTED_PROTOCOL_VERSIONS[0]
+    };
+    json!({
+        "protocolVersion": protocol_version,
+        "capabilities": {
+            "tools": {}
+        },
+        "serverInfo": {
+            "name": config.server_name,
+            "version": env!("CARGO_PKG_VERSION")
+        },
+        "instructions": "Use model_file or source for .valid files, or registry_binary plus model_name for Rust registry mode."
+    })
+}
+
+fn response(id: Value, result: Value) -> Value {
+    json!({
+        "jsonrpc": "2.0",
+        "id": id,
+        "result": result
+    })
+}
+
+fn error_response(id: Value, code: i64, message: &str) -> Value {
+    json!({
+        "jsonrpc": "2.0",
+        "id": id,
+        "error": {
+            "code": code,
+            "message": message
+        }
+    })
+}
+
+fn tool_definitions() -> Vec<Value> {
+    vec![
+        tool(
+            "valid_inspect",
+            "Inspect a valid model and return state fields, actions, properties, and capabilities.",
+            input_schema_with_backend(),
+            true,
+        ),
+        tool(
+            "valid_check",
+            "Run property verification and return PASS, FAIL, or UNKNOWN with evidence details.",
+            input_schema_with_backend_and_property(),
+            true,
+        ),
+        tool(
+            "valid_explain",
+            "Explain a counterexample and return likely causes, hints, and involved fields.",
+            input_schema_with_backend_and_property(),
+            true,
+        ),
+        tool(
+            "valid_coverage",
+            "Compute transition and guard coverage from the current verification trace.",
+            input_schema_with_backend_and_property(),
+            true,
+        ),
+        tool(
+            "valid_testgen",
+            "Generate regression or witness vectors for a model.",
+            input_schema_with_testgen(),
+            false,
+        ),
+        tool(
+            "valid_replay",
+            "Replay an action sequence and report the terminal state and property result.",
+            input_schema_with_replay(),
+            true,
+        ),
+        tool(
+            "valid_contract_snapshot",
+            "Return the current contract hash for a model or registry.",
+            input_schema_with_contract_snapshot(),
+            true,
+        ),
+        tool(
+            "valid_contract_check",
+            "Compare the current contract against a lock file and report drift.",
+            input_schema_with_contract_check(),
+            true,
+        ),
+        tool(
+            "valid_list_models",
+            "List bundled models or models exported by a registry binary.",
+            input_schema_list_models(),
+            true,
+        ),
+        tool(
+            "valid_graph",
+            "Render a model graph as Mermaid, DOT, SVG, text, or JSON.",
+            input_schema_with_graph(),
+            true,
+        ),
+        tool(
+            "valid_lint",
+            "Run static analysis and capability lint checks on a model.",
+            input_schema_basic(),
+            true,
+        ),
+    ]
+}
+
+fn tool(name: &str, description: &str, input_schema: Value, read_only: bool) -> Value {
+    json!({
+        "name": name,
+        "title": name,
+        "description": description,
+        "inputSchema": input_schema,
+        "annotations": {
+            "readOnlyHint": read_only,
+            "destructiveHint": false,
+            "idempotentHint": read_only,
+            "openWorldHint": false
+        }
+    })
+}
+
+fn input_schema_basic() -> Value {
+    json!({
+        "type": "object",
+        "properties": common_target_properties(),
+        "additionalProperties": false,
+        "anyOf": [
+            { "required": ["model_file"] },
+            { "required": ["source"] },
+            { "required": ["registry_binary", "model_name"] }
+        ]
+    })
+}
+
+fn input_schema_with_backend() -> Value {
+    let mut properties = common_target_properties();
+    properties.insert(
+        "backend".to_string(),
+        json!({
+            "type": "string",
+            "enum": ["explicit", "mock-bmc", "sat-varisat", "smt-cvc5", "command"]
+        }),
+    );
+    properties.insert("solver_executable".to_string(), json!({ "type": "string" }));
+    properties.insert(
+        "solver_args".to_string(),
+        json!({
+            "type": "array",
+            "items": { "type": "string" }
+        }),
+    );
+    json!({
+        "type": "object",
+        "properties": properties,
+        "additionalProperties": false,
+        "anyOf": [
+            { "required": ["model_file"] },
+            { "required": ["source"] },
+            { "required": ["registry_binary", "model_name"] }
+        ]
+    })
+}
+
+fn input_schema_with_backend_and_property() -> Value {
+    let mut properties = common_target_properties();
+    properties.insert("property_id".to_string(), json!({ "type": "string" }));
+    properties.insert(
+        "backend".to_string(),
+        json!({
+            "type": "string",
+            "enum": ["explicit", "mock-bmc", "sat-varisat", "smt-cvc5", "command"]
+        }),
+    );
+    properties.insert("solver_executable".to_string(), json!({ "type": "string" }));
+    properties.insert(
+        "solver_args".to_string(),
+        json!({
+            "type": "array",
+            "items": { "type": "string" }
+        }),
+    );
+    json!({
+        "type": "object",
+        "properties": properties,
+        "additionalProperties": false,
+        "anyOf": [
+            { "required": ["model_file"] },
+            { "required": ["source"] },
+            { "required": ["registry_binary", "model_name"] }
+        ]
+    })
+}
+
+fn input_schema_with_testgen() -> Value {
+    let mut properties = common_target_properties();
+    properties.insert("property_id".to_string(), json!({ "type": "string" }));
+    properties.insert("strategy".to_string(), json!({
+        "type": "string",
+        "enum": ["counterexample", "transition", "witness", "guard", "boundary", "path", "random"]
+    }));
+    properties.insert(
+        "backend".to_string(),
+        json!({
+            "type": "string",
+            "enum": ["explicit", "mock-bmc", "sat-varisat", "smt-cvc5", "command"]
+        }),
+    );
+    properties.insert("solver_executable".to_string(), json!({ "type": "string" }));
+    properties.insert(
+        "solver_args".to_string(),
+        json!({
+            "type": "array",
+            "items": { "type": "string" }
+        }),
+    );
+    json!({
+        "type": "object",
+        "properties": properties,
+        "additionalProperties": false,
+        "anyOf": [
+            { "required": ["model_file"] },
+            { "required": ["source"] },
+            { "required": ["registry_binary", "model_name"] }
+        ]
+    })
+}
+
+fn input_schema_with_replay() -> Value {
+    let mut properties = common_target_properties();
+    properties.insert("property_id".to_string(), json!({ "type": "string" }));
+    properties.insert("focus_action_id".to_string(), json!({ "type": "string" }));
+    properties.insert(
+        "actions".to_string(),
+        json!({
+            "type": "array",
+            "items": { "type": "string" }
+        }),
+    );
+    json!({
+        "type": "object",
+        "properties": properties,
+        "additionalProperties": false,
+        "anyOf": [
+            { "required": ["model_file"] },
+            { "required": ["source"] },
+            { "required": ["registry_binary", "model_name"] }
+        ]
+    })
+}
+
+fn input_schema_with_contract_snapshot() -> Value {
+    json!({
+        "type": "object",
+        "properties": {
+            "model_file": { "type": "string" },
+            "source_name": { "type": "string" },
+            "source": { "type": "string" },
+            "registry_binary": { "type": "string" },
+            "model_name": { "type": "string" }
+        },
+        "additionalProperties": false
+    })
+}
+
+fn input_schema_with_contract_check() -> Value {
+    let mut properties = common_target_properties();
+    properties.insert("lock_file".to_string(), json!({ "type": "string" }));
+    json!({
+        "type": "object",
+        "properties": properties,
+        "required": ["lock_file"],
+        "additionalProperties": false,
+        "anyOf": [
+            { "required": ["model_file", "lock_file"] },
+            { "required": ["source", "lock_file"] },
+            { "required": ["registry_binary", "lock_file"] }
+        ]
+    })
+}
+
+fn input_schema_list_models() -> Value {
+    json!({
+        "type": "object",
+        "properties": {
+            "registry_binary": { "type": "string" }
+        },
+        "additionalProperties": false
+    })
+}
+
+fn input_schema_with_graph() -> Value {
+    let mut properties = common_target_properties();
+    properties.insert(
+        "format".to_string(),
+        json!({
+            "type": "string",
+            "enum": ["mermaid", "dot", "svg", "text", "json"]
+        }),
+    );
+    properties.insert(
+        "view".to_string(),
+        json!({
+            "type": "string",
+            "enum": ["overview", "logic"]
+        }),
+    );
+    json!({
+        "type": "object",
+        "properties": properties,
+        "additionalProperties": false,
+        "anyOf": [
+            { "required": ["model_file"] },
+            { "required": ["source"] },
+            { "required": ["registry_binary", "model_name"] }
+        ]
+    })
+}
+
+fn common_target_properties() -> serde_json::Map<String, Value> {
+    let mut properties = serde_json::Map::new();
+    properties.insert("model_file".to_string(), json!({ "type": "string" }));
+    properties.insert("source_name".to_string(), json!({ "type": "string" }));
+    properties.insert("source".to_string(), json!({ "type": "string" }));
+    properties.insert("registry_binary".to_string(), json!({ "type": "string" }));
+    properties.insert("model_name".to_string(), json!({ "type": "string" }));
+    properties
+}
+
+fn handle_tool_call(config: &ServerConfig, params: &Value) -> Result<ToolResult, String> {
+    let call: ToolCallParams = serde_json::from_value(params.clone())
+        .map_err(|err| format!("invalid tool call: {err}"))?;
+    let arguments = call.arguments.unwrap_or_else(|| json!({}));
+
+    match call.name.as_str() {
+        "valid_inspect" => {
+            let args = parse_args::<BasicArgs>(&arguments)?;
+            inspect_tool(config, &args)
+        }
+        "valid_check" => {
+            let args = parse_args::<BackendArgs>(&arguments)?;
+            check_tool(config, &args)
+        }
+        "valid_explain" => {
+            let args = parse_args::<BackendArgs>(&arguments)?;
+            explain_tool(config, &args)
+        }
+        "valid_coverage" => {
+            let args = parse_args::<BackendArgs>(&arguments)?;
+            coverage_tool(config, &args)
+        }
+        "valid_testgen" => {
+            let args = parse_args::<TestgenArgs>(&arguments)?;
+            testgen_tool(config, &args)
+        }
+        "valid_replay" => {
+            let args = parse_args::<ReplayArgs>(&arguments)?;
+            replay_tool(config, &args)
+        }
+        "valid_contract_snapshot" => {
+            let args = parse_args::<ContractSnapshotArgs>(&arguments)?;
+            contract_snapshot_tool(config, &args)
+        }
+        "valid_contract_check" => {
+            let args = parse_args::<ContractCheckArgs>(&arguments)?;
+            contract_check_tool(config, &args)
+        }
+        "valid_list_models" => {
+            let args = parse_args::<ListModelsArgs>(&arguments)?;
+            list_models_tool(config, &args)
+        }
+        "valid_graph" => {
+            let args = parse_args::<GraphArgs>(&arguments)?;
+            graph_tool(config, &args)
+        }
+        "valid_lint" => {
+            let args = parse_args::<BasicArgs>(&arguments)?;
+            lint_tool(config, &args)
+        }
+        other => Err(format!("unknown tool `{other}`")),
+    }
+}
+
+fn parse_args<T>(arguments: &Value) -> Result<T, String>
+where
+    T: for<'de> Deserialize<'de>,
+{
+    serde_json::from_value(arguments.clone())
+        .map_err(|err| format!("invalid tool arguments: {err}"))
+}
+
+#[derive(Debug, Deserialize)]
+struct ToolCallParams {
+    name: String,
+    #[serde(default)]
+    arguments: Option<Value>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+struct TargetArgs {
+    model_file: Option<String>,
+    source_name: Option<String>,
+    source: Option<String>,
+    registry_binary: Option<String>,
+    model_name: Option<String>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+struct BasicArgs {
+    #[serde(flatten)]
+    target: TargetArgs,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+struct BackendArgs {
+    #[serde(flatten)]
+    target: TargetArgs,
+    property_id: Option<String>,
+    backend: Option<String>,
+    solver_executable: Option<String>,
+    solver_args: Vec<String>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+struct TestgenArgs {
+    #[serde(flatten)]
+    target: TargetArgs,
+    property_id: Option<String>,
+    strategy: Option<String>,
+    backend: Option<String>,
+    solver_executable: Option<String>,
+    solver_args: Vec<String>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+struct ReplayArgs {
+    #[serde(flatten)]
+    target: TargetArgs,
+    property_id: Option<String>,
+    focus_action_id: Option<String>,
+    actions: Vec<String>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+struct ContractSnapshotArgs {
+    #[serde(flatten)]
+    target: TargetArgs,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+struct ContractCheckArgs {
+    #[serde(flatten)]
+    target: TargetArgs,
+    lock_file: String,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+struct ListModelsArgs {
+    registry_binary: Option<String>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+struct GraphArgs {
+    #[serde(flatten)]
+    target: TargetArgs,
+    format: Option<String>,
+    view: Option<String>,
+}
+
+enum ResolvedTarget {
+    Dsl {
+        source_name: String,
+        source: String,
+    },
+    Registry {
+        registry_binary: String,
+        model_name: String,
+    },
+}
+
+enum ContractTarget {
+    Dsl {
+        source: String,
+    },
+    Registry {
+        registry_binary: String,
+        model_name: Option<String>,
+    },
+}
+
+impl TargetArgs {
+    fn resolve(&self, config: &ServerConfig) -> Result<ResolvedTarget, String> {
+        let registry_binary = self
+            .registry_binary
+            .clone()
+            .or_else(|| config.default_registry_binary.clone());
+        let model_file = self
+            .model_file
+            .clone()
+            .or_else(|| config.default_model_file.clone());
+        let uses_registry = registry_binary.is_some() || self.model_name.is_some();
+        let uses_dsl = model_file.is_some() || self.source.is_some();
+
+        if uses_registry && uses_dsl {
+            return Err(
+                "provide either model_file/source or registry_binary+model_name, not both"
+                    .to_string(),
+            );
+        }
+
+        if uses_registry {
+            let registry_binary =
+                registry_binary.ok_or_else(|| "registry_binary is required".to_string())?;
+            let model_name = self
+                .model_name
+                .clone()
+                .ok_or_else(|| "model_name is required when using registry mode".to_string())?;
+            return Ok(ResolvedTarget::Registry {
+                registry_binary,
+                model_name,
+            });
+        }
+
+        let source = if let Some(source) = &self.source {
+            source.clone()
+        } else if let Some(path) = model_file.clone() {
+            fs::read_to_string(&path).map_err(|err| format!("failed to read `{path}`: {err}"))?
+        } else {
+            return Err(
+                "provide model_file or source for DSL mode, or registry_binary+model_name for registry mode"
+                    .to_string(),
+            );
+        };
+
+        if source.trim().is_empty() {
+            return Err("source must not be empty".to_string());
+        }
+
+        Ok(ResolvedTarget::Dsl {
+            source_name: self
+                .source_name
+                .clone()
+                .or(model_file)
+                .unwrap_or_else(|| "inline.valid".to_string()),
+            source,
+        })
+    }
+
+    fn registry_binary(&self, config: &ServerConfig) -> Result<String, String> {
+        self.registry_binary
+            .clone()
+            .or_else(|| config.default_registry_binary.clone())
+            .ok_or_else(|| "registry_binary is required".to_string())
+    }
+
+    fn resolve_contract_target(&self, config: &ServerConfig) -> Result<ContractTarget, String> {
+        let explicit_dsl = self.model_file.is_some() || self.source.is_some();
+        let explicit_registry = self.registry_binary.is_some();
+        if explicit_dsl && explicit_registry {
+            return Err(
+                "provide either model_file/source or registry_binary for contract operations"
+                    .to_string(),
+            );
+        }
+        if explicit_dsl {
+            let source = if let Some(source) = &self.source {
+                source.clone()
+            } else {
+                let path = self
+                    .model_file
+                    .clone()
+                    .or_else(|| config.default_model_file.clone())
+                    .ok_or_else(|| "model_file is required".to_string())?;
+                fs::read_to_string(&path)
+                    .map_err(|err| format!("failed to read `{path}`: {err}"))?
+            };
+            if source.trim().is_empty() {
+                return Err("source must not be empty".to_string());
+            }
+            return Ok(ContractTarget::Dsl { source });
+        }
+        if explicit_registry || config.default_registry_binary.is_some() {
+            return Ok(ContractTarget::Registry {
+                registry_binary: self.registry_binary(config)?,
+                model_name: self.model_name.clone(),
+            });
+        }
+        if let Some(path) = config.default_model_file.clone() {
+            let source = fs::read_to_string(&path)
+                .map_err(|err| format!("failed to read `{path}`: {err}"))?;
+            if source.trim().is_empty() {
+                return Err("source must not be empty".to_string());
+            }
+            return Ok(ContractTarget::Dsl { source });
+        }
+        Err(
+            "provide model_file/source for DSL mode, or registry_binary for registry mode"
+                .to_string(),
+        )
+    }
+}
+
+#[derive(Debug)]
+struct ToolResult {
+    structured_content: Value,
+    text: String,
+    is_error: bool,
+}
+
+impl ToolResult {
+    fn success(structured_content: Value) -> Self {
+        let text = default_text(&structured_content);
+        Self {
+            structured_content,
+            text,
+            is_error: false,
+        }
+    }
+
+    fn success_with_text(structured_content: Value, text: String) -> Self {
+        Self {
+            structured_content,
+            text,
+            is_error: false,
+        }
+    }
+
+    fn error(structured_content: Value) -> Self {
+        let text = default_text(&structured_content);
+        Self {
+            structured_content,
+            text,
+            is_error: true,
+        }
+    }
+
+    fn error_message(message: impl Into<String>) -> Self {
+        let message = message.into();
+        Self {
+            structured_content: json!({ "error": message.clone() }),
+            text: message,
+            is_error: true,
+        }
+    }
+
+    fn into_value(self) -> Value {
+        json!({
+            "content": [{
+                "type": "text",
+                "text": self.text
+            }],
+            "structuredContent": self.structured_content,
+            "isError": self.is_error
+        })
+    }
+}
+
+fn default_text(value: &Value) -> String {
+    serde_json::to_string_pretty(value).unwrap_or_else(|_| value.to_string())
+}
+
+fn registry_tool_result(result: Result<(i32, Value), String>, success_codes: &[i32]) -> ToolResult {
+    match result {
+        Ok((code, value)) if success_codes.contains(&code) => ToolResult::success(value),
+        Ok((_, value)) => ToolResult::error(value),
+        Err(message) => ToolResult::error_message(message),
+    }
+}
+
+fn inspect_tool(config: &ServerConfig, args: &BasicArgs) -> Result<ToolResult, String> {
+    match args.target.resolve(config)? {
+        ResolvedTarget::Dsl {
+            source_name,
+            source,
+        } => {
+            let request = InspectRequest {
+                request_id: "mcp-inspect".to_string(),
+                source_name,
+                source,
+            };
+            match inspect_source(&request) {
+                Ok(response) => Ok(ToolResult::success(parse_embedded_json(
+                    "inspect response",
+                    &render_inspect_json(&response),
+                )?)),
+                Err(diagnostics) => Ok(ToolResult::error(parse_embedded_json(
+                    "diagnostics",
+                    &render_diagnostics_json(&diagnostics),
+                )?)),
+            }
+        }
+        ResolvedTarget::Registry {
+            registry_binary,
+            model_name,
+        } => Ok(registry_tool_result(
+            run_registry_json(&registry_binary, &["inspect", &model_name, "--json"]),
+            &[0],
+        )),
+    }
+}
+
+fn check_tool(config: &ServerConfig, args: &BackendArgs) -> Result<ToolResult, String> {
+    match args.target.resolve(config)? {
+        ResolvedTarget::Dsl {
+            source_name,
+            source,
+        } => {
+            let request = CheckRequest {
+                request_id: "mcp-check".to_string(),
+                source_name: source_name.clone(),
+                source,
+                property_id: args.property_id.clone(),
+                backend: args.backend.clone(),
+                solver_executable: args.solver_executable.clone(),
+                solver_args: args.solver_args.clone(),
+            };
+            let outcome = check_source(&request);
+            let rendered = render_outcome_json(&source_name, &outcome);
+            let value = parse_embedded_json("check outcome", &rendered)?;
+            Ok(match outcome {
+                CheckOutcome::Completed(_) => ToolResult::success(value),
+                CheckOutcome::Errored(_) => ToolResult::error(value),
+            })
+        }
+        ResolvedTarget::Registry {
+            registry_binary,
+            model_name,
+        } => Ok(registry_tool_result(
+            run_registry_json(
+                &registry_binary,
+                &registry_command_args("check", &model_name, args),
+            ),
+            &[0, 2, 4],
+        )),
+    }
+}
+
+fn explain_tool(config: &ServerConfig, args: &BackendArgs) -> Result<ToolResult, String> {
+    match args.target.resolve(config)? {
+        ResolvedTarget::Dsl {
+            source_name,
+            source,
+        } => {
+            let request = CheckRequest {
+                request_id: "mcp-explain".to_string(),
+                source_name,
+                source,
+                property_id: args.property_id.clone(),
+                backend: args.backend.clone(),
+                solver_executable: args.solver_executable.clone(),
+                solver_args: args.solver_args.clone(),
+            };
+            match explain_source(&request) {
+                Ok(response) => Ok(ToolResult::success(parse_embedded_json(
+                    "explain response",
+                    &render_explain_json(&response),
+                )?)),
+                Err(error) => Ok(ToolResult::error(parse_embedded_json(
+                    "diagnostics",
+                    &render_diagnostics_json(&error.diagnostics),
+                )?)),
+            }
+        }
+        ResolvedTarget::Registry {
+            registry_binary,
+            model_name,
+        } => Ok(registry_tool_result(
+            run_registry_json(
+                &registry_binary,
+                &registry_command_args("explain", &model_name, args),
+            ),
+            &[0],
+        )),
+    }
+}
+
+fn coverage_tool(config: &ServerConfig, args: &BackendArgs) -> Result<ToolResult, String> {
+    match args.target.resolve(config)? {
+        ResolvedTarget::Dsl {
+            source_name,
+            source,
+        } => {
+            let model = match compile_source(&source) {
+                Ok(model) => model,
+                Err(diagnostics) => {
+                    return Ok(ToolResult::error(parse_embedded_json(
+                        "diagnostics",
+                        &render_diagnostics_json(&diagnostics),
+                    )?));
+                }
+            };
+            let request = CheckRequest {
+                request_id: "mcp-coverage".to_string(),
+                source_name,
+                source,
+                property_id: args.property_id.clone(),
+                backend: args.backend.clone(),
+                solver_executable: args.solver_executable.clone(),
+                solver_args: args.solver_args.clone(),
+            };
+            match check_source(&request) {
+                CheckOutcome::Completed(result) => {
+                    let traces = result.trace.into_iter().collect::<Vec<_>>();
+                    let report = collect_coverage(&model, &traces);
+                    Ok(ToolResult::success(parse_embedded_json(
+                        "coverage report",
+                        &render_coverage_json(&report),
+                    )?))
+                }
+                CheckOutcome::Errored(error) => Ok(ToolResult::error(parse_embedded_json(
+                    "diagnostics",
+                    &render_diagnostics_json(&error.diagnostics),
+                )?)),
+            }
+        }
+        ResolvedTarget::Registry {
+            registry_binary,
+            model_name,
+        } => Ok(registry_tool_result(
+            run_registry_json(
+                &registry_binary,
+                &registry_command_args("coverage", &model_name, args),
+            ),
+            &[0],
+        )),
+    }
+}
+
+fn testgen_tool(config: &ServerConfig, args: &TestgenArgs) -> Result<ToolResult, String> {
+    match args.target.resolve(config)? {
+        ResolvedTarget::Dsl {
+            source_name,
+            source,
+        } => {
+            let request = TestgenRequest {
+                request_id: "mcp-testgen".to_string(),
+                source_name,
+                source,
+                property_id: args.property_id.clone(),
+                strategy: args
+                    .strategy
+                    .clone()
+                    .unwrap_or_else(|| "counterexample".to_string()),
+                backend: args.backend.clone(),
+                solver_executable: args.solver_executable.clone(),
+                solver_args: args.solver_args.clone(),
+            };
+            match testgen_source(&request) {
+                Ok(response) => Ok(ToolResult::success(json!({
+                    "schema_version": response.schema_version,
+                    "request_id": response.request_id,
+                    "status": response.status,
+                    "vector_ids": response.vector_ids,
+                    "vectors": response.vectors.into_iter().map(|vector| json!({
+                        "vector_id": vector.vector_id,
+                        "strictness": vector.strictness,
+                        "derivation": vector.derivation,
+                        "source_kind": vector.source_kind,
+                        "strategy": vector.strategy
+                    })).collect::<Vec<_>>(),
+                    "generated_files": response.generated_files
+                }))),
+                Err(error) => Ok(ToolResult::error(parse_embedded_json(
+                    "diagnostics",
+                    &render_diagnostics_json(&error.diagnostics),
+                )?)),
+            }
+        }
+        ResolvedTarget::Registry {
+            registry_binary,
+            model_name,
+        } => {
+            let mut command = registry_testgen_command_args(&model_name, args);
+            if let Some(strategy) = &args.strategy {
+                command.push(format!("--strategy={strategy}"));
+            }
+            Ok(registry_tool_result(
+                run_registry_json(&registry_binary, &command),
+                &[0],
+            ))
+        }
+    }
+}
+
+fn replay_tool(config: &ServerConfig, args: &ReplayArgs) -> Result<ToolResult, String> {
+    match args.target.resolve(config)? {
+        ResolvedTarget::Dsl {
+            source_name: _,
+            source,
+        } => {
+            let model = match compile_model(&source) {
+                Ok(model) => model,
+                Err(diagnostics) => {
+                    return Ok(ToolResult::error(parse_embedded_json(
+                        "diagnostics",
+                        &render_diagnostics_json(&diagnostics),
+                    )?));
+                }
+            };
+            let property_id = args
+                .property_id
+                .clone()
+                .or_else(|| {
+                    model
+                        .properties
+                        .first()
+                        .map(|property| property.property_id.clone())
+                })
+                .unwrap_or_else(|| "P_SAFE".to_string());
+            let terminal = match replay_actions(&model, &args.actions) {
+                Ok(terminal) => terminal,
+                Err(diagnostic) => {
+                    return Ok(ToolResult::error(parse_embedded_json(
+                        "diagnostics",
+                        &render_diagnostics_json(&[diagnostic]),
+                    )?));
+                }
+            };
+            let focus_action_enabled = args.focus_action_id.as_deref().map(|action_id| {
+                apply_action(&model, &terminal, action_id)
+                    .ok()
+                    .flatten()
+                    .is_some()
+            });
+            let Some(property) = model
+                .properties
+                .iter()
+                .find(|candidate| candidate.property_id == property_id)
+            else {
+                return Ok(ToolResult::error_message(format!(
+                    "unknown property `{property_id}`"
+                )));
+            };
+            let property_holds = matches!(
+                eval_expr(&model, &terminal, &property.expr),
+                Ok(crate::ir::Value::Bool(true))
+            );
+            let mut path_tags = BTreeSet::new();
+            for action_id in &args.actions {
+                for action in model
+                    .actions
+                    .iter()
+                    .filter(|action| action.action_id == *action_id)
+                {
+                    for tag in &action.path_tags {
+                        path_tags.insert(tag.clone());
+                    }
+                }
+            }
+            Ok(ToolResult::success(parse_embedded_json(
+                "replay response",
+                &render_replay_json(
+                    &property_id,
+                    &args.actions,
+                    &terminal.as_named_map(&model),
+                    args.focus_action_id.as_deref(),
+                    focus_action_enabled,
+                    Some(property_holds),
+                    &path_tags.into_iter().collect::<Vec<_>>(),
+                ),
+            )?))
+        }
+        ResolvedTarget::Registry {
+            registry_binary,
+            model_name,
+        } => {
+            let mut command = vec!["replay".to_string(), model_name, "--json".to_string()];
+            if let Some(property_id) = &args.property_id {
+                command.push(format!("--property={property_id}"));
+            }
+            if let Some(focus_action_id) = &args.focus_action_id {
+                command.push(format!("--focus-action={focus_action_id}"));
+            }
+            if !args.actions.is_empty() {
+                command.push(format!("--actions={}", args.actions.join(",")));
+            }
+            Ok(registry_tool_result(
+                run_registry_json(&registry_binary, &command),
+                &[0],
+            ))
+        }
+    }
+}
+
+fn contract_snapshot_tool(
+    config: &ServerConfig,
+    args: &ContractSnapshotArgs,
+) -> Result<ToolResult, String> {
+    match args.target.resolve_contract_target(config)? {
+        ContractTarget::Registry {
+            registry_binary,
+            model_name,
+        } => {
+            let result = run_registry_json(&registry_binary, &["contract", "snapshot", "--json"]);
+            let tool = match result {
+                Ok((code, value)) if code == 0 => {
+                    if let Some(model_name) = model_name.as_deref() {
+                        match select_named_entry(value, "snapshots", model_name, &registry_binary) {
+                            Ok(filtered) => ToolResult::success(filtered),
+                            Err(message) => ToolResult::error_message(message),
+                        }
+                    } else {
+                        ToolResult::success(value)
+                    }
+                }
+                Ok((_, value)) => ToolResult::error(value),
+                Err(message) => ToolResult::error_message(message),
+            };
+            Ok(tool)
+        }
+        ContractTarget::Dsl { source } => {
+            let model = match compile_source(&source) {
+                Ok(model) => model,
+                Err(diagnostics) => {
+                    return Ok(ToolResult::error(parse_embedded_json(
+                        "diagnostics",
+                        &render_diagnostics_json(&diagnostics),
+                    )?));
+                }
+            };
+            let snapshot = snapshot_model(&model);
+            Ok(ToolResult::success(json!({
+                "schema_version": "1.0.0",
+                "model_id": snapshot.model_id,
+                "contract_hash": snapshot.contract_hash,
+                "state_fields": snapshot.state_fields,
+                "actions": snapshot.actions,
+                "properties": snapshot.properties
+            })))
+        }
+    }
+}
+
+fn contract_check_tool(
+    config: &ServerConfig,
+    args: &ContractCheckArgs,
+) -> Result<ToolResult, String> {
+    match args.target.resolve_contract_target(config)? {
+        ContractTarget::Registry {
+            registry_binary,
+            model_name,
+        } => {
+            let result = run_registry_json(
+                &registry_binary,
+                &["contract", "check", &args.lock_file, "--json"],
+            );
+            let tool = match result {
+                Ok((code, value)) if matches!(code, 0 | 2) => {
+                    if let Some(model_name) = model_name.as_deref() {
+                        match select_named_entry(value, "reports", model_name, &registry_binary) {
+                            Ok(filtered) => ToolResult::success(filtered),
+                            Err(message) => ToolResult::error_message(message),
+                        }
+                    } else {
+                        ToolResult::success(value)
+                    }
+                }
+                Ok((_, value)) => ToolResult::error(value),
+                Err(message) => ToolResult::error_message(message),
+            };
+            Ok(tool)
+        }
+        ContractTarget::Dsl { source } => {
+            let model = match compile_source(&source) {
+                Ok(model) => model,
+                Err(diagnostics) => {
+                    return Ok(ToolResult::error(parse_embedded_json(
+                        "diagnostics",
+                        &render_diagnostics_json(&diagnostics),
+                    )?));
+                }
+            };
+            let snapshot = snapshot_model(&model);
+            let lock_body = match fs::read_to_string(&args.lock_file) {
+                Ok(lock_body) => lock_body,
+                Err(err) => {
+                    return Ok(ToolResult::error_message(format!(
+                        "failed to read `{}`: {err}",
+                        args.lock_file
+                    )));
+                }
+            };
+            let lock = match parse_lock_file(&lock_body) {
+                Ok(lock) => lock,
+                Err(err) => {
+                    return Ok(ToolResult::error_message(format!(
+                        "failed to parse `{}`: {err}",
+                        args.lock_file
+                    )));
+                }
+            };
+            let report = if let Some(expected) = lock
+                .entries
+                .iter()
+                .find(|entry| entry.model_id == snapshot.model_id)
+            {
+                let drift = compare_snapshot(expected, &snapshot);
+                json!({
+                    "schema_version": "1.0.0",
+                    "status": drift.status,
+                    "contract_id": snapshot.model_id,
+                    "old_hash": expected.contract_hash,
+                    "new_hash": snapshot.contract_hash,
+                    "changes": drift.changes,
+                    "lock_file": args.lock_file
+                })
+            } else {
+                json!({
+                    "schema_version": "1.0.0",
+                    "status": "missing",
+                    "contract_id": snapshot.model_id,
+                    "old_hash": Value::Null,
+                    "new_hash": snapshot.contract_hash,
+                    "changes": ["missing_from_lock_file"],
+                    "lock_file": args.lock_file
+                })
+            };
+            Ok(ToolResult::success(report))
+        }
+    }
+}
+
+fn list_models_tool(config: &ServerConfig, args: &ListModelsArgs) -> Result<ToolResult, String> {
+    let registry_binary = args
+        .registry_binary
+        .clone()
+        .or_else(|| config.default_registry_binary.clone());
+    if let Some(registry_binary) = registry_binary {
+        return Ok(registry_tool_result(
+            run_registry_json(&registry_binary, &["list", "--json"]),
+            &[0],
+        ));
+    }
+
+    Ok(ToolResult::success(json!({
+        "models": list_bundled_models()
+    })))
+}
+
+fn graph_tool(config: &ServerConfig, args: &GraphArgs) -> Result<ToolResult, String> {
+    let format = args.format.as_deref().unwrap_or("mermaid");
+    let view = GraphView::parse(args.view.as_deref());
+    match args.target.resolve(config)? {
+        ResolvedTarget::Dsl {
+            source_name,
+            source,
+        } => {
+            let request = InspectRequest {
+                request_id: "mcp-graph".to_string(),
+                source_name,
+                source,
+            };
+            match inspect_source(&request) {
+                Ok(response) => match format {
+                    "json" => Ok(ToolResult::success(parse_embedded_json(
+                        "inspect response",
+                        &render_inspect_json(&response),
+                    )?)),
+                    "text" => Ok(ToolResult::success_with_text(
+                        json!({
+                            "format": "text",
+                            "view": view_name(view),
+                            "graph": crate::api::render_inspect_text(&response)
+                        }),
+                        crate::api::render_inspect_text(&response),
+                    )),
+                    "dot" => {
+                        let graph = render_model_dot_with_view(&response, view);
+                        Ok(ToolResult::success_with_text(
+                            json!({ "format": "dot", "view": view_name(view), "graph": graph }),
+                            render_model_dot_with_view(&response, view),
+                        ))
+                    }
+                    "svg" => {
+                        let graph = render_model_svg_with_view(&response, view);
+                        Ok(ToolResult::success_with_text(
+                            json!({ "format": "svg", "view": view_name(view), "graph": graph }),
+                            render_model_svg_with_view(&response, view),
+                        ))
+                    }
+                    _ => {
+                        let graph = render_model_mermaid_with_view(&response, view);
+                        Ok(ToolResult::success_with_text(
+                            json!({ "format": "mermaid", "view": view_name(view), "graph": graph }),
+                            render_model_mermaid_with_view(&response, view),
+                        ))
+                    }
+                },
+                Err(diagnostics) => Ok(ToolResult::error(parse_embedded_json(
+                    "diagnostics",
+                    &render_diagnostics_json(&diagnostics),
+                )?)),
+            }
+        }
+        ResolvedTarget::Registry {
+            registry_binary,
+            model_name,
+        } => {
+            if format == "json" {
+                return Ok(registry_tool_result(
+                    run_registry_json(
+                        &registry_binary,
+                        &[
+                            "graph",
+                            &model_name,
+                            "--format=json",
+                            &format!("--view={}", view_name(view)),
+                        ],
+                    ),
+                    &[0],
+                ));
+            }
+            let mut command = Command::new(&registry_binary);
+            command
+                .arg("graph")
+                .arg(&model_name)
+                .arg(format!("--format={format}"))
+                .arg(format!("--view={}", view_name(view)));
+            let output = match command.output() {
+                Ok(output) => output,
+                Err(err) => {
+                    return Ok(ToolResult::error_message(format!(
+                        "failed to execute `{registry_binary}`: {err}"
+                    )));
+                }
+            };
+            let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+            if output.status.success() {
+                Ok(ToolResult::success_with_text(
+                    json!({
+                        "format": format,
+                        "view": view_name(view),
+                        "graph": stdout
+                    }),
+                    stdout,
+                ))
+            } else {
+                let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+                Ok(ToolResult::error_message(if stderr.is_empty() {
+                    stdout
+                } else {
+                    stderr
+                }))
+            }
+        }
+    }
+}
+
+fn lint_tool(config: &ServerConfig, args: &BasicArgs) -> Result<ToolResult, String> {
+    match args.target.resolve(config)? {
+        ResolvedTarget::Dsl {
+            source_name,
+            source,
+        } => {
+            let request = InspectRequest {
+                request_id: "mcp-lint".to_string(),
+                source_name,
+                source,
+            };
+            match lint_source(&request) {
+                Ok(response) => Ok(ToolResult::success(parse_embedded_json(
+                    "lint response",
+                    &render_lint_json(&response),
+                )?)),
+                Err(diagnostics) => Ok(ToolResult::error(parse_embedded_json(
+                    "diagnostics",
+                    &render_diagnostics_json(&diagnostics),
+                )?)),
+            }
+        }
+        ResolvedTarget::Registry {
+            registry_binary,
+            model_name,
+        } => Ok(registry_tool_result(
+            run_registry_json(&registry_binary, &["lint", &model_name, "--json"]),
+            &[0, 2],
+        )),
+    }
+}
+
+fn registry_command_args(command: &str, model_name: &str, args: &BackendArgs) -> Vec<String> {
+    let mut command_args = vec![
+        command.to_string(),
+        model_name.to_string(),
+        "--json".to_string(),
+    ];
+    if let Some(property_id) = &args.property_id {
+        command_args.push(format!("--property={property_id}"));
+    }
+    if let Some(backend) = &args.backend {
+        command_args.push(format!("--backend={backend}"));
+    }
+    if let Some(solver_executable) = &args.solver_executable {
+        command_args.push("--solver-exec".to_string());
+        command_args.push(solver_executable.clone());
+    }
+    for solver_arg in &args.solver_args {
+        command_args.push("--solver-arg".to_string());
+        command_args.push(solver_arg.clone());
+    }
+    command_args
+}
+
+fn registry_testgen_command_args(model_name: &str, args: &TestgenArgs) -> Vec<String> {
+    let mut command_args = vec![
+        "testgen".to_string(),
+        model_name.to_string(),
+        "--json".to_string(),
+    ];
+    if let Some(property_id) = &args.property_id {
+        command_args.push(format!("--property={property_id}"));
+    }
+    if let Some(backend) = &args.backend {
+        command_args.push(format!("--backend={backend}"));
+    }
+    if let Some(solver_executable) = &args.solver_executable {
+        command_args.push("--solver-exec".to_string());
+        command_args.push(solver_executable.clone());
+    }
+    for solver_arg in &args.solver_args {
+        command_args.push("--solver-arg".to_string());
+        command_args.push(solver_arg.clone());
+    }
+    command_args
+}
+
+fn run_registry_json(
+    registry_binary: &str,
+    args: &[impl AsRef<str>],
+) -> Result<(i32, Value), String> {
+    let mut command = Command::new(registry_binary);
+    for arg in args {
+        command.arg(arg.as_ref());
+    }
+    let output = command
+        .output()
+        .map_err(|err| format!("failed to execute `{registry_binary}`: {err}"))?;
+    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if stdout.is_empty() {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        return Err(if stderr.is_empty() {
+            format!("`{registry_binary}` returned no JSON output")
+        } else {
+            stderr
+        });
+    }
+    let value = serde_json::from_str(&stdout)
+        .map_err(|err| format!("failed to parse JSON from `{registry_binary}`: {err}: {stdout}"))?;
+    Ok((output.status.code().unwrap_or(1), value))
+}
+
+fn parse_embedded_json(label: &str, body: &str) -> Result<Value, String> {
+    serde_json::from_str(body).map_err(|err| format!("failed to parse {label}: {err}"))
+}
+
+fn select_named_entry(
+    value: Value,
+    field: &str,
+    model_name: &str,
+    registry_binary: &str,
+) -> Result<Value, String> {
+    let Some(entries) = value.get(field).and_then(Value::as_array) else {
+        return Err(format!("registry response did not contain `{field}`"));
+    };
+
+    if let Some(entry) = entries
+        .iter()
+        .find(|entry| entry.get("model_id").and_then(Value::as_str) == Some(model_name))
+    {
+        return Ok(entry.clone());
+    }
+
+    if let Some(entry) = entries
+        .iter()
+        .find(|entry| entry.get("contract_id").and_then(Value::as_str) == Some(model_name))
+    {
+        return Ok(entry.clone());
+    }
+
+    let model_id = registry_model_id(registry_binary, model_name)?;
+    entries
+        .iter()
+        .find(|entry| {
+            entry.get("model_id").and_then(Value::as_str) == Some(model_id.as_str())
+                || entry.get("contract_id").and_then(Value::as_str) == Some(model_id.as_str())
+        })
+        .cloned()
+        .ok_or_else(|| format!("no entry found for model `{model_name}`"))
+}
+
+fn registry_model_id(registry_binary: &str, model_name: &str) -> Result<String, String> {
+    let (code, value) = run_registry_json(registry_binary, &["inspect", model_name, "--json"])?;
+    if code != 0 {
+        return Err(format!("failed to inspect model `{model_name}`"));
+    }
+    value
+        .get("model_id")
+        .and_then(Value::as_str)
+        .map(ToString::to_string)
+        .ok_or_else(|| format!("inspect output did not contain model_id for `{model_name}`"))
+}
+
+fn view_name(view: GraphView) -> &'static str {
+    match view {
+        GraphView::Overview => "overview",
+        GraphView::Logic => "logic",
+    }
+}

--- a/tests/e2e_mcp.rs
+++ b/tests/e2e_mcp.rs
@@ -1,0 +1,418 @@
+use std::{
+    fs,
+    io::{BufRead, BufReader, Write},
+    path::{Path, PathBuf},
+    process::{Child, ChildStdin, ChildStdout, Command, Stdio},
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+use serde_json::{json, Value};
+
+fn manifest_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+fn fixture(name: &str) -> PathBuf {
+    manifest_dir()
+        .join("tests")
+        .join("fixtures")
+        .join("models")
+        .join(name)
+}
+
+struct TempDir {
+    path: PathBuf,
+}
+
+impl TempDir {
+    fn new(prefix: &str) -> Self {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock should be monotonic enough for tests")
+            .as_nanos();
+        let path =
+            std::env::temp_dir().join(format!("valid-{prefix}-{}-{unique}", std::process::id()));
+        fs::create_dir_all(&path).expect("temp dir should be created");
+        Self { path }
+    }
+
+    fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+impl Drop for TempDir {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.path);
+    }
+}
+
+struct McpClient {
+    child: Child,
+    stdin: ChildStdin,
+    stdout: BufReader<ChildStdout>,
+    next_id: u64,
+}
+
+impl McpClient {
+    fn spawn(args: &[&str], cwd: &Path) -> Self {
+        let mut child = Command::new(env!("CARGO_BIN_EXE_valid-mcp"))
+            .args(args)
+            .current_dir(cwd)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::inherit())
+            .spawn()
+            .expect("valid-mcp should start");
+        let stdin = child.stdin.take().expect("stdin should be piped");
+        let stdout = child.stdout.take().expect("stdout should be piped");
+        Self {
+            child,
+            stdin,
+            stdout: BufReader::new(stdout),
+            next_id: 1,
+        }
+    }
+
+    fn initialize(&mut self) -> Value {
+        let result = self.request(
+            "initialize",
+            json!({
+                "protocolVersion": "2025-06-18",
+                "capabilities": {},
+                "clientInfo": { "name": "valid-test", "version": "0.1.0" }
+            }),
+        );
+        self.notify("notifications/initialized", json!({}));
+        result
+    }
+
+    fn request(&mut self, method: &str, params: Value) -> Value {
+        let id = self.next_id;
+        self.next_id += 1;
+        self.send(json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "method": method,
+            "params": params
+        }));
+        loop {
+            let response = self.read_message();
+            if response.get("id").and_then(Value::as_u64) == Some(id) {
+                if let Some(error) = response.get("error") {
+                    panic!("mcp request failed: {error}");
+                }
+                return response
+                    .get("result")
+                    .cloned()
+                    .expect("successful response should contain result");
+            }
+        }
+    }
+
+    fn notify(&mut self, method: &str, params: Value) {
+        self.send(json!({
+            "jsonrpc": "2.0",
+            "method": method,
+            "params": params
+        }));
+    }
+
+    fn call_tool(&mut self, name: &str, arguments: Value) -> Value {
+        self.request(
+            "tools/call",
+            json!({
+                "name": name,
+                "arguments": arguments
+            }),
+        )
+    }
+
+    fn send(&mut self, message: Value) {
+        let encoded = serde_json::to_string(&message).expect("message should serialize");
+        self.stdin
+            .write_all(encoded.as_bytes())
+            .expect("message should be written");
+        self.stdin
+            .write_all(b"\n")
+            .expect("newline should be written");
+        self.stdin.flush().expect("stdin should flush");
+    }
+
+    fn read_message(&mut self) -> Value {
+        let mut line = String::new();
+        self.stdout
+            .read_line(&mut line)
+            .expect("response should be readable");
+        assert!(!line.is_empty(), "server closed stdout unexpectedly");
+        serde_json::from_str(line.trim()).expect("response should be valid json")
+    }
+}
+
+impl Drop for McpClient {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+fn structured_content(tool_result: Value) -> Value {
+    assert_eq!(
+        tool_result.get("isError").and_then(Value::as_bool),
+        Some(false),
+        "tool returned error: {tool_result}"
+    );
+    tool_result
+        .get("structuredContent")
+        .cloned()
+        .expect("tool result should include structuredContent")
+}
+
+#[test]
+fn valid_mcp_lists_tools_and_executes_dsl_mode() {
+    let temp = TempDir::new("mcp-dsl");
+    let mut client = McpClient::spawn(&[], temp.path());
+
+    let initialize = client.initialize();
+    assert_eq!(
+        initialize
+            .get("protocolVersion")
+            .and_then(Value::as_str)
+            .expect("protocol version should be present"),
+        "2025-06-18"
+    );
+
+    let tools = client.request("tools/list", json!({}));
+    let tool_names = tools
+        .get("tools")
+        .and_then(Value::as_array)
+        .expect("tools/list should return tools")
+        .iter()
+        .filter_map(|tool| tool.get("name").and_then(Value::as_str))
+        .collect::<Vec<_>>();
+    for expected in [
+        "valid_inspect",
+        "valid_check",
+        "valid_explain",
+        "valid_coverage",
+        "valid_testgen",
+        "valid_replay",
+        "valid_contract_snapshot",
+        "valid_contract_check",
+        "valid_list_models",
+        "valid_graph",
+        "valid_lint",
+    ] {
+        assert!(tool_names.contains(&expected), "missing tool {expected}");
+    }
+
+    let model_file = fixture("failing_counter.valid");
+    let model_file_str = model_file.to_string_lossy().to_string();
+
+    let inspect = structured_content(
+        client.call_tool("valid_inspect", json!({ "model_file": model_file_str })),
+    );
+    assert_eq!(inspect["model_id"], "FailingCounter");
+    assert_eq!(inspect["actions"].as_array().map(Vec::len), Some(2));
+
+    let check = structured_content(
+        client.call_tool("valid_check", json!({ "model_file": model_file_str })),
+    );
+    assert_eq!(check["status"], "FAIL");
+    assert_eq!(check["property_result"]["property_id"], "P_FAIL");
+    assert!(
+        check["trace"]["steps"]
+            .as_array()
+            .expect("trace steps should be present")
+            .len()
+            >= 2
+    );
+
+    let explain = structured_content(
+        client.call_tool("valid_explain", json!({ "model_file": model_file_str })),
+    );
+    assert_eq!(explain["property_id"], "P_FAIL");
+    assert!(
+        explain["candidate_causes"]
+            .as_array()
+            .expect("candidate causes should exist")
+            .len()
+            >= 1
+    );
+
+    let coverage = structured_content(
+        client.call_tool("valid_coverage", json!({ "model_file": model_file_str })),
+    );
+    assert_eq!(coverage["model_id"], "FailingCounter");
+    assert!(
+        coverage["summary"]["step_count"]
+            .as_u64()
+            .expect("step count should be numeric")
+            >= 1
+    );
+
+    let graph = structured_content(client.call_tool(
+        "valid_graph",
+        json!({ "model_file": model_file_str, "format": "mermaid", "view": "logic" }),
+    ));
+    assert_eq!(graph["format"], "mermaid");
+    assert!(graph["graph"]
+        .as_str()
+        .expect("graph should be text")
+        .contains("flowchart"));
+
+    let lint =
+        structured_content(client.call_tool("valid_lint", json!({ "model_file": model_file_str })));
+    assert_eq!(lint["status"], "ok");
+    assert!(lint["findings"].is_array());
+
+    let replay = structured_content(client.call_tool(
+        "valid_replay",
+        json!({
+            "model_file": model_file_str,
+            "property_id": "P_FAIL",
+            "actions": ["Inc", "Inc"]
+        }),
+    ));
+    assert_eq!(replay["status"], "ok");
+    assert_eq!(replay["property_holds"], false);
+
+    let snapshot = structured_content(client.call_tool(
+        "valid_contract_snapshot",
+        json!({ "model_file": model_file_str }),
+    ));
+    let lock_file = temp.path().join("valid.lock.json");
+    fs::write(
+        &lock_file,
+        serde_json::to_vec(&json!({
+            "schema_version": "1.0.0",
+            "generated_at": "1970-01-01T00:00:00Z",
+            "entries": [{
+                "model_id": snapshot["model_id"],
+                "contract_hash": snapshot["contract_hash"],
+                "state_fields": snapshot["state_fields"],
+                "actions": snapshot["actions"],
+                "properties": snapshot["properties"]
+            }]
+        }))
+        .expect("lock json should serialize"),
+    )
+    .expect("lock file should be written");
+
+    let contract_check = structured_content(client.call_tool(
+        "valid_contract_check",
+        json!({
+            "model_file": model_file_str,
+            "lock_file": lock_file.to_string_lossy().to_string()
+        }),
+    ));
+    assert_eq!(contract_check["status"], "unchanged");
+
+    let testgen = structured_content(client.call_tool(
+        "valid_testgen",
+        json!({
+            "model_file": model_file_str,
+            "strategy": "counterexample"
+        }),
+    ));
+    assert!(
+        testgen["vector_ids"]
+            .as_array()
+            .expect("vector ids should be present")
+            .len()
+            >= 1
+    );
+    let generated_file = testgen["generated_files"]
+        .as_array()
+        .and_then(|items| items.first())
+        .and_then(Value::as_str)
+        .expect("generated file should be present");
+    assert!(temp.path().join(generated_file).exists() || PathBuf::from(generated_file).exists());
+
+    let bundled = structured_content(client.call_tool("valid_list_models", json!({})));
+    assert!(bundled["models"]
+        .as_array()
+        .expect("bundled models should be present")
+        .iter()
+        .any(|item| item == "counter"));
+}
+
+#[cfg(unix)]
+fn make_mock_registry(temp: &TempDir) -> PathBuf {
+    use std::os::unix::fs::PermissionsExt;
+
+    let path = temp.path().join("mock-registry.sh");
+    let body = r#"#!/bin/sh
+cmd="$1"
+sub="$2"
+
+if [ "$cmd" = "list" ]; then
+  printf '%s\n' '{"models":["mock-safe","mock-broken"]}'
+  exit 0
+fi
+
+if [ "$cmd" = "check" ]; then
+  printf '%s\n' '{"kind":"completed","model_id":"mock-broken","manifest":{"request_id":"registry-check","run_id":"run-registry","schema_version":"1.0.0","source_hash":"sha256:source","contract_hash":"sha256:contract","engine_version":"0.1.0","backend_name":"explicit","backend_version":"0.1.0","seed":null},"status":"FAIL","assurance_level":"COMPLETE","explored_states":3,"explored_transitions":2,"property_result":{"property_id":"P_FAIL","property_kind":"invariant","status":"FAIL","assurance_level":"COMPLETE","reason_code":"MOCK_COUNTEREXAMPLE","unknown_reason":null,"terminal_state_id":"s2","evidence_id":"ev-1","summary":"mock registry fail"},"trace":null,"ci":{"exit_code":2,"status":"FAIL","backend":"explicit"},"review_summary":{"headline":"FAIL P_FAIL for mock-broken","trace_steps":0,"failing_action_id":null,"action_sequence":[],"next_steps":[]}}'
+  exit 2
+fi
+
+if [ "$cmd" = "contract" ] && [ "$sub" = "snapshot" ]; then
+  printf '%s\n' '{"snapshots":[{"model_id":"mock-safe","contract_hash":"sha256:safe"},{"model_id":"mock-broken","contract_hash":"sha256:broken"}]}'
+  exit 0
+fi
+
+if [ "$cmd" = "contract" ] && [ "$sub" = "check" ]; then
+  printf '%s\n' '{"reports":[{"schema_version":"1.0.0","status":"changed","contract_id":"mock-broken","old_hash":"sha256:old","new_hash":"sha256:new","changes":["actions"]}]}'
+  exit 2
+fi
+
+printf '%s\n' '{"diagnostics":[{"error_code":"SEARCH","segment":"engine-search","message":"unsupported mock command","primary_span":null,"help":[],"best_practices":[]}]}'
+exit 3
+"#;
+    fs::write(&path, body).expect("mock registry script should be written");
+    let mut permissions = fs::metadata(&path)
+        .expect("mock registry metadata should be available")
+        .permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(&path, permissions).expect("mock registry should be executable");
+    path
+}
+
+#[cfg(unix)]
+#[test]
+fn valid_mcp_supports_registry_mode_with_default_binary() {
+    let temp = TempDir::new("mcp-registry");
+    let registry = make_mock_registry(&temp);
+    let registry_str = registry.to_string_lossy().to_string();
+    let mut client = McpClient::spawn(&["--registry-binary", &registry_str], temp.path());
+    client.initialize();
+
+    let listed = structured_content(client.call_tool("valid_list_models", json!({})));
+    assert_eq!(listed["models"][0], "mock-safe");
+
+    let check =
+        structured_content(client.call_tool("valid_check", json!({ "model_name": "mock-broken" })));
+    assert_eq!(check["status"], "FAIL");
+    assert_eq!(
+        check["property_result"]["reason_code"],
+        "MOCK_COUNTEREXAMPLE"
+    );
+
+    let snapshot = structured_content(client.call_tool(
+        "valid_contract_snapshot",
+        json!({ "model_name": "mock-broken" }),
+    ));
+    assert_eq!(snapshot["contract_hash"], "sha256:broken");
+
+    let lock_file = temp.path().join("mock.lock.json");
+    fs::write(&lock_file, "{}").expect("placeholder lock file should be written");
+    let drift = structured_content(client.call_tool(
+        "valid_contract_check",
+        json!({
+            "model_name": "mock-broken",
+            "lock_file": lock_file.to_string_lossy().to_string()
+        }),
+    ));
+    assert_eq!(drift["status"], "changed");
+    assert_eq!(drift["contract_id"], "mock-broken");
+}


### PR DESCRIPTION
## Summary
- add a `valid-mcp` binary and reusable MCP stdio server module that exposes inspect/check/explain/coverage/testgen/replay/contract/list_models/graph/lint
- support both `.valid` DSL mode through direct library calls and Rust registry mode through a registry binary bridge
- document Claude Desktop and Claude Code setup with config templates and add end-to-end MCP tests for both modes

## Testing
- cargo test -q
- cargo test --test e2e_mcp
- manual smoke test with `target/debug/valid-mcp` against `tests/fixtures/models/failing_counter.valid`
- manual smoke test with `target/debug/valid-mcp --registry-binary target/debug/examples/valid_models`

Closes #19
