### PR TITLE
Add reachability property support

### DIFF
--- a/packages/valid/src/api/mod.rs
+++ b/packages/valid/src/api/mod.rs
@@ -23,7 +23,7 @@ use crate::{
     },
     testgen::{
         build_counterexample_vector, build_model_test_vectors_for_strategy,
-        build_synthetic_witness_vectors, minimize_counterexample_vector,
+        build_synthetic_witness_vectors, build_witness_vector, minimize_counterexample_vector,
         write_generated_test_files, MinimizeResult, ReplayTarget,
     },
 };
@@ -430,7 +430,7 @@ pub fn inspect_source(request: &InspectRequest) -> Result<InspectResponse, Vec<D
             .iter()
             .map(|property| InspectProperty {
                 property_id: property.property_id.clone(),
-                kind: format!("{:?}", property.kind),
+                kind: property.kind.to_string(),
                 expr: Some(render_expr_ir(&property.expr)),
             })
             .collect(),
@@ -839,6 +839,16 @@ pub fn explain_source(request: &CheckRequest) -> Result<ExplainResponse, CheckEr
             let coverage_report = compiled_model
                 .as_ref()
                 .map(|model| collect_coverage(model, std::slice::from_ref(&trace)));
+            let property_kind = compiled_model
+                .as_ref()
+                .and_then(|model| {
+                    model
+                        .properties
+                        .iter()
+                        .find(|property| property.property_id == trace.property_id)
+                        .map(|property| property.kind)
+                })
+                .unwrap_or(crate::ir::PropertyKind::Invariant);
             let write_overlap = action_metadata
                 .as_ref()
                 .map(|(_, _, writes, _)| {
@@ -854,8 +864,8 @@ pub fn explain_source(request: &CheckRequest) -> Result<ExplainResponse, CheckEr
                     ExplainCandidateCause {
                         kind: "terminal_violation".to_string(),
                         message: format!(
-                            "property {} failed without a field diff at terminal step",
-                            trace.property_id
+                            "{} property {} reached its terminal condition without a field diff",
+                            property_kind, trace.property_id
                         ),
                     },
                     ExplainCandidateCause {
@@ -863,14 +873,37 @@ pub fn explain_source(request: &CheckRequest) -> Result<ExplainResponse, CheckEr
                         message: failure_step
                             .action_id
                             .as_ref()
-                            .map(|action| format!("{action} reached a violating state without a visible field delta"))
-                            .unwrap_or_else(|| "initial or terminal condition violated the property".to_string()),
+                            .map(|action| match property_kind {
+                                crate::ir::PropertyKind::Invariant => {
+                                    format!("{action} reached a violating state without a visible field delta")
+                                }
+                                crate::ir::PropertyKind::Reachability => {
+                                    format!("{action} reached the target state without a visible field delta")
+                                }
+                            })
+                            .unwrap_or_else(|| match property_kind {
+                                crate::ir::PropertyKind::Invariant => {
+                                    "initial or terminal condition violated the property".to_string()
+                                }
+                                crate::ir::PropertyKind::Reachability => {
+                                    "initial or terminal condition satisfied the reachability target".to_string()
+                                }
+                            }),
                     },
                 ]
             } else {
                 let mut causes = Vec::new();
                 if let Some((action_id, reads, writes, decision_path)) = &action_metadata {
                     let path_tags = decision_path.legacy_path_tags();
+                    if property_kind == crate::ir::PropertyKind::Reachability {
+                        causes.push(ExplainCandidateCause {
+                            kind: "reachability_target".to_string(),
+                            message: format!(
+                                "action {action_id} reached the target state at step {}",
+                                failure_step.index
+                            ),
+                        });
+                    }
                     if !write_overlap.is_empty() {
                         causes.push(ExplainCandidateCause {
                             kind: "write_set_overlap".to_string(),
@@ -936,7 +969,10 @@ pub fn explain_source(request: &CheckRequest) -> Result<ExplainResponse, CheckEr
             };
             let mut repair_hints = vec![
                 "review the guard and update set of the failing action".to_string(),
-                format!("verify invariant {} is intended", trace.property_id),
+                format!(
+                    "verify {} property {} is intended",
+                    property_kind, trace.property_id
+                ),
             ];
             if let Some(action_id) = &failure_step.action_id {
                 repair_hints.push(format!(
@@ -1205,6 +1241,34 @@ pub fn testgen_source(request: &TestgenRequest) -> Result<TestgenResponse, Check
             .iter()
             .filter_map(|trace| build_counterexample_vector(trace).ok())
             .collect::<Vec<_>>()
+    } else if request.strategy == "witness" {
+        let trace_vectors = traces
+            .iter()
+            .filter_map(|trace| build_witness_vector(trace).ok())
+            .collect::<Vec<_>>();
+        if trace_vectors.is_empty() {
+            let mut vectors = build_model_test_vectors_for_strategy(
+                &model,
+                target_property_id,
+                &request.strategy,
+            )
+            .map_err(|message| CheckErrorEnvelope {
+                manifest: result.manifest.clone(),
+                status: crate::engine::ErrorStatus::Error,
+                assurance_level: crate::engine::AssuranceLevel::Incomplete,
+                diagnostics: vec![Diagnostic::new(
+                    crate::support::diagnostics::ErrorCode::SearchError,
+                    crate::support::diagnostics::DiagnosticSegment::EngineSearch,
+                    message,
+                )],
+            })?;
+            if vectors.is_empty() {
+                vectors = build_synthetic_witness_vectors(&model, target_property_id);
+            }
+            vectors
+        } else {
+            trace_vectors
+        }
     } else {
         let mut vectors =
             build_model_test_vectors_for_strategy(&model, target_property_id, &request.strategy)
@@ -2823,8 +2887,21 @@ mod tests {
             response.state_field_details[0].range.as_deref(),
             Some("0..=7")
         );
-        assert_eq!(response.property_details[0].kind, "Invariant");
+        assert_eq!(response.property_details[0].kind, "invariant");
         assert!(response.transition_details.is_empty());
+        validate_inspect_response(&response).unwrap();
+    }
+
+    #[test]
+    fn inspect_reports_reachability_kind() {
+        let source = "model A\nstate:\n  x: u8[0..7]\ninit:\n  x = 0\nproperty P_REACH:\n  reachability: x == 2\n";
+        let request = InspectRequest {
+            request_id: "req-inspect-reach".to_string(),
+            source_name: "a.valid".to_string(),
+            source: source.to_string(),
+        };
+        let response = inspect_source(&request).unwrap();
+        assert_eq!(response.property_details[0].kind, "reachability");
         validate_inspect_response(&response).unwrap();
     }
 
@@ -3004,6 +3081,30 @@ mod tests {
     }
 
     #[test]
+    fn explain_uses_reachability_specific_wording() {
+        let source = "model A\nstate:\n  x: u8[0..7]\ninit:\n  x = 0\naction Jump:\n  pre: true\n  post:\n    x = 2\nproperty P_REACH:\n  reachability: x == 2\n";
+        let request = CheckRequest {
+            request_id: "req-explain-reach".to_string(),
+            source_name: "a.valid".to_string(),
+            source: source.to_string(),
+            property_id: Some("P_REACH".to_string()),
+            backend: None,
+            solver_executable: None,
+            solver_args: vec![],
+        };
+        let response = explain_source(&request).unwrap();
+        assert!(response
+            .repair_hints
+            .iter()
+            .any(|hint| hint.contains("verify reachability property P_REACH is intended")));
+        assert!(response
+            .candidate_causes
+            .iter()
+            .any(|cause| cause.message.contains("target state")));
+        validate_explain_response(&response).unwrap();
+    }
+
+    #[test]
     fn minimize_returns_shorter_vector_when_failure_is_preserved() {
         let source = "model A\nstate:\n  x: u8[0..7]\ninit:\n  x = 0\naction Inc:\n  pre: true\n  post:\n    x = x + 1\naction Jump:\n  pre: true\n  post:\n    x = 2\nproperty P_SAFE:\n  invariant: x <= 1\n";
         let request = MinimizeRequest {
@@ -3057,6 +3158,26 @@ mod tests {
         })
         .unwrap();
         assert!(response.vector_ids.len() >= 1);
+        validate_testgen_response(&response).unwrap();
+        cleanup_generated_files(&response.generated_files);
+    }
+
+    #[test]
+    fn witness_testgen_uses_reachability_trace_when_available() {
+        let source = "model A\nstate:\n  x: u8[0..7]\ninit:\n  x = 0\naction Jump:\n  pre: true\n  post:\n    x = 2\nproperty P_REACH:\n  reachability: x == 2\n";
+        let response = testgen_source(&TestgenRequest {
+            request_id: "req-witness-reach".to_string(),
+            source_name: "a.valid".to_string(),
+            source: source.to_string(),
+            property_id: Some("P_REACH".to_string()),
+            strategy: "witness".to_string(),
+            backend: None,
+            solver_executable: None,
+            solver_args: vec![],
+        })
+        .unwrap();
+        assert_eq!(response.vector_ids.len(), 1);
+        assert_eq!(response.vectors[0].source_kind, "witness");
         validate_testgen_response(&response).unwrap();
         cleanup_generated_files(&response.generated_files);
     }

--- a/packages/valid/src/bundled_models.rs
+++ b/packages/valid/src/bundled_models.rs
@@ -561,7 +561,7 @@ fn build_inspect_response<M: crate::modeling::VerifiedMachine>(
         .into_iter()
         .map(|property| InspectProperty {
             property_id: property.property_id.to_string(),
-            kind: format!("{:?}", property.property_kind),
+            kind: property.property_kind.to_string(),
             expr: property.expr.map(str::to_string),
         })
         .collect::<Vec<_>>();

--- a/packages/valid/src/contract/mod.rs
+++ b/packages/valid/src/contract/mod.rs
@@ -241,9 +241,7 @@ fn field_type_label(field_type: &FieldType) -> String {
 }
 
 fn property_kind_label(kind: &PropertyKind) -> &'static str {
-    match kind {
-        PropertyKind::Invariant => "invariant",
-    }
+    kind.as_str()
 }
 
 fn extract_json_string(body: &str, key: &str) -> Option<String> {

--- a/packages/valid/src/engine/explicit.rs
+++ b/packages/valid/src/engine/explicit.rs
@@ -124,7 +124,7 @@ fn run_explicit(model: &ModelIr, plan: &RunPlan) -> Result<ExplicitRunResult, Di
         }
 
         let node = nodes[node_index].clone();
-        if !property_holds(model, &node.state, property)? {
+        if property_triggered(model, &node.state, property)? {
             return Ok(fail_result(model, plan, property, &nodes, node_index));
         }
 
@@ -166,7 +166,7 @@ fn run_explicit(model: &ModelIr, plan: &RunPlan) -> Result<ExplicitRunResult, Di
             }
         }
 
-        if plan.detect_deadlocks && enabled == 0 {
+        if plan.detect_deadlocks && enabled == 0 && property.kind == PropertyKind::Invariant {
             return Ok(deadlock_result(model, plan, property, &nodes, node_index));
         }
     }
@@ -183,22 +183,14 @@ fn run_explicit(model: &ModelIr, plan: &RunPlan) -> Result<ExplicitRunResult, Di
         assurance_level: assurance,
         property_result: PropertyResult {
             property_id: property.property_id.clone(),
-            property_kind: property.kind.clone(),
+            property_kind: property.kind,
             status: RunStatus::Pass,
             assurance_level: assurance,
-            reason_code: Some(if assurance == AssuranceLevel::Bounded {
-                "BOUNDED_SPACE_EXHAUSTED".to_string()
-            } else {
-                "COMPLETE_SPACE_EXHAUSTED".to_string()
-            }),
+            reason_code: Some(pass_reason_code(property.kind, assurance).to_string()),
             unknown_reason: None,
             terminal_state_id: None,
             evidence_id: None,
-            summary: if assurance == AssuranceLevel::Bounded {
-                "no violating state found within the configured depth bound".to_string()
-            } else {
-                "no violating state found in the reachable state space".to_string()
-            },
+            summary: pass_summary(property, assurance),
         },
         explored_states: visited.len(),
         explored_transitions,
@@ -229,24 +221,34 @@ fn selected_property<'a>(model: &'a ModelIr, plan: &RunPlan) -> Result<&'a Prope
         })
 }
 
-fn property_holds(
+fn property_triggered(
     model: &ModelIr,
     state: &MachineState,
     property: &PropertyIr,
 ) -> Result<bool, Diagnostic> {
-    match property.kind {
-        PropertyKind::Invariant => match eval_expr(model, state, &property.expr)? {
-            Value::Bool(value) => Ok(value),
-            _ => Err(Diagnostic::new(
-                ErrorCode::EvalError,
-                DiagnosticSegment::EngineSearch,
-                format!(
-                    "property `{}` did not evaluate to bool",
-                    property.property_id
-                ),
-            )
-            .with_help("keep invariant properties boolean after lowering")),
-        },
+    let value = property_value(model, state, property)?;
+    Ok(match property.kind {
+        PropertyKind::Invariant => !value,
+        PropertyKind::Reachability => value,
+    })
+}
+
+fn property_value(
+    model: &ModelIr,
+    state: &MachineState,
+    property: &PropertyIr,
+) -> Result<bool, Diagnostic> {
+    match eval_expr(model, state, &property.expr)? {
+        Value::Bool(value) => Ok(value),
+        _ => Err(Diagnostic::new(
+            ErrorCode::EvalError,
+            DiagnosticSegment::EngineSearch,
+            format!(
+                "property `{}` did not evaluate to bool",
+                property.property_id
+            ),
+        )
+        .with_help("keep lowered properties boolean regardless of property kind")),
     }
 }
 
@@ -269,17 +271,14 @@ fn fail_result(
         assurance_level: assurance,
         property_result: PropertyResult {
             property_id: property.property_id.clone(),
-            property_kind: property.kind.clone(),
+            property_kind: property.kind,
             status: RunStatus::Fail,
             assurance_level: assurance,
-            reason_code: Some("PROPERTY_FAILED".to_string()),
+            reason_code: Some(fail_reason_code(property.kind).to_string()),
             unknown_reason: None,
             terminal_state_id: Some(format!("s-{failing_index:06}")),
             evidence_id: Some(evidence_id.clone()),
-            summary: format!(
-                "property `{}` failed during explicit exploration",
-                property.property_id
-            ),
+            summary: fail_summary(property),
         },
         explored_states: nodes.len(),
         explored_transitions: nodes.len().saturating_sub(1),
@@ -288,9 +287,10 @@ fn fail_result(
             &evidence_id,
             &plan.manifest.run_id,
             &property.property_id,
+            property_evidence_kind(property.kind),
             nodes,
             failing_index,
-            None,
+            Some(fail_note(property.kind).to_string()),
             assurance,
         )),
     }
@@ -315,7 +315,7 @@ fn deadlock_result(
         assurance_level: assurance,
         property_result: PropertyResult {
             property_id: property.property_id.clone(),
-            property_kind: property.kind.clone(),
+            property_kind: property.kind,
             status: RunStatus::Fail,
             assurance_level: assurance,
             reason_code: Some("DEADLOCK_REACHED".to_string()),
@@ -331,6 +331,7 @@ fn deadlock_result(
             &evidence_id,
             &plan.manifest.run_id,
             &property.property_id,
+            EvidenceKind::Trace,
             nodes,
             deadlock_index,
             Some("deadlock detected".to_string()),
@@ -347,15 +348,20 @@ fn unknown_result(
     reason: UnknownReason,
 ) -> ExplicitRunResult {
     let last_index = nodes.len().saturating_sub(1);
+    let property = selected_property(model, plan).ok();
     ExplicitRunResult {
         manifest: plan.manifest.clone(),
         status: RunStatus::Unknown,
         assurance_level: AssuranceLevel::Incomplete,
         property_result: PropertyResult {
-            property_id: selected_property(model, plan)
-                .map(|p| p.property_id.clone())
-                .unwrap_or_else(|_| "unknown".to_string()),
-            property_kind: PropertyKind::Invariant,
+            property_id: property
+                .as_ref()
+                .map(|property| property.property_id.clone())
+                .unwrap_or_else(|| "unknown".to_string()),
+            property_kind: property
+                .as_ref()
+                .map(|property| property.kind)
+                .unwrap_or(PropertyKind::Invariant),
             status: RunStatus::Unknown,
             assurance_level: AssuranceLevel::Incomplete,
             reason_code: None,
@@ -373,9 +379,11 @@ fn unknown_result(
             model,
             &format!("dbg-{}", plan.manifest.run_id),
             &plan.manifest.run_id,
-            &selected_property(model, plan)
-                .map(|p| p.property_id.clone())
-                .unwrap_or_else(|_| "unknown".to_string()),
+            property
+                .as_ref()
+                .map(|property| property.property_id.as_str())
+                .unwrap_or("unknown"),
+            EvidenceKind::Trace,
             nodes,
             last_index,
             Some(format!("search stopped: {}", unknown_reason_label(reason))),
@@ -422,6 +430,7 @@ fn build_trace(
     evidence_id: &str,
     run_id: &str,
     property_id: &str,
+    evidence_kind: EvidenceKind,
     nodes: &[NodeRecord],
     end_index: usize,
     final_note: Option<String>,
@@ -465,10 +474,70 @@ fn build_trace(
         evidence_id: evidence_id.to_string(),
         run_id: run_id.to_string(),
         property_id: property_id.to_string(),
-        evidence_kind: EvidenceKind::Trace,
+        evidence_kind,
         assurance_level,
         trace_hash: format!("trace:{}:{}", evidence_id, steps.len()),
         steps,
+    }
+}
+
+fn property_evidence_kind(kind: PropertyKind) -> EvidenceKind {
+    match kind {
+        PropertyKind::Invariant => EvidenceKind::Counterexample,
+        PropertyKind::Reachability => EvidenceKind::Witness,
+    }
+}
+
+fn fail_reason_code(kind: PropertyKind) -> &'static str {
+    match kind {
+        PropertyKind::Invariant => "PROPERTY_FAILED",
+        PropertyKind::Reachability => "TARGET_REACHED",
+    }
+}
+
+fn pass_reason_code(kind: PropertyKind, assurance: AssuranceLevel) -> &'static str {
+    match (kind, assurance) {
+        (PropertyKind::Invariant, AssuranceLevel::Bounded) => "BOUNDED_SPACE_EXHAUSTED",
+        (PropertyKind::Invariant, _) => "COMPLETE_SPACE_EXHAUSTED",
+        (PropertyKind::Reachability, AssuranceLevel::Bounded) => "TARGET_NOT_REACHED_WITHIN_BOUND",
+        (PropertyKind::Reachability, _) => "TARGET_UNREACHABLE",
+    }
+}
+
+fn fail_summary(property: &PropertyIr) -> String {
+    match property.kind {
+        PropertyKind::Invariant => format!(
+            "property `{}` failed during explicit exploration",
+            property.property_id
+        ),
+        PropertyKind::Reachability => format!(
+            "reachability target for `{}` was reached during explicit exploration",
+            property.property_id
+        ),
+    }
+}
+
+fn pass_summary(property: &PropertyIr, assurance: AssuranceLevel) -> String {
+    match (property.kind, assurance) {
+        (PropertyKind::Invariant, AssuranceLevel::Bounded) => {
+            "no violating state found within the configured depth bound".to_string()
+        }
+        (PropertyKind::Invariant, _) => {
+            "no violating state found in the reachable state space".to_string()
+        }
+        (PropertyKind::Reachability, AssuranceLevel::Bounded) => {
+            "reachability target was not reached within the configured depth bound".to_string()
+        }
+        (PropertyKind::Reachability, _) => {
+            "reachability target was not found in the reachable state space".to_string()
+        }
+    }
+}
+
+fn fail_note(kind: PropertyKind) -> &'static str {
+    match kind {
+        PropertyKind::Invariant => "property violated",
+        PropertyKind::Reachability => "reachability target reached",
     }
 }
 
@@ -479,6 +548,7 @@ mod tests {
             check_explicit, AssuranceLevel, CheckOutcome, PropertySelection, ResourceLimits,
             RunPlan, RunStatus, SearchBounds, SearchStrategy, UnknownReason,
         },
+        evidence::EvidenceKind,
         ir::{
             ActionIr, BinaryOp, ExprIr, FieldType, InitAssignment, ModelIr, PropertyIr,
             PropertyKind, SourceSpan, StateField, UpdateIr, Value,
@@ -548,6 +618,27 @@ mod tests {
     fn default_plan() -> RunPlan {
         RunPlan {
             property_selection: PropertySelection::ExactlyOne("SAFE".to_string()),
+            ..RunPlan::default()
+        }
+    }
+
+    fn reachability_model(target: u64) -> ModelIr {
+        let mut model = counter_model();
+        model.properties = vec![PropertyIr {
+            property_id: "REACH".to_string(),
+            kind: PropertyKind::Reachability,
+            expr: ExprIr::Binary {
+                op: BinaryOp::Equal,
+                left: Box::new(ExprIr::FieldRef("x".to_string())),
+                right: Box::new(ExprIr::Literal(Value::UInt(target))),
+            },
+        }];
+        model
+    }
+
+    fn reachability_plan() -> RunPlan {
+        RunPlan {
+            property_selection: PropertySelection::ExactlyOne("REACH".to_string()),
             ..RunPlan::default()
         }
     }
@@ -629,6 +720,40 @@ mod tests {
             result.property_result.unknown_reason,
             Some(UnknownReason::TimeLimitReached)
         );
+    }
+
+    #[test]
+    fn reachability_returns_witness_when_target_is_reachable() {
+        let model = reachability_model(2);
+        let outcome = check_explicit(&model, &reachability_plan());
+        let CheckOutcome::Completed(result) = outcome else {
+            panic!("expected completed")
+        };
+        assert_eq!(result.status, RunStatus::Fail);
+        assert_eq!(
+            result.property_result.reason_code.as_deref(),
+            Some("TARGET_REACHED")
+        );
+        let trace = result.trace.expect("reachability should emit a witness");
+        assert_eq!(trace.evidence_kind, EvidenceKind::Witness);
+        assert_eq!(trace.steps.len(), 1);
+        assert_eq!(trace.steps[0].action_id.as_deref(), Some("Jump"));
+    }
+
+    #[test]
+    fn reachability_returns_pass_when_target_is_unreachable() {
+        let model = reachability_model(4);
+        let outcome = check_explicit(&model, &reachability_plan());
+        let CheckOutcome::Completed(result) = outcome else {
+            panic!("expected completed")
+        };
+        assert_eq!(result.status, RunStatus::Pass);
+        assert_eq!(result.assurance_level, AssuranceLevel::Complete);
+        assert_eq!(
+            result.property_result.reason_code.as_deref(),
+            Some("TARGET_UNREACHABLE")
+        );
+        assert!(result.trace.is_none());
     }
 
     #[test]

--- a/packages/valid/src/evidence/mod.rs
+++ b/packages/valid/src/evidence/mod.rs
@@ -23,6 +23,8 @@ use crate::{
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum EvidenceKind {
     Trace,
+    Counterexample,
+    Witness,
     Certificate,
 }
 
@@ -716,9 +718,7 @@ fn error_status_label(status: ErrorStatus) -> &'static str {
     }
 }
 fn property_kind_label(kind: &crate::ir::PropertyKind) -> &'static str {
-    match kind {
-        crate::ir::PropertyKind::Invariant => "invariant",
-    }
+    kind.as_str()
 }
 fn assurance_label(level: AssuranceLevel) -> &'static str {
     match level {
@@ -745,6 +745,8 @@ fn backend_label(kind: crate::engine::BackendKind) -> &'static str {
 fn evidence_kind_label(kind: &EvidenceKind) -> &'static str {
     match kind {
         EvidenceKind::Trace => "trace",
+        EvidenceKind::Counterexample => "counterexample",
+        EvidenceKind::Witness => "witness",
         EvidenceKind::Certificate => "certificate",
     }
 }

--- a/packages/valid/src/frontend/ir_lowering.rs
+++ b/packages/valid/src/frontend/ir_lowering.rs
@@ -105,10 +105,17 @@ pub fn lower_model(typed: TypedModel) -> Result<ModelIr, Vec<Diagnostic>> {
 
     let mut properties = Vec::new();
     for property in &parsed.properties {
+        let Some(kind) = PropertyKind::parse(&property.kind) else {
+            errors.push(lowering_error(
+                format!("unsupported property kind `{}`", property.kind),
+                property.line,
+            ));
+            continue;
+        };
         match lower_expr(&property.expr) {
             Some(expr) => properties.push(PropertyIr {
                 property_id: property.name.clone(),
-                kind: PropertyKind::Invariant,
+                kind,
                 expr,
             }),
             None => errors.push(lowering_error(
@@ -571,5 +578,24 @@ property P_SAFE:
                 max: 500000
             }
         ));
+    }
+
+    #[test]
+    fn lowers_reachability_properties() {
+        let source = r#"
+model DoorControl
+state:
+  open: bool
+init:
+  open = false
+property P_OPEN:
+  reachability: open == true
+"#;
+
+        let model = compile_model(source).expect("compile");
+        assert_eq!(
+            model.properties[0].kind,
+            crate::ir::PropertyKind::Reachability
+        );
     }
 }

--- a/packages/valid/src/frontend/typecheck.rs
+++ b/packages/valid/src/frontend/typecheck.rs
@@ -59,7 +59,7 @@ pub fn typecheck_model(resolved: ResolvedModel) -> Result<TypedModel, Vec<Diagno
     }
 
     for property in &resolved.parsed.properties {
-        if property.kind != "invariant" {
+        if crate::ir::PropertyKind::parse(&property.kind).is_none() {
             errors.push(type_error(
                 format!("unsupported property kind `{}`", property.kind),
                 property.line,
@@ -152,5 +152,21 @@ property P_SAFE:
         let parsed = parse_model(source).expect("parse");
         let resolved = resolve_model(parsed).expect("resolve");
         typecheck_model(resolved).expect("u32 fields should typecheck");
+    }
+
+    #[test]
+    fn accepts_reachability_properties() {
+        let source = r#"
+model DoorControl
+state:
+  open: bool
+init:
+  open = false
+property P_OPEN:
+  reachability: open == true
+"#;
+        let parsed = parse_model(source).expect("parse");
+        let resolved = resolve_model(parsed).expect("resolve");
+        typecheck_model(resolved).expect("reachability properties should typecheck");
     }
 }

--- a/packages/valid/src/ir/property.rs
+++ b/packages/valid/src/ir/property.rs
@@ -1,4 +1,5 @@
 use crate::ir::expr::ExprIr;
+use std::fmt;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PropertyIr {
@@ -7,7 +8,31 @@ pub struct PropertyIr {
     pub expr: ExprIr,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PropertyKind {
     Invariant,
+    Reachability,
+}
+
+impl PropertyKind {
+    pub fn parse(input: &str) -> Option<Self> {
+        match input {
+            "invariant" => Some(Self::Invariant),
+            "reachability" => Some(Self::Reachability),
+            _ => None,
+        }
+    }
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Invariant => "invariant",
+            Self::Reachability => "reachability",
+        }
+    }
+}
+
+impl fmt::Display for PropertyKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
 }

--- a/packages/valid/src/modeling/mod.rs
+++ b/packages/valid/src/modeling/mod.rs
@@ -2223,9 +2223,13 @@ pub fn explain_machine<M: VerifiedMachine>(request_id: &str) -> Result<ExplainRe
             });
         }
     }
+    let property_kind = find_property::<M>(&trace.property_id).property_kind;
     let mut repair_hints = vec![
         "review the action semantics that lead into the violating state".to_string(),
-        format!("verify invariant {} is intended", trace.property_id),
+        format!(
+            "verify {} property {} is intended",
+            property_kind, trace.property_id
+        ),
     ];
     if !write_overlap_fields.is_empty() {
         repair_hints.push(format!(

--- a/packages/valid/src/registry.rs
+++ b/packages/valid/src/registry.rs
@@ -714,7 +714,7 @@ fn inspect_machine<M: VerifiedMachine>(request_id: &str) -> InspectResponse {
         .into_iter()
         .map(|property| InspectProperty {
             property_id: property.property_id.to_string(),
-            kind: format!("{:?}", property.property_kind),
+            kind: property.property_kind.to_string(),
             expr: property.expr.map(str::to_string),
         })
         .collect::<Vec<_>>();

--- a/packages/valid/src/reporter/mod.rs
+++ b/packages/valid/src/reporter/mod.rs
@@ -923,7 +923,7 @@ mod tests {
             }],
             property_details: vec![InspectProperty {
                 property_id: "P_RANGE".to_string(),
-                kind: "Invariant".to_string(),
+                kind: "invariant".to_string(),
                 expr: None,
             }],
         };
@@ -976,7 +976,7 @@ mod tests {
             }],
             property_details: vec![InspectProperty {
                 property_id: "P_RANGE".to_string(),
-                kind: "Invariant".to_string(),
+                kind: "invariant".to_string(),
                 expr: None,
             }],
         };
@@ -1029,7 +1029,7 @@ mod tests {
             }],
             property_details: vec![InspectProperty {
                 property_id: "P_RANGE".to_string(),
-                kind: "Invariant".to_string(),
+                kind: "invariant".to_string(),
                 expr: None,
             }],
         };
@@ -1099,7 +1099,7 @@ mod tests {
             }],
             property_details: vec![InspectProperty {
                 property_id: "P_RANGE".to_string(),
-                kind: "Invariant".to_string(),
+                kind: "invariant".to_string(),
                 expr: None,
             }],
         };

--- a/packages/valid/src/solver/mod.rs
+++ b/packages/valid/src/solver/mod.rs
@@ -228,7 +228,7 @@ impl SolverAdapter for ExplicitAdapter {
             supports_bmc: false,
             supports_certificate: false,
             supports_trace: true,
-            supports_witness: false,
+            supports_witness: true,
             selfcheck_compatible: true,
         }
     }
@@ -764,7 +764,7 @@ fn normalize_protocol_result(
             evidence_id: format!("ev-{}", run_plan.manifest.run_id),
             run_id: run_plan.manifest.run_id.clone(),
             property_id: property_id.clone(),
-            evidence_kind: EvidenceKind::Trace,
+            evidence_kind: protocol_trace_kind(property_kind, protocol.status.as_str()),
             assurance_level,
             trace_hash: stable_hash_hex(&protocol.actions.join("\u{1f}")),
             steps: vec![TraceStep {
@@ -903,6 +903,14 @@ fn normalize_protocol_result(
     };
 
     Ok(NormalizedRunResult { outcome, trace })
+}
+
+fn protocol_trace_kind(property_kind: crate::ir::PropertyKind, status: &str) -> EvidenceKind {
+    match (property_kind, status) {
+        (crate::ir::PropertyKind::Invariant, "FAIL") => EvidenceKind::Counterexample,
+        (crate::ir::PropertyKind::Reachability, "FAIL") => EvidenceKind::Witness,
+        _ => EvidenceKind::Trace,
+    }
 }
 
 fn rebase_normalized_outcome(

--- a/packages/valid/src/solver/smt.rs
+++ b/packages/valid/src/solver/smt.rs
@@ -101,7 +101,7 @@ pub fn build_invariant_bmc_query(
     if property.kind != PropertyKind::Invariant {
         return Err(format!(
             "SMT adapter only supports invariant properties, got `{}`",
-            property.property_id
+            property.kind
         ));
     }
 

--- a/packages/valid/src/solver/varisat.rs
+++ b/packages/valid/src/solver/varisat.rs
@@ -872,7 +872,10 @@ fn validate_varisat_model(model: &ModelIr, target_property_ids: &[String]) -> Re
         .find(|property| &property.property_id == property_id)
         .ok_or_else(|| format!("unknown property `{property_id}`"))?;
     if property.kind != PropertyKind::Invariant {
-        return Err("backend=sat-varisat currently supports invariant properties only".to_string());
+        return Err(format!(
+            "backend=sat-varisat currently supports invariant properties only, got `{}`",
+            property.kind
+        ));
     }
     for field in &model.state_fields {
         if !matches!(

--- a/packages/valid/src/testgen/mod.rs
+++ b/packages/valid/src/testgen/mod.rs
@@ -3,7 +3,7 @@
 use std::collections::{BTreeMap, BTreeSet, HashSet, VecDeque};
 
 use crate::{
-    evidence::EvidenceTrace,
+    evidence::{EvidenceKind, EvidenceTrace},
     ir::{DecisionKind, DecisionOutcome, ModelIr, Path, PropertyKind, Value},
     kernel::{
         eval::eval_expr,
@@ -78,6 +78,13 @@ pub fn build_counterexample_vector(trace: &EvidenceTrace) -> Result<TestVector, 
     if trace.steps.is_empty() {
         return Err("cannot build a counterexample vector from an empty trace".to_string());
     }
+    if trace.evidence_kind == EvidenceKind::Witness {
+        return Err("cannot build a counterexample vector from a witness trace".to_string());
+    }
+    build_base_vector_from_trace(trace)
+}
+
+fn build_base_vector_from_trace(trace: &EvidenceTrace) -> Result<TestVector, String> {
     let actions = trace
         .steps
         .iter()
@@ -162,7 +169,10 @@ pub fn build_witness_vector(trace: &EvidenceTrace) -> Result<TestVector, String>
     if trace.steps.is_empty() {
         return Err("cannot build a witness vector from an empty trace".to_string());
     }
-    let mut vector = build_counterexample_vector(trace)?;
+    if trace.evidence_kind == EvidenceKind::Counterexample {
+        return Err("cannot build a witness vector from a counterexample trace".to_string());
+    }
+    let mut vector = build_base_vector_from_trace(trace)?;
     vector.source_kind = "witness".to_string();
     vector.strictness = "strict".to_string();
     vector.derivation = "witness_trace".to_string();
@@ -173,6 +183,13 @@ pub fn build_witness_vector(trace: &EvidenceTrace) -> Result<TestVector, String>
 }
 
 pub fn build_synthetic_witness_vectors(model: &ModelIr, property_id: &str) -> Vec<TestVector> {
+    let Some(property) = model
+        .properties
+        .iter()
+        .find(|property| property.property_id == property_id)
+    else {
+        return Vec::new();
+    };
     let initial = match build_initial_state(model) {
         Ok(state) => state,
         Err(_) => return Vec::new(),
@@ -187,6 +204,9 @@ pub fn build_synthetic_witness_vectors(model: &ModelIr, property_id: &str) -> Ve
         else {
             continue;
         };
+        if !state_satisfies_property(model, property, &first_state) {
+            continue;
+        }
 
         let single = synthetic_trace_from_states(
             model,
@@ -223,6 +243,9 @@ pub fn build_synthetic_witness_vectors(model: &ModelIr, property_id: &str) -> Ve
             else {
                 continue;
             };
+            if !state_satisfies_property(model, property, &second_state) {
+                continue;
+            }
             let Some(trace) = synthetic_trace_from_states(
                 model,
                 property_id,
@@ -365,11 +388,22 @@ fn synthetic_trace_from_states(
         ),
         run_id: format!("run-witness-{}", action_signature.replace("->", "-")),
         property_id: property_id.to_string(),
-        evidence_kind: crate::evidence::EvidenceKind::Trace,
+        evidence_kind: crate::evidence::EvidenceKind::Witness,
         assurance_level: crate::engine::AssuranceLevel::Complete,
         trace_hash: format!("trace:witness:{action_signature}"),
         steps,
     })
+}
+
+fn state_satisfies_property(
+    model: &ModelIr,
+    property: &crate::ir::PropertyIr,
+    state: &MachineState,
+) -> bool {
+    matches!(
+        eval_expr(model, state, &property.expr),
+        Ok(Value::Bool(true))
+    )
 }
 
 pub fn minimize_counterexample_vector(
@@ -1345,7 +1379,7 @@ mod tests {
             evidence_id: format!("ev-{}", actions.join("-")),
             run_id: "run-1".to_string(),
             property_id: "SAFE".to_string(),
-            evidence_kind: EvidenceKind::Trace,
+            evidence_kind: EvidenceKind::Witness,
             assurance_level: AssuranceLevel::Complete,
             trace_hash: "sha256:trace".to_string(),
             steps,
@@ -1415,7 +1449,7 @@ mod tests {
             evidence_id: "ev-000001".to_string(),
             run_id: "run-1".to_string(),
             property_id: "P_SAFE".to_string(),
-            evidence_kind: EvidenceKind::Trace,
+            evidence_kind: EvidenceKind::Counterexample,
             assurance_level: AssuranceLevel::Complete,
             trace_hash: "sha256:x".to_string(),
             steps: vec![TraceStep {
@@ -1452,9 +1486,11 @@ mod tests {
     #[test]
     fn builds_synthetic_witness_vectors_from_model() {
         let vectors = build_synthetic_witness_vectors(&minimization_model(), "SAFE");
-        assert_eq!(vectors.len(), 6);
+        assert_eq!(vectors.len(), 1);
         assert!(vectors.iter().all(|vector| vector.source_kind == "witness"));
-        assert!(vectors.iter().any(|vector| vector.actions.len() == 2));
+        assert!(vectors
+            .iter()
+            .all(|vector| vector.expected_property_holds == Some(true)));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add `PropertyKind::Reachability` to the IR/frontend pipeline and surface it through inspect/reporting
- teach the explicit engine, evidence, explain, and test generation flows to treat reachability as target search with witness traces
- keep solver adapters explicit about witness vs counterexample evidence and reject unsupported reachability in invariant-only backends

## Testing
- cargo test -q -p valid

Closes #1