### PR TITLE
Document A3 decision for valid_model! frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -634,7 +634,8 @@ tracked reference set.
 - `packages/valid/src/`
   engine, DSL, lowering, solver adapters, and CLI implementation
 - `packages/valid_derive/`
-  proc-macro crate for DSL derives and function-like macro validation
+  proc-macro crate for DSL derives; `valid_model!` itself currently expands via
+  `macro_rules!` in `packages/valid/src/modeling/mod.rs`
 
 ## Recommended Workflow
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,9 @@
   Current implemented surface and semantic subset for the Rust DSL.
 - [DSL Language Evolution](./dsl/language-evolution.md)
   Design notes for proposed and in-flight language features.
+- [ADR-0001: `valid_model!` Frontend Decision](./adr/0001-valid-model-frontend.md)
+  Decision record for keeping `valid_model!` on the `macro_rules!` track unless
+  A1 fails to recover `rust-analyzer` compatibility.
 - [RDD](./rdd/README.md)
   Requirements, architecture, planning, and delivery documents for the project
   itself.

--- a/docs/adr/0001-valid-model-frontend.md
+++ b/docs/adr/0001-valid-model-frontend.md
@@ -1,0 +1,66 @@
+# ADR-0001: `valid_model!` Frontend Decision
+
+- Status: Accepted
+- Date: 2026-03-07
+- Related issues: `#4` (A1), `#15` (A3)
+
+## Context
+
+`valid_model!` is currently implemented as `macro_rules!` in
+`packages/valid/src/modeling/mod.rs`.
+
+Issue `#4` defines the acceptance criteria for keeping that direction:
+
+- reduce the macro to 5 arms or fewer
+- eliminate self-recursion
+- eliminate nested optional repetition
+- restore `rust-analyzer` compatibility for normal authoring flows
+
+As of this ADR, those criteria are not yet met. The current macro still carries
+syntax-normalization arms, recursive rewrites, and compatibility branches for
+multiple surface forms. That means A1 has not produced the evidence needed to
+declare the `macro_rules!` frontend successful.
+
+At the same time, `packages/valid_derive` already uses handwritten
+`proc_macro::TokenTree` parsing for derive macros and does not currently depend
+on `syn` or `quote`. Reverting `valid_model!` to a function-like proc-macro is
+therefore technically feasible, but it would reintroduce a second frontend
+implementation while A1 is still unresolved.
+
+## Decision
+
+We do not restore `valid_model!` to a function-like proc-macro now.
+
+Instead:
+
+1. `valid_model!` stays on the `macro_rules!` track while A1 remains active.
+2. A3 is resolved as a fallback decision, not an immediate implementation task.
+3. If A1 fails to satisfy its acceptance criteria, we will restore a
+   function-like proc-macro frontend in `packages/valid_derive`.
+4. If that fallback is triggered, we will prefer the existing lightweight
+   `TokenTree` parsing style first and add `syn` / `quote` only if handwritten
+   parsing becomes the maintenance bottleneck.
+
+## Rationale
+
+- Shipping the proc-macro rollback before A1 concludes would abandon the
+  grammar-simplification path without measuring it.
+- Keeping the current implementation avoids extra dependency churn and preserves
+  current build characteristics.
+- Recording the fallback explicitly removes ambiguity: if `rust-analyzer`
+  compatibility cannot be recovered with a simplified `macro_rules!` surface,
+  the project should prefer authoring correctness and recoverable diagnostics
+  over macro purity.
+- The existing derive proc-macro crate lowers the implementation risk of the
+  fallback because the repository already has a proc-macro boundary and a
+  custom parser style.
+
+## Consequences
+
+- No immediate code migration from `macro_rules!` to proc-macro is performed by
+  this ADR.
+- Documentation must describe `valid_model!` as a `macro_rules!` frontend today,
+  not as an already-restored proc-macro.
+- The next concrete implementation step remains A1: simplify the grammar until
+  either the acceptance criteria pass or failure is clear enough to trigger the
+  proc-macro fallback.

--- a/docs/dsl/README.md
+++ b/docs/dsl/README.md
@@ -10,6 +10,7 @@ Related documents:
 
 - [Current Language Spec](./language-spec.md)
 - [Language Evolution Notes](./language-evolution.md)
+- [ADR-0001: `valid_model!` Frontend Decision](../adr/0001-valid-model-frontend.md)
 
 ## What the DSL is
 
@@ -27,7 +28,7 @@ That means:
 
 - Rust registry authoring requires a Rust toolchain
 - the DSL is designed to feel natural in `rust-analyzer`
-- procedural-macro diagnostics and `cargo valid readiness` are part of the
+- macro/derive diagnostics and `cargo valid readiness` are part of the
   authoring experience, not just the runtime experience
 
 ## Canonical Modeling Path
@@ -186,8 +187,10 @@ Current guidance for a smoother IDE experience:
   ambiguous
 - keep examples and registries small enough that transition intent is obvious
 
-`valid_model!` uses a procedural-macro front-end specifically to improve
-diagnostics and keep parser errors closer to the DSL surface.
+`valid_model!` is currently implemented as a `macro_rules!` frontend. The
+active plan is to simplify that grammar for better `rust-analyzer`
+compatibility; if A1 cannot meet its acceptance criteria, the fallback is to
+restore a function-like proc-macro frontend as described in ADR-0001.
 
 ## Model Definition
 


### PR DESCRIPTION
## Summary
- add ADR-0001 to record the A3 decision for `valid_model!`
- state that `valid_model!` remains on the `macro_rules!` track until A1 proves insufficient
- align README and DSL docs with the current implementation

## Testing
- cargo test -q --test ui_macro_diagnostics
- cargo test -q

Closes #15

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README with clarification on macro expansion mechanism and location.
  * Added new Architecture Decision Record (ADR-0001) documenting frontend implementation decisions.
  * Enhanced DSL documentation with updated references and implementation details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->