### PR TITLE
DSL: support `..state` in declarative transition updates

### DIFF
--- a/docs/dsl/README.md
+++ b/docs/dsl/README.md
@@ -259,13 +259,27 @@ transitions {
         [tags = ["allow_path", "approval_path"]]
         when |state| state.approved == false
         => [ReviewState {
-            score: state.score,
-            waiver: state.waiver,
             approved: true,
+            ..state
         }];
     }
 }
 ```
+
+When a transition only changes a subset of fields, prefer explicit frame
+condition sugar:
+
+```rust
+=> [ReviewState {
+    approved: true,
+    ..state
+}];
+```
+
+`..state` keeps omitted fields from the current state. Only explicitly listed
+fields are recorded as transition updates in the transition metadata and
+machine IR. There is no implicit carry-forward of omitted fields; write
+`..state` when you want that behavior.
 
 Each transition carries:
 

--- a/docs/dsl/language-evolution.md
+++ b/docs/dsl/language-evolution.md
@@ -80,7 +80,86 @@ on Inc {
 - text abstraction
   - raw string theoryではなく、policy/password向けの bounded abstraction
 
-## 検討中 5: logic sugar
+## 検討中 5: transition updates sugar (`..state`)
+
+### 背景
+
+declarative `transitions` は canonical path ですが、更新対象が少ない遷移でも
+現状は state literal を全面的に書き下ろす必要がありました。
+
+```rust
+on Approve {
+    when |state| !state.approved
+    => [ReviewState {
+        score: state.score,
+        waiver: state.waiver,
+        approved: true,
+    }];
+}
+```
+
+これは:
+
+- frame condition が冗長になる
+- `String` など非 `Copy` field の保持が書きづらい
+- arbitrary expr list に逃げると transition metadata が薄くなる
+
+という問題を持ちます。
+
+### 決定
+
+declarative transition 内の state literal に、明示的な frame condition sugar として
+`..state` を導入します。
+
+```rust
+on Approve {
+    when |state| !state.approved
+    => [ReviewState {
+        approved: true,
+        ..state
+    }];
+}
+```
+
+意味は次の通りです。
+
+- 明示した field だけが update
+- `..state` が未指定 field の保持を表す
+- implicit retention はしない
+
+つまり、未変更 field を残したいときは必ず `..state` を書きます。
+
+### lowering / IR 方針
+
+- generated `step` では `State { approved: true, ..state.clone() }` 相当に展開する
+- `TransitionUpdateDescriptor` / machine IR updates には明示 field だけを残す
+- `effect` 文字列は source-level の `..state` 形を保持する
+- `reads` / `writes` は従来どおり action metadata を一次ソースとする
+
+これにより core IR は flat guarded transition のまま保てます。
+
+### `macro_rules!` 制約との整合
+
+今回の採用構文は `macro_rules!` で扱える範囲に限定します。
+
+- 許可: `..state` のような identifier-based struct update
+- 非採用: `..state.clone()` のような arbitrary expression
+
+後者を許すと、opaque expr path に落ちて transition metadata を失いやすいためです。
+
+### 後方互換性
+
+- 既存の `field: expr` を並べる完全な state literal はそのまま使える
+- `=> [expr, ...];` の generic form もそのまま使える
+- 新しい sugar は declarative transition literal の ergonomic improvement に留める
+
+### non-goals
+
+- implicit frame condition inference
+- nested spread / multiple spread
+- write-set の自動推論変更
+
+## 検討中 6: logic sugar
 
 今後の候補:
 
@@ -92,7 +171,7 @@ on Inc {
 
 ただし core IR は小さく保つ方針です。
 
-## 検討中 6: text / regex story
+## 検討中 7: text / regex story
 
 現在の text support は explicit-first です。
 
@@ -118,7 +197,7 @@ on Inc {
 
 これは backend-neutral にしやすい可能性があります。
 
-## 検討中 7: step の位置づけ
+## 検討中 8: step の位置づけ
 
 `step` を完全に消す予定はありませんが、位置づけはかなり明確です。
 
@@ -131,7 +210,7 @@ on Inc {
   - solver-visible
   - graph/coverage/testgen/explain の正規入力
 
-## 検討中 8: IDE / diagnostics
+## 検討中 9: IDE / diagnostics
 
 今後強めたいもの:
 
@@ -140,7 +219,7 @@ on Inc {
 - rust-analyzer での誤診断低減
 - `cargo valid readiness` / `cargo valid migrate` の提案精度向上
 
-## 検討中 9: packaging
+## 検討中 10: packaging
 
 目標:
 

--- a/docs/dsl/language-spec.md
+++ b/docs/dsl/language-spec.md
@@ -105,7 +105,17 @@ transitions {
 }
 ```
 
-内部では flat な guarded transition IR に lower されます。
+未変更 field を明示的に保持したいときは、struct update 形式の `..state` を使えます。
+
+```rust
+=> [ReviewState {
+    approved: true,
+    ..state
+}];
+```
+
+この `..state` は frame condition sugar です。内部では flat な guarded
+transition IR に lower され、IR 上の update として残るのは明示 field だけです。
 
 ### 2. step
 

--- a/packages/valid/src/modeling/mod.rs
+++ b/packages/valid/src/modeling/mod.rs
@@ -1404,7 +1404,7 @@ macro_rules! valid_model {
                     $(
                         $( [ tags = [$($path_tag:literal),* $(,)?] ] )?
                         when |$guard_state:ident| $guard_expr:expr
-                        => [$state_ctor:ident { $($field:ident : $update_expr:expr),* $(,)? }];
+                        => [$($next_state:tt)+];
                     )+
                 }
             )+
@@ -1419,7 +1419,7 @@ macro_rules! valid_model {
             transitions {
                 $(
                     $(
-                        transition $group_action $( [ tags = [$($path_tag),*] ] )? when |$guard_state| $guard_expr => [$state_ctor { $($field: $update_expr),* }];
+                        transition $group_action $( [ tags = [$($path_tag),*] ] )? when |$guard_state| $guard_expr => [$($next_state)+];
                     )+
                 )+
             }
@@ -1432,40 +1432,7 @@ macro_rules! valid_model {
         model $model:ident<$state_ty:ty, $action_ty:ty>;
         init [$($init_state:expr),* $(,)?];
         transitions {
-            $(
-                on $group_action:ident {
-                    $(
-                        $( [ tags = [$($path_tag:literal),* $(,)?] ] )?
-                        when |$guard_state:ident| $guard_expr:expr
-                        => [$($next_state:expr),* $(,)?];
-                    )+
-                }
-            )+
-        }
-        properties {
-            $(invariant $property:ident |$holds_state:ident| $holds_expr:expr;)+
-        }
-    ) => {
-        $crate::valid_model! {
-            model $model<$state_ty, $action_ty>;
-            init [$($init_state),*];
-            transitions {
-                $(
-                    $(
-                        transition $group_action $( [ tags = [$($path_tag),*] ] )? when |$guard_state| $guard_expr => [$($next_state),*];
-                    )+
-                )+
-            }
-            properties {
-                $(invariant $property |$holds_state| $holds_expr;)+
-            }
-        }
-    };
-    (
-        model $model:ident<$state_ty:ty, $action_ty:ty>;
-        init [$($init_state:expr),* $(,)?];
-        transitions {
-            $(transition $transition_action:ident $( [ tags = [$($path_tag:literal),* $(,)?] ] )? when |$guard_state:ident| $guard_expr:expr => [$state_ctor:ident { $($field:ident : $update_expr:expr),* $(,)? }];)+
+            $(transition $transition_action:ident $( [ tags = [$($path_tag:literal),* $(,)?] ] )? when |$guard_state:ident| $guard_expr:expr => [$($next_state:tt)+];)+
         }
         properties {
             $(invariant $property:ident |$holds_state:ident| $holds_expr:expr;)+
@@ -1491,7 +1458,7 @@ macro_rules! valid_model {
                     if matches!(action, <$action_ty>::$transition_action) {
                         let $guard_state = state;
                         if $guard_expr {
-                            next_states.push($state_ctor { $($field: $update_expr),* });
+                            $crate::valid_model!(@transition_push next_states, [$($next_state)+]);
                         }
                     }
                 )+
@@ -1513,105 +1480,128 @@ macro_rules! valid_model {
             fn transitions() -> Vec<$crate::modeling::TransitionDescriptor> {
                 vec![
                     $(
-                        {
-                            let descriptor = $crate::modeling::action_descriptor_by_variant::<$action_ty>(
-                                stringify!($transition_action)
-                            );
-                            $crate::modeling::TransitionDescriptor {
-                                action_variant: descriptor.variant,
-                                action_id: descriptor.action_id,
-                                guard: stringify!($guard_expr),
-                                effect: stringify!($state_ctor { $($field: $update_expr),* }),
-                                reads: descriptor.reads,
-                                writes: descriptor.writes,
-                                path_tags: $crate::valid_model!(@path_tags $($($path_tag),*)?),
-                                updates: &[
-                                    $(
-                                        $crate::modeling::TransitionUpdateDescriptor {
-                                            field: stringify!($field),
-                                            expr: stringify!($update_expr),
-                                        }
-                                    ),*
-                                ],
-                            }
-                        }
+                        $crate::valid_model!(
+                            @transition_descriptor
+                            [$action_ty]
+                            $transition_action
+                            $( [ tags = [$($path_tag),*] ] )?
+                            |$guard_state| $guard_expr
+                            => [$($next_state)+]
+                        )
                     ),+
                 ]
             }
         }
+    };
+    (@transition_push $next_states:ident, [$state_ctor:ident { $($field:ident : $update_expr:expr,)* .. $rest_state:ident $(,)? }]) => {
+        $next_states.push($state_ctor {
+            $($field: $update_expr,)*
+            ..$rest_state.clone()
+        });
+    };
+    (@transition_push $next_states:ident, [$state_ctor:ident { $($field:ident : $update_expr:expr,)* .. $($unsupported_rest:tt)+ }]) => {
+        compile_error!(
+            "declarative transition struct updates support only `..state`-style identifiers; write `..state`, not an arbitrary expression"
+        );
+    };
+    (@transition_push $next_states:ident, [$state_ctor:ident { $($field:ident : $update_expr:expr),* $(,)? }]) => {
+        $next_states.push($state_ctor { $($field: $update_expr),* });
+    };
+    (@transition_push $next_states:ident, [$($next_state:expr),* $(,)?]) => {
+        $next_states.extend(vec![$($next_state),*]);
     };
     (
-        model $model:ident<$state_ty:ty, $action_ty:ty>;
-        init [$($init_state:expr),* $(,)?];
-        transitions {
-            $(transition $transition_action:ident $( [ tags = [$($path_tag:literal),* $(,)?] ] )? when |$guard_state:ident| $guard_expr:expr => [$($next_state:expr),* $(,)?];)+
-        }
-        properties {
-            $(invariant $property:ident |$holds_state:ident| $holds_expr:expr;)+
-        }
-    ) => {
-        struct $model;
-
-        impl $crate::modeling::ModelSpec for $model {
-            type State = $state_ty;
-            type Action = $action_ty;
-
-            fn model_id() -> &'static str {
-                stringify!($model)
-            }
-
-            fn init_states() -> Vec<Self::State> {
-                vec![$($init_state),*]
-            }
-
-            fn step(state: &Self::State, action: &Self::Action) -> Vec<Self::State> {
-                let mut next_states = Vec::new();
+        @transition_descriptor
+        [$action_ty:ty]
+        $transition_action:ident
+        $( [ tags = [$($path_tag:literal),* $(,)?] ] )?
+        |$guard_state:ident| $guard_expr:expr
+        => [$state_ctor:ident { $($field:ident : $update_expr:expr,)* .. $rest_state:ident $(,)? }]
+    ) => {{
+        let descriptor = $crate::modeling::action_descriptor_by_variant::<$action_ty>(
+            stringify!($transition_action)
+        );
+        $crate::modeling::TransitionDescriptor {
+            action_variant: descriptor.variant,
+            action_id: descriptor.action_id,
+            guard: stringify!($guard_expr),
+            effect: stringify!($state_ctor { $($field: $update_expr,)* ..$rest_state }),
+            reads: descriptor.reads,
+            writes: descriptor.writes,
+            path_tags: $crate::valid_model!(@path_tags $($($path_tag),*)?),
+            updates: &[
                 $(
-                    if matches!(action, <$action_ty>::$transition_action) {
-                        let $guard_state = state;
-                        if $guard_expr {
-                            next_states.extend(vec![$($next_state),*]);
-                        }
+                    $crate::modeling::TransitionUpdateDescriptor {
+                        field: stringify!($field),
+                        expr: stringify!($update_expr),
                     }
-                )+
-                next_states
-            }
-
-            fn properties() -> Vec<$crate::modeling::ModelProperty<Self::State>> {
-                vec![
-                    $(
-                        $crate::modeling::ModelProperty::invariant_expr(
-                            stringify!($property),
-                            Some(stringify!($holds_expr)),
-                            |$holds_state: &Self::State| $holds_expr,
-                        )
-                    ),+
-                ]
-            }
-
-            fn transitions() -> Vec<$crate::modeling::TransitionDescriptor> {
-                vec![
-                    $(
-                        {
-                            let descriptor = $crate::modeling::action_descriptor_by_variant::<$action_ty>(
-                                stringify!($transition_action)
-                            );
-                            $crate::modeling::TransitionDescriptor {
-                                action_variant: descriptor.variant,
-                                action_id: descriptor.action_id,
-                                guard: stringify!($guard_expr),
-                                effect: stringify!([$($next_state),*]),
-                                reads: descriptor.reads,
-                                writes: descriptor.writes,
-                                path_tags: $crate::valid_model!(@path_tags $($($path_tag),*)?),
-                                updates: &[],
-                            }
-                        }
-                    ),+
-                ]
-            }
+                ),*
+            ],
         }
-    };
+    }};
+    (
+        @transition_descriptor
+        [$action_ty:ty]
+        $transition_action:ident
+        $( [ tags = [$($path_tag:literal),* $(,)?] ] )?
+        |$guard_state:ident| $guard_expr:expr
+        => [$state_ctor:ident { $($field:ident : $update_expr:expr,)* .. $($unsupported_rest:tt)+ }]
+    ) => {{
+        compile_error!(
+            "declarative transition struct updates support only `..state`-style identifiers; write `..state`, not an arbitrary expression"
+        );
+    }};
+    (
+        @transition_descriptor
+        [$action_ty:ty]
+        $transition_action:ident
+        $( [ tags = [$($path_tag:literal),* $(,)?] ] )?
+        |$guard_state:ident| $guard_expr:expr
+        => [$state_ctor:ident { $($field:ident : $update_expr:expr),* $(,)? }]
+    ) => {{
+        let descriptor = $crate::modeling::action_descriptor_by_variant::<$action_ty>(
+            stringify!($transition_action)
+        );
+        $crate::modeling::TransitionDescriptor {
+            action_variant: descriptor.variant,
+            action_id: descriptor.action_id,
+            guard: stringify!($guard_expr),
+            effect: stringify!($state_ctor { $($field: $update_expr),* }),
+            reads: descriptor.reads,
+            writes: descriptor.writes,
+            path_tags: $crate::valid_model!(@path_tags $($($path_tag),*)?),
+            updates: &[
+                $(
+                    $crate::modeling::TransitionUpdateDescriptor {
+                        field: stringify!($field),
+                        expr: stringify!($update_expr),
+                    }
+                ),*
+            ],
+        }
+    }};
+    (
+        @transition_descriptor
+        [$action_ty:ty]
+        $transition_action:ident
+        $( [ tags = [$($path_tag:literal),* $(,)?] ] )?
+        |$guard_state:ident| $guard_expr:expr
+        => [$($next_state:expr),* $(,)?]
+    ) => {{
+        let descriptor = $crate::modeling::action_descriptor_by_variant::<$action_ty>(
+            stringify!($transition_action)
+        );
+        $crate::modeling::TransitionDescriptor {
+            action_variant: descriptor.variant,
+            action_id: descriptor.action_id,
+            guard: stringify!($guard_expr),
+            effect: stringify!([$($next_state),*]),
+            reads: descriptor.reads,
+            writes: descriptor.writes,
+            path_tags: $crate::valid_model!(@path_tags $($($path_tag),*)?),
+            updates: &[],
+        }
+    }};
     (@path_tags $($path_tag:literal),*) => {
         &[$($path_tag),*]
     };
@@ -4132,6 +4122,94 @@ mod tests {
             }
         ));
         assert_eq!(model.actions[0].updates[0].field, "attached");
+    }
+
+    valid_state! {
+        struct SpreadState {
+            note: String [range = "0..=32"],
+            approved: bool,
+            archived: bool,
+        }
+    }
+
+    valid_actions! {
+        enum SpreadAction {
+            Approve => "APPROVE" [reads = ["approved"], writes = ["approved"]],
+            Archive => "ARCHIVE" [reads = ["approved", "archived"], writes = ["note", "approved", "archived"]],
+        }
+    }
+
+    crate::valid_model! {
+        model SpreadModel<SpreadState, SpreadAction>;
+        init [SpreadState {
+            note: "draft".to_string(),
+            approved: false,
+            archived: false,
+        }];
+        transitions {
+            on Approve {
+                [tags = ["approval_path"]]
+                when |state| state.approved == false => [SpreadState {
+                    approved: true,
+                    ..state
+                }];
+            }
+            on Archive {
+                [tags = ["archive_path"]]
+                when |state| state.approved && state.archived == false => [SpreadState {
+                    note: "archived".to_string(),
+                    approved: state.approved,
+                    archived: true,
+                }];
+            }
+        }
+        properties {
+            invariant P_ARCHIVE_REQUIRES_APPROVAL |state| state.archived == false || state.approved;
+        }
+    }
+
+    #[test]
+    fn declarative_transition_struct_updates_clone_unchanged_fields() {
+        let init = <SpreadModel as crate::modeling::ModelSpec>::init_states()
+            .into_iter()
+            .next()
+            .expect("spread model init state");
+        let next_states =
+            <SpreadModel as crate::modeling::ModelSpec>::step(&init, &SpreadAction::Approve);
+        assert_eq!(
+            next_states,
+            vec![SpreadState {
+                note: "draft".to_string(),
+                approved: true,
+                archived: false,
+            }]
+        );
+    }
+
+    #[test]
+    fn declarative_transition_struct_updates_preserve_explicit_update_metadata() {
+        let transitions = machine_transition_ir::<SpreadModel>();
+        assert_eq!(transitions.len(), 2);
+        assert_eq!(transitions[0].action_id, "APPROVE");
+        assert!(transitions[0]
+            .effect
+            .expect("spread transition effect")
+            .contains(".. state"));
+        assert_eq!(transitions[0].updates.len(), 1);
+        assert_eq!(transitions[0].updates[0].field, "approved");
+        assert_eq!(transitions[0].updates[0].expr, Some("true"));
+        assert_eq!(transitions[1].updates.len(), 3);
+    }
+
+    #[test]
+    fn declarative_transition_struct_updates_lower_with_mixed_literal_forms() {
+        let model =
+            lower_machine_model::<SpreadModel>().expect("spread model lowering should work");
+        assert_eq!(model.actions.len(), 2);
+        assert_eq!(model.actions[0].action_id, "APPROVE");
+        assert_eq!(model.actions[0].updates.len(), 1);
+        assert_eq!(model.actions[0].updates[0].field, "approved");
+        assert!(matches!(model.state_fields[0].ty, FieldType::String { .. }));
     }
 
     crate::valid_model! {

--- a/tests/ui_macro_diagnostics.rs
+++ b/tests/ui_macro_diagnostics.rs
@@ -90,3 +90,79 @@ fn main() {}
 
     let _ = fs::remove_dir_all(project_dir);
 }
+
+#[test]
+fn valid_model_reports_struct_update_expression_diagnostic() {
+    let _guard = cargo_guard();
+    let project_dir = unique_temp_project_dir("valid-ui-diagnostics-struct-update");
+    fs::create_dir_all(project_dir.join("src")).expect("temp src dir");
+    fs::write(
+        project_dir.join("Cargo.toml"),
+        format!(
+            "[package]\nname = \"valid-ui-diagnostics-struct-update\"\nversion = \"0.1.0\"\nedition = \"2021\"\n\n[dependencies]\nvalid = {{ path = {:?} }}\n",
+            env!("CARGO_MANIFEST_DIR")
+        ),
+    )
+    .expect("temp Cargo.toml");
+    fs::write(
+        project_dir.join("src").join("main.rs"),
+        r#"use valid::{valid_actions, valid_model, valid_state};
+
+valid_state! {
+    struct State {
+        note: String [range = "0..=16"],
+        ready: bool,
+    }
+}
+
+valid_actions! {
+    enum Action {
+        Enable => "ENABLE" [reads = ["ready"], writes = ["ready"]],
+    }
+}
+
+valid_model! {
+    model BrokenSpreadModel<State, Action>;
+    init [State {
+        note: "draft".to_string(),
+        ready: false,
+    }];
+    transitions {
+        on Enable {
+            when |state| state.ready == false => [State {
+                ready: true,
+                ..state.clone()
+            }];
+        }
+    }
+    properties {
+        invariant P_READY |state| state.ready == false || state.ready == true;
+    }
+}
+
+fn main() {}
+"#,
+    )
+    .expect("temp main.rs");
+
+    let output = Command::new("cargo")
+        .arg("check")
+        .arg("--offline")
+        .current_dir(&project_dir)
+        .env("CARGO_NET_OFFLINE", "true")
+        .output()
+        .expect("cargo check should run");
+    assert!(
+        !output.status.success(),
+        "cargo check unexpectedly succeeded"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains(
+            "declarative transition struct updates support only `..state`-style identifiers"
+        ),
+        "unexpected stderr: {stderr}"
+    );
+
+    let _ = fs::remove_dir_all(project_dir);
+}


### PR DESCRIPTION
## Summary
- add `State { field: expr, ..state }` support to declarative `valid_model!` transitions while preserving explicit update metadata
- reject arbitrary struct update expressions like `..state.clone()` so models do not silently fall back to opaque transition metadata
- document the design/RFC and update the DSL guide/spec to describe explicit frame-condition sugar and compatibility

## Testing
- cargo test -q

Closes #16