### PR TITLE
SMT-CVC5: encode relation and map fields for cvc5

### DIFF
--- a/packages/valid/src/solver/smt.rs
+++ b/packages/valid/src/solver/smt.rs
@@ -1,4 +1,4 @@
-use crate::ir::{BinaryOp, ExprIr, FieldType, ModelIr, PropertyKind, UnaryOp, Value};
+use crate::ir::{BinaryOp, ExprIr, FieldType, ModelIr, PropertyKind, StateField, UnaryOp, Value};
 use std::{
     io::Write,
     process::{Command, Stdio},
@@ -126,11 +126,7 @@ pub fn build_invariant_bmc_query(
 
     for step in 0..=depth {
         for field in &model.state_fields {
-            smtlib.push_str(&format!(
-                "(declare-fun {} () {})\n",
-                state_symbol(field.name.as_str(), step),
-                smt_sort(&field.ty)
-            ));
+            declare_state_symbols(&mut smtlib, field, step);
         }
     }
 
@@ -141,11 +137,7 @@ pub fn build_invariant_bmc_query(
 
     for step in 0..=depth {
         for field in &model.state_fields {
-            if let Some((min, max)) = integer_bounds(&field.ty) {
-                let symbol = state_symbol(field.name.as_str(), step);
-                smtlib.push_str(&format!("(assert (<= {} {}))\n", min, symbol));
-                smtlib.push_str(&format!("(assert (<= {} {}))\n", symbol, max));
-            }
+            assert_state_bounds(&mut smtlib, field, step);
         }
     }
 
@@ -155,11 +147,9 @@ pub fn build_invariant_bmc_query(
             .iter()
             .find(|field| field.id == init.field)
             .ok_or_else(|| format!("unknown init field `{}`", init.field))?;
-        smtlib.push_str(&format!(
-            "(assert (= {} {}))\n",
-            state_symbol(field.name.as_str(), 0),
-            literal(&init.value)
-        ));
+        for constraint in render_init_constraints(field, &init.value, 0)? {
+            smtlib.push_str(&format!("(assert {constraint})\n"));
+        }
     }
 
     for step in 0..depth {
@@ -178,15 +168,20 @@ pub fn build_invariant_bmc_query(
                     render_expr(model, &action.guard, step)?,
                 ];
                 for field in &model.state_fields {
-                    let next_symbol = state_symbol(field.name.as_str(), step + 1);
+                    let default_expr = ExprIr::FieldRef(field.id.clone());
                     let next_expr = action
                         .updates
                         .iter()
                         .find(|update| update.field == field.id)
-                        .map(|update| render_expr(model, &update.value, step))
-                        .transpose()?
-                        .unwrap_or_else(|| state_symbol(field.name.as_str(), step));
-                    conjuncts.push(format!("(= {next_symbol} {next_expr})"));
+                        .map(|update| &update.value)
+                        .unwrap_or(&default_expr);
+                    conjuncts.extend(render_field_assignment_constraints(
+                        model,
+                        field,
+                        next_expr,
+                        step,
+                        step + 1,
+                    )?);
                 }
                 Ok::<_, String>(format!("(and {})", conjuncts.join(" ")))
             })
@@ -316,9 +311,10 @@ fn smt_sort(ty: &FieldType) -> &'static str {
         | FieldType::BoundedU16 { .. }
         | FieldType::BoundedU32 { .. }
         | FieldType::Enum { .. }
-        | FieldType::EnumSet { .. }
-        | FieldType::EnumRelation { .. }
-        | FieldType::EnumMap { .. } => "Int",
+        | FieldType::EnumSet { .. } => "Int",
+        FieldType::EnumRelation { .. } | FieldType::EnumMap { .. } => {
+            panic!("relation/map fields expand into dedicated SMT symbols")
+        }
     }
 }
 
@@ -339,23 +335,7 @@ fn integer_bounds(ty: &FieldType) -> Option<(u64, u64)> {
                 Some((0, (1u64 << variants.len()) - 1))
             }
         }
-        FieldType::EnumRelation {
-            left_variants,
-            right_variants,
-        }
-        | FieldType::EnumMap {
-            key_variants: left_variants,
-            value_variants: right_variants,
-        } => {
-            let slots = left_variants.len().saturating_mul(right_variants.len());
-            if slots > 64 {
-                None
-            } else if slots == 64 {
-                Some((0, u64::MAX))
-            } else {
-                Some((0, (1u64 << slots) - 1))
-            }
-        }
+        FieldType::EnumRelation { .. } | FieldType::EnumMap { .. } => None,
     }
 }
 
@@ -363,40 +343,179 @@ fn state_symbol(field_name: &str, step: usize) -> String {
     format!("{field_name}_{step}")
 }
 
+fn relation_slot_symbol(
+    field_name: &str,
+    step: usize,
+    left_index: usize,
+    right_index: usize,
+) -> String {
+    format!("{field_name}_{step}_pair_{left_index}_{right_index}")
+}
+
+fn map_present_symbol(field_name: &str, step: usize, key_index: usize) -> String {
+    format!("{field_name}_{step}_key_{key_index}_present")
+}
+
+fn map_value_symbol(field_name: &str, step: usize, key_index: usize) -> String {
+    format!("{field_name}_{step}_key_{key_index}_value")
+}
+
 fn action_symbol(step: usize) -> String {
     format!("action_{step}")
 }
 
-fn literal(value: &Value) -> String {
-    match value {
-        Value::Bool(value) => value.to_string(),
-        Value::UInt(value) => value.to_string(),
-        Value::String(value) => format!("{value:?}"),
-        Value::EnumVariant { index, .. } => index.to_string(),
-        Value::PairVariant { .. } => {
-            panic!("pair literals must be rendered through relation/map operators")
+fn declare_state_symbols(smtlib: &mut String, field: &StateField, step: usize) {
+    match &field.ty {
+        FieldType::EnumRelation {
+            left_variants,
+            right_variants,
+        } => {
+            for left_index in 0..left_variants.len() {
+                for right_index in 0..right_variants.len() {
+                    smtlib.push_str(&format!(
+                        "(declare-fun {} () Bool)\n",
+                        relation_slot_symbol(field.name.as_str(), step, left_index, right_index)
+                    ));
+                }
+            }
+        }
+        FieldType::EnumMap {
+            key_variants,
+            value_variants: _,
+        } => {
+            for key_index in 0..key_variants.len() {
+                smtlib.push_str(&format!(
+                    "(declare-fun {} () Bool)\n",
+                    map_present_symbol(field.name.as_str(), step, key_index)
+                ));
+                smtlib.push_str(&format!(
+                    "(declare-fun {} () Int)\n",
+                    map_value_symbol(field.name.as_str(), step, key_index)
+                ));
+            }
+        }
+        _ => {
+            smtlib.push_str(&format!(
+                "(declare-fun {} () {})\n",
+                state_symbol(field.name.as_str(), step),
+                smt_sort(&field.ty)
+            ));
         }
     }
 }
 
-fn render_expr(model: &ModelIr, expr: &ExprIr, step: usize) -> Result<String, String> {
-    match expr {
-        ExprIr::Literal(Value::PairVariant { .. }) => Err(
+fn assert_state_bounds(smtlib: &mut String, field: &StateField, step: usize) {
+    match &field.ty {
+        FieldType::EnumMap {
+            key_variants,
+            value_variants,
+        } => {
+            for key_index in 0..key_variants.len() {
+                if let Some(max) = value_variants.len().checked_sub(1) {
+                    let value_symbol = map_value_symbol(field.name.as_str(), step, key_index);
+                    smtlib.push_str(&format!("(assert (<= 0 {value_symbol}))\n"));
+                    smtlib.push_str(&format!("(assert (<= {value_symbol} {}))\n", max));
+                }
+                let present_symbol = map_present_symbol(field.name.as_str(), step, key_index);
+                let value_symbol = map_value_symbol(field.name.as_str(), step, key_index);
+                smtlib.push_str(&format!(
+                    "(assert (=> (not {present_symbol}) (= {value_symbol} 0)))\n"
+                ));
+            }
+        }
+        _ => {
+            if let Some((min, max)) = integer_bounds(&field.ty) {
+                let symbol = state_symbol(field.name.as_str(), step);
+                smtlib.push_str(&format!("(assert (<= {} {}))\n", min, symbol));
+                smtlib.push_str(&format!("(assert (<= {} {}))\n", symbol, max));
+            }
+        }
+    }
+}
+
+fn render_literal(value: &Value, expected_ty: Option<&FieldType>) -> Result<String, String> {
+    match value {
+        Value::Bool(value) => Ok(value.to_string()),
+        Value::UInt(value) => match expected_ty {
+            Some(FieldType::EnumRelation { .. }) | Some(FieldType::EnumMap { .. }) => Err(
+                "relation/map literals must be decomposed through dedicated render helpers"
+                    .to_string(),
+            ),
+            _ => Ok(value.to_string()),
+        },
+        Value::String(value) => Ok(format!("{value:?}")),
+        Value::EnumVariant { index, .. } => Ok(index.to_string()),
+        Value::PairVariant { .. } => Err(
             "pair literals are only supported inside relation/map helper expressions".to_string(),
         ),
-        ExprIr::Literal(value) => Ok(literal(value)),
+    }
+}
+
+fn render_expr(model: &ModelIr, expr: &ExprIr, step: usize) -> Result<String, String> {
+    render_expr_with_expected_type(model, expr, step, None)
+}
+
+fn render_expr_with_expected_type(
+    model: &ModelIr,
+    expr: &ExprIr,
+    step: usize,
+    expected_ty: Option<&FieldType>,
+) -> Result<String, String> {
+    match expr {
+        ExprIr::Literal(value) => render_literal(value, expected_ty),
         ExprIr::FieldRef(field) => {
-            let field_name = model
-                .state_fields
-                .iter()
-                .find(|item| item.id == *field)
-                .map(|item| item.name.as_str())
-                .ok_or_else(|| format!("unknown field reference `{field}`"))?;
-            Ok(state_symbol(field_name, step))
+            let field = field_for_id(model, field)?;
+            match field.ty {
+                FieldType::EnumRelation { .. } | FieldType::EnumMap { .. } => Err(format!(
+                    "relation/map field `{}` must be used through dedicated relation/map operators",
+                    field.name
+                )),
+                _ => Ok(state_symbol(field.name.as_str(), step)),
+            }
         }
         ExprIr::Unary { op, expr } => match op {
-            UnaryOp::Not => Ok(format!("(not {})", render_expr(model, expr, step)?)),
-            UnaryOp::SetIsEmpty => Ok(format!("(= {} 0)", render_expr(model, expr, step)?)),
+            UnaryOp::Not => Ok(format!(
+                "(not {})",
+                render_expr_with_expected_type(model, expr, step, expected_ty)?
+            )),
+            UnaryOp::SetIsEmpty => match field_type_for_expr(model, expr) {
+                Some(FieldType::EnumRelation {
+                    left_variants,
+                    right_variants,
+                }) => render_all(
+                    (0..left_variants.len()).flat_map(|left_index| {
+                        (0..right_variants.len()).map(move |right_index| {
+                            Ok(format!(
+                                "(not {})",
+                                render_relation_slot_expr(
+                                    model,
+                                    expr,
+                                    step,
+                                    left_index,
+                                    right_index,
+                                    None,
+                                )?
+                            ))
+                        })
+                    }),
+                    "and",
+                    "true",
+                ),
+                Some(FieldType::EnumMap { key_variants, .. }) => render_all(
+                    (0..key_variants.len()).map(|key_index| {
+                        Ok(format!(
+                            "(not {})",
+                            render_map_presence_expr(model, expr, step, key_index, None)?
+                        ))
+                    }),
+                    "and",
+                    "true",
+                ),
+                _ => Ok(format!(
+                    "(= {} 0)",
+                    render_expr_with_expected_type(model, expr, step, expected_ty)?
+                )),
+            },
             UnaryOp::StringLen => Err(
                 "SMT adapter does not yet support string length expressions; use explicit backend"
                     .to_string(),
@@ -412,101 +531,90 @@ fn render_expr(model: &ModelIr, expr: &ExprIr, step: usize) -> Result<String, St
                     .to_string(),
             ),
             BinaryOp::RelationContains => {
-                let left_rendered = render_expr(model, left, step)?;
                 let (left_index, right_index) = extract_pair_indexes(right.as_ref(), expr)?;
-                let mask = relation_mask_for_expr(model, left.as_ref(), left_index, right_index)?;
-                Ok(format!("(= (mod (div {left_rendered} {mask}) 2) 1)"))
+                render_relation_slot_expr(
+                    model,
+                    left,
+                    step,
+                    left_index as usize,
+                    right_index as usize,
+                    None,
+                )
             }
-            BinaryOp::RelationInsert => {
-                let left_rendered = render_expr(model, left, step)?;
-                let (left_index, right_index) = extract_pair_indexes(right.as_ref(), expr)?;
-                let mask = relation_mask_for_expr(model, left.as_ref(), left_index, right_index)?;
-                Ok(format!(
-                    "(+ {left_rendered} (* (- 1 (mod (div {left_rendered} {mask}) 2)) {mask}))"
-                ))
-            }
-            BinaryOp::RelationRemove => {
-                let left_rendered = render_expr(model, left, step)?;
-                let (left_index, right_index) = extract_pair_indexes(right.as_ref(), expr)?;
-                let mask = relation_mask_for_expr(model, left.as_ref(), left_index, right_index)?;
-                Ok(format!(
-                    "(- {left_rendered} (* (mod (div {left_rendered} {mask}) 2) {mask}))"
-                ))
-            }
+            BinaryOp::RelationInsert | BinaryOp::RelationRemove => Err(
+                "relation value expressions must appear in field assignments or equality checks"
+                    .to_string(),
+            ),
             BinaryOp::RelationIntersects => {
-                let left_rendered = render_expr(model, left, step)?;
-                let right_rendered = render_expr(model, right, step)?;
-                let masks = relation_masks_for_expr(model, left.as_ref())?;
-                if masks.is_empty() {
-                    Ok("false".to_string())
-                } else {
-                    Ok(format!(
-                            "(or {})",
-                            masks
-                                .iter()
-                                .map(|mask| format!(
-                                    "(and (= (mod (div {left_rendered} {mask}) 2) 1) (= (mod (div {right_rendered} {mask}) 2) 1))"
+                match relation_type_for_expr(model, left, None)? {
+                    FieldType::EnumRelation {
+                        left_variants,
+                        right_variants,
+                    } => render_any(
+                        (0..left_variants.len()).flat_map(|left_index| {
+                            (0..right_variants.len()).map(move |right_index| {
+                                Ok(format!(
+                                    "(and {} {})",
+                                    render_relation_slot_expr(
+                                        model,
+                                        left,
+                                        step,
+                                        left_index,
+                                        right_index,
+                                        None,
+                                    )?,
+                                    render_relation_slot_expr(
+                                        model,
+                                        right,
+                                        step,
+                                        left_index,
+                                        right_index,
+                                        None,
+                                    )?
                                 ))
-                                .collect::<Vec<_>>()
-                                .join(" ")
-                        ))
+                            })
+                        }),
+                        "false",
+                    ),
+                    _ => unreachable!(),
                 }
             }
             BinaryOp::MapContainsKey => {
-                let left_rendered = render_expr(model, left, step)?;
                 let key_index = extract_enum_index_from_expr(right.as_ref(), expr)?;
-                let masks = map_masks_for_key(model, left.as_ref(), key_index)?;
-                if masks.is_empty() {
-                    Ok("false".to_string())
-                } else {
-                    Ok(format!(
-                        "(or {})",
-                        masks
-                            .iter()
-                            .map(|mask| format!("(= (mod (div {left_rendered} {mask}) 2) 1)"))
-                            .collect::<Vec<_>>()
-                            .join(" ")
-                    ))
-                }
+                render_map_presence_expr(model, left, step, key_index as usize, None)
             }
             BinaryOp::MapContainsEntry => {
-                let left_rendered = render_expr(model, left, step)?;
                 let (key_index, value_index) = extract_pair_indexes(right.as_ref(), expr)?;
-                let mask = relation_mask_for_expr(model, left.as_ref(), key_index, value_index)?;
-                Ok(format!("(= (mod (div {left_rendered} {mask}) 2) 1)"))
-            }
-            BinaryOp::MapPut => {
-                let left_rendered = render_expr(model, left, step)?;
-                let (key_index, value_index) = extract_pair_indexes(right.as_ref(), expr)?;
-                let clear = render_map_clear_expr(model, left.as_ref(), &left_rendered, key_index)?;
-                let mask = relation_mask_for_expr(model, left.as_ref(), key_index, value_index)?;
+                let key_index = key_index as usize;
                 Ok(format!(
-                    "(+ {clear} (* (- 1 (mod (div {clear} {mask}) 2)) {mask}))"
+                    "(and {} (= {} {}))",
+                    render_map_presence_expr(model, left, step, key_index, None)?,
+                    render_map_value_expr(model, left, step, key_index, None)?,
+                    value_index
                 ))
             }
-            BinaryOp::MapRemoveKey => {
-                let left_rendered = render_expr(model, left, step)?;
-                let key_index = extract_enum_index_from_expr(right.as_ref(), expr)?;
-                render_map_clear_expr(model, left.as_ref(), &left_rendered, key_index)
-            }
+            BinaryOp::MapPut | BinaryOp::MapRemoveKey => Err(
+                "map value expressions must appear in field assignments or equality checks"
+                    .to_string(),
+            ),
             BinaryOp::Add => {
-                let left = render_expr(model, left, step)?;
-                let right = render_expr(model, right, step)?;
+                let left = render_expr_with_expected_type(model, left, step, expected_ty)?;
+                let right = render_expr_with_expected_type(model, right, step, expected_ty)?;
                 Ok(format!("(+ {left} {right})"))
             }
             BinaryOp::Sub => {
-                let left = render_expr(model, left, step)?;
-                let right = render_expr(model, right, step)?;
+                let left = render_expr_with_expected_type(model, left, step, expected_ty)?;
+                let right = render_expr_with_expected_type(model, right, step, expected_ty)?;
                 Ok(format!("(- {left} {right})"))
             }
             BinaryOp::Mod => {
-                let left = render_expr(model, left, step)?;
-                let right = render_expr(model, right, step)?;
+                let left = render_expr_with_expected_type(model, left, step, expected_ty)?;
+                let right = render_expr_with_expected_type(model, right, step, expected_ty)?;
                 Ok(format!("(mod {left} {right})"))
             }
             BinaryOp::SetContains => {
-                let left = render_expr(model, left, step)?;
-                let right = render_expr(model, right, step)?;
+                let left = render_expr_with_expected_type(model, left, step, expected_ty)?;
+                let right = render_expr_with_expected_type(model, right, step, expected_ty)?;
                 let index = extract_enum_index(right.as_str(), expr)?;
                 Ok(format!(
                     "(= (mod (div {left} {}) 2) 1)",
@@ -514,8 +622,8 @@ fn render_expr(model: &ModelIr, expr: &ExprIr, step: usize) -> Result<String, St
                 ))
             }
             BinaryOp::SetInsert => {
-                let left = render_expr(model, left, step)?;
-                let right = render_expr(model, right, step)?;
+                let left = render_expr_with_expected_type(model, left, step, expected_ty)?;
+                let right = render_expr_with_expected_type(model, right, step, expected_ty)?;
                 let index = extract_enum_index(right.as_str(), expr)?;
                 let mask = enum_variant_mask(index);
                 Ok(format!(
@@ -523,53 +631,189 @@ fn render_expr(model: &ModelIr, expr: &ExprIr, step: usize) -> Result<String, St
                 ))
             }
             BinaryOp::SetRemove => {
-                let left = render_expr(model, left, step)?;
-                let right = render_expr(model, right, step)?;
+                let left = render_expr_with_expected_type(model, left, step, expected_ty)?;
+                let right = render_expr_with_expected_type(model, right, step, expected_ty)?;
                 let index = extract_enum_index(right.as_str(), expr)?;
                 let mask = enum_variant_mask(index);
                 Ok(format!("(- {left} (* (mod (div {left} {mask}) 2) {mask}))"))
             }
             BinaryOp::LessThan => {
-                let left = render_expr(model, left, step)?;
-                let right = render_expr(model, right, step)?;
+                let left = render_expr_with_expected_type(model, left, step, expected_ty)?;
+                let right = render_expr_with_expected_type(model, right, step, expected_ty)?;
                 Ok(format!("(< {left} {right})"))
             }
             BinaryOp::LessThanOrEqual => {
-                let left = render_expr(model, left, step)?;
-                let right = render_expr(model, right, step)?;
+                let left = render_expr_with_expected_type(model, left, step, expected_ty)?;
+                let right = render_expr_with_expected_type(model, right, step, expected_ty)?;
                 Ok(format!("(<= {left} {right})"))
             }
             BinaryOp::GreaterThan => {
-                let left = render_expr(model, left, step)?;
-                let right = render_expr(model, right, step)?;
+                let left = render_expr_with_expected_type(model, left, step, expected_ty)?;
+                let right = render_expr_with_expected_type(model, right, step, expected_ty)?;
                 Ok(format!("(> {left} {right})"))
             }
             BinaryOp::GreaterThanOrEqual => {
-                let left = render_expr(model, left, step)?;
-                let right = render_expr(model, right, step)?;
+                let left = render_expr_with_expected_type(model, left, step, expected_ty)?;
+                let right = render_expr_with_expected_type(model, right, step, expected_ty)?;
                 Ok(format!("(>= {left} {right})"))
             }
             BinaryOp::Equal => {
-                let left = render_expr(model, left, step)?;
-                let right = render_expr(model, right, step)?;
-                Ok(format!("(= {left} {right})"))
+                if let Some(ty) = composite_type_for_exprs(model, left, right) {
+                    render_equality_expr(model, left, right, step, ty, false)
+                } else {
+                    let left =
+                        render_expr_with_expected_type(model, left, step, expected_ty)?;
+                    let right =
+                        render_expr_with_expected_type(model, right, step, expected_ty)?;
+                    Ok(format!("(= {left} {right})"))
+                }
             }
             BinaryOp::NotEqual => {
-                let left = render_expr(model, left, step)?;
-                let right = render_expr(model, right, step)?;
-                Ok(format!("(not (= {left} {right}))"))
+                if let Some(ty) = composite_type_for_exprs(model, left, right) {
+                    render_equality_expr(model, left, right, step, ty, true)
+                } else {
+                    let left =
+                        render_expr_with_expected_type(model, left, step, expected_ty)?;
+                    let right =
+                        render_expr_with_expected_type(model, right, step, expected_ty)?;
+                    Ok(format!("(not (= {left} {right}))"))
+                }
             }
             BinaryOp::And => {
-                let left = render_expr(model, left, step)?;
-                let right = render_expr(model, right, step)?;
+                let left = render_expr_with_expected_type(model, left, step, expected_ty)?;
+                let right = render_expr_with_expected_type(model, right, step, expected_ty)?;
                 Ok(format!("(and {left} {right})"))
             }
             BinaryOp::Or => {
-                let left = render_expr(model, left, step)?;
-                let right = render_expr(model, right, step)?;
+                let left = render_expr_with_expected_type(model, left, step, expected_ty)?;
+                let right = render_expr_with_expected_type(model, right, step, expected_ty)?;
                 Ok(format!("(or {left} {right})"))
             }
         },
+    }
+}
+
+fn render_init_constraints(
+    field: &StateField,
+    value: &Value,
+    step: usize,
+) -> Result<Vec<String>, String> {
+    match (&field.ty, value) {
+        (
+            FieldType::EnumRelation {
+                left_variants,
+                right_variants,
+            },
+            Value::UInt(bits),
+        ) => {
+            let mut constraints = Vec::new();
+            for left_index in 0..left_variants.len() {
+                for right_index in 0..right_variants.len() {
+                    constraints.push(format!(
+                        "(= {} {})",
+                        relation_slot_symbol(field.name.as_str(), step, left_index, right_index),
+                        relation_literal_contains(
+                            *bits,
+                            right_variants.len(),
+                            left_index,
+                            right_index
+                        )
+                    ));
+                }
+            }
+            Ok(constraints)
+        }
+        (
+            FieldType::EnumMap {
+                key_variants,
+                value_variants,
+            },
+            Value::UInt(bits),
+        ) => {
+            let mut constraints = Vec::new();
+            for key_index in 0..key_variants.len() {
+                let decoded = decode_map_literal(*bits, value_variants.len(), key_index)?;
+                constraints.push(format!(
+                    "(= {} {})",
+                    map_present_symbol(field.name.as_str(), step, key_index),
+                    bool_literal(decoded.is_some())
+                ));
+                constraints.push(format!(
+                    "(= {} {})",
+                    map_value_symbol(field.name.as_str(), step, key_index),
+                    decoded.unwrap_or(0)
+                ));
+            }
+            Ok(constraints)
+        }
+        _ => Ok(vec![format!(
+            "(= {} {})",
+            state_symbol(field.name.as_str(), step),
+            render_literal(value, Some(&field.ty))?
+        )]),
+    }
+}
+
+fn render_field_assignment_constraints(
+    model: &ModelIr,
+    field: &StateField,
+    expr: &ExprIr,
+    source_step: usize,
+    target_step: usize,
+) -> Result<Vec<String>, String> {
+    match &field.ty {
+        FieldType::EnumRelation {
+            left_variants,
+            right_variants,
+        } => {
+            let mut constraints = Vec::new();
+            for left_index in 0..left_variants.len() {
+                for right_index in 0..right_variants.len() {
+                    constraints.push(format!(
+                        "(= {} {})",
+                        relation_slot_symbol(
+                            field.name.as_str(),
+                            target_step,
+                            left_index,
+                            right_index
+                        ),
+                        render_relation_slot_expr(
+                            model,
+                            expr,
+                            source_step,
+                            left_index,
+                            right_index,
+                            Some(&field.ty),
+                        )?
+                    ));
+                }
+            }
+            Ok(constraints)
+        }
+        FieldType::EnumMap {
+            key_variants,
+            value_variants: _,
+        } => {
+            let mut constraints = Vec::new();
+            for key_index in 0..key_variants.len() {
+                constraints.push(format!(
+                    "(= {} {})",
+                    map_present_symbol(field.name.as_str(), target_step, key_index),
+                    render_map_presence_expr(model, expr, source_step, key_index, Some(&field.ty))?
+                ));
+                constraints.push(format!(
+                    "(= {} {})",
+                    map_value_symbol(field.name.as_str(), target_step, key_index),
+                    render_map_value_expr(model, expr, source_step, key_index, Some(&field.ty))?
+                ));
+            }
+            Ok(constraints)
+        }
+        _ => Ok(vec![format!(
+            "(= {} {})",
+            state_symbol(field.name.as_str(), target_step),
+            render_expr_with_expected_type(model, expr, source_step, Some(&field.ty))?
+        )]),
     }
 }
 
@@ -593,79 +837,306 @@ fn field_type_for_expr<'a>(model: &'a ModelIr, expr: &ExprIr) -> Option<&'a Fiel
     }
 }
 
-fn relation_mask_for_expr(
-    model: &ModelIr,
-    expr: &ExprIr,
-    left_index: u64,
-    right_index: u64,
-) -> Result<u64, String> {
-    let right_len = match field_type_for_expr(model, expr) {
-        Some(FieldType::EnumRelation { right_variants, .. }) => right_variants.len() as u64,
-        Some(FieldType::EnumMap { value_variants, .. }) => value_variants.len() as u64,
-        other => {
-            return Err(format!(
-                "relation/map operation requires a relation or map field, got `{other:?}`"
-            ))
-        }
-    };
-    let bit_index = left_index
-        .checked_mul(right_len)
-        .and_then(|value| value.checked_add(right_index))
-        .ok_or_else(|| "relation/map bit index overflow".to_string())?;
-    Ok(enum_variant_mask(bit_index))
+fn field_for_id<'a>(model: &'a ModelIr, field_id: &str) -> Result<&'a StateField, String> {
+    model
+        .state_fields
+        .iter()
+        .find(|item| item.id == field_id)
+        .ok_or_else(|| format!("unknown field reference `{field_id}`"))
 }
 
-fn relation_masks_for_expr(model: &ModelIr, expr: &ExprIr) -> Result<Vec<u64>, String> {
-    match field_type_for_expr(model, expr) {
-        Some(FieldType::EnumRelation {
-            left_variants,
-            right_variants,
+fn composite_type_for_exprs<'a>(
+    model: &'a ModelIr,
+    left: &'a ExprIr,
+    right: &'a ExprIr,
+) -> Option<&'a FieldType> {
+    field_type_for_expr(model, left)
+        .or_else(|| field_type_for_expr(model, right))
+        .filter(|ty| {
+            matches!(
+                ty,
+                FieldType::EnumRelation { .. } | FieldType::EnumMap { .. }
+            )
         })
-        | Some(FieldType::EnumMap {
-            key_variants: left_variants,
-            value_variants: right_variants,
-        }) => Ok((0..left_variants.len() as u64)
-            .flat_map(|left_index| {
-                (0..right_variants.len() as u64).map(move |right_index| {
-                    enum_variant_mask(left_index * right_variants.len() as u64 + right_index)
-                })
-            })
-            .collect()),
+}
+
+fn relation_type_for_expr<'a>(
+    model: &'a ModelIr,
+    expr: &'a ExprIr,
+    expected_ty: Option<&'a FieldType>,
+) -> Result<&'a FieldType, String> {
+    match expected_ty.or_else(|| field_type_for_expr(model, expr)) {
+        Some(ty @ FieldType::EnumRelation { .. }) => Ok(ty),
         other => Err(format!(
-            "relation/map operation requires a relation or map field, got `{other:?}`"
+            "relation operation requires a relation field, got `{other:?}`"
         )),
     }
 }
 
-fn map_masks_for_key(model: &ModelIr, expr: &ExprIr, key_index: u64) -> Result<Vec<u64>, String> {
-    match field_type_for_expr(model, expr) {
-        Some(FieldType::EnumMap { value_variants, .. }) => Ok((0..value_variants.len() as u64)
-            .map(|value_index| relation_mask_for_expr(model, expr, key_index, value_index))
-            .collect::<Result<Vec<_>, _>>()?),
+fn map_type_for_expr<'a>(
+    model: &'a ModelIr,
+    expr: &'a ExprIr,
+    expected_ty: Option<&'a FieldType>,
+) -> Result<&'a FieldType, String> {
+    match expected_ty.or_else(|| field_type_for_expr(model, expr)) {
+        Some(ty @ FieldType::EnumMap { .. }) => Ok(ty),
         other => Err(format!(
             "map operation requires a map field, got `{other:?}`"
         )),
     }
 }
 
-fn render_map_clear_expr(
+fn render_relation_slot_expr(
     model: &ModelIr,
     expr: &ExprIr,
-    rendered_left: &str,
-    key_index: u64,
+    step: usize,
+    left_index: usize,
+    right_index: usize,
+    expected_ty: Option<&FieldType>,
 ) -> Result<String, String> {
-    let masks = map_masks_for_key(model, expr, key_index)?;
-    if masks.is_empty() {
-        return Ok(rendered_left.to_string());
+    match expr {
+        ExprIr::Literal(Value::UInt(bits)) => {
+            match relation_type_for_expr(model, expr, expected_ty)? {
+                FieldType::EnumRelation { right_variants, .. } => Ok(bool_literal(
+                    relation_literal_contains(*bits, right_variants.len(), left_index, right_index),
+                )
+                .to_string()),
+                _ => unreachable!(),
+            }
+        }
+        ExprIr::FieldRef(field) => {
+            let field = field_for_id(model, field)?;
+            match field.ty {
+                FieldType::EnumRelation { .. } => Ok(relation_slot_symbol(
+                    field.name.as_str(),
+                    step,
+                    left_index,
+                    right_index,
+                )),
+                _ => Err(format!(
+                    "relation operation requires a relation field, got `{}`",
+                    field.name
+                )),
+            }
+        }
+        ExprIr::Binary {
+            op: BinaryOp::RelationInsert,
+            left,
+            right,
+        } => {
+            let (target_left, target_right) = extract_pair_indexes(right.as_ref(), expr)?;
+            if left_index == target_left as usize && right_index == target_right as usize {
+                Ok("true".to_string())
+            } else {
+                render_relation_slot_expr(model, left, step, left_index, right_index, expected_ty)
+            }
+        }
+        ExprIr::Binary {
+            op: BinaryOp::RelationRemove,
+            left,
+            right,
+        } => {
+            let (target_left, target_right) = extract_pair_indexes(right.as_ref(), expr)?;
+            if left_index == target_left as usize && right_index == target_right as usize {
+                Ok("false".to_string())
+            } else {
+                render_relation_slot_expr(model, left, step, left_index, right_index, expected_ty)
+            }
+        }
+        other => Err(format!(
+            "unsupported relation value expression `{other:?}` in SMT encoding"
+        )),
     }
-    Ok(format!(
-        "(- {rendered_left} (+ {}))",
-        masks
-            .iter()
-            .map(|mask| format!("(* (mod (div {rendered_left} {mask}) 2) {mask})"))
-            .collect::<Vec<_>>()
-            .join(" ")
-    ))
+}
+
+fn render_map_presence_expr(
+    model: &ModelIr,
+    expr: &ExprIr,
+    step: usize,
+    key_index: usize,
+    expected_ty: Option<&FieldType>,
+) -> Result<String, String> {
+    match expr {
+        ExprIr::Literal(Value::UInt(bits)) => match map_type_for_expr(model, expr, expected_ty)? {
+            FieldType::EnumMap { value_variants, .. } => Ok(bool_literal(
+                decode_map_literal(*bits, value_variants.len(), key_index)?.is_some(),
+            )
+            .to_string()),
+            _ => unreachable!(),
+        },
+        ExprIr::FieldRef(field) => {
+            let field = field_for_id(model, field)?;
+            match field.ty {
+                FieldType::EnumMap { .. } => {
+                    Ok(map_present_symbol(field.name.as_str(), step, key_index))
+                }
+                _ => Err(format!(
+                    "map operation requires a map field, got `{}`",
+                    field.name
+                )),
+            }
+        }
+        ExprIr::Binary {
+            op: BinaryOp::MapPut,
+            left,
+            right,
+        } => {
+            let (target_key, _) = extract_pair_indexes(right.as_ref(), expr)?;
+            if key_index == target_key as usize {
+                Ok("true".to_string())
+            } else {
+                render_map_presence_expr(model, left, step, key_index, expected_ty)
+            }
+        }
+        ExprIr::Binary {
+            op: BinaryOp::MapRemoveKey,
+            left,
+            right,
+        } => {
+            let target_key = extract_enum_index_from_expr(right.as_ref(), expr)?;
+            if key_index == target_key as usize {
+                Ok("false".to_string())
+            } else {
+                render_map_presence_expr(model, left, step, key_index, expected_ty)
+            }
+        }
+        other => Err(format!(
+            "unsupported map value expression `{other:?}` in SMT encoding"
+        )),
+    }
+}
+
+fn render_map_value_expr(
+    model: &ModelIr,
+    expr: &ExprIr,
+    step: usize,
+    key_index: usize,
+    expected_ty: Option<&FieldType>,
+) -> Result<String, String> {
+    match expr {
+        ExprIr::Literal(Value::UInt(bits)) => match map_type_for_expr(model, expr, expected_ty)? {
+            FieldType::EnumMap { value_variants, .. } => {
+                Ok(decode_map_literal(*bits, value_variants.len(), key_index)?
+                    .unwrap_or(0)
+                    .to_string())
+            }
+            _ => unreachable!(),
+        },
+        ExprIr::FieldRef(field) => {
+            let field = field_for_id(model, field)?;
+            match field.ty {
+                FieldType::EnumMap { .. } => {
+                    Ok(map_value_symbol(field.name.as_str(), step, key_index))
+                }
+                _ => Err(format!(
+                    "map operation requires a map field, got `{}`",
+                    field.name
+                )),
+            }
+        }
+        ExprIr::Binary {
+            op: BinaryOp::MapPut,
+            left,
+            right,
+        } => {
+            let (target_key, target_value) = extract_pair_indexes(right.as_ref(), expr)?;
+            if key_index == target_key as usize {
+                Ok(target_value.to_string())
+            } else {
+                render_map_value_expr(model, left, step, key_index, expected_ty)
+            }
+        }
+        ExprIr::Binary {
+            op: BinaryOp::MapRemoveKey,
+            left,
+            right,
+        } => {
+            let target_key = extract_enum_index_from_expr(right.as_ref(), expr)?;
+            if key_index == target_key as usize {
+                Ok("0".to_string())
+            } else {
+                render_map_value_expr(model, left, step, key_index, expected_ty)
+            }
+        }
+        other => Err(format!(
+            "unsupported map value expression `{other:?}` in SMT encoding"
+        )),
+    }
+}
+
+fn render_equality_expr(
+    model: &ModelIr,
+    left: &ExprIr,
+    right: &ExprIr,
+    step: usize,
+    ty: &FieldType,
+    negate: bool,
+) -> Result<String, String> {
+    let equality = match ty {
+        FieldType::EnumRelation {
+            left_variants,
+            right_variants,
+        } => render_all(
+            (0..left_variants.len()).flat_map(|left_index| {
+                (0..right_variants.len()).map(move |right_index| {
+                    Ok(format!(
+                        "(= {} {})",
+                        render_relation_slot_expr(
+                            model,
+                            left,
+                            step,
+                            left_index,
+                            right_index,
+                            Some(ty)
+                        )?,
+                        render_relation_slot_expr(
+                            model,
+                            right,
+                            step,
+                            left_index,
+                            right_index,
+                            Some(ty)
+                        )?,
+                    ))
+                })
+            }),
+            "and",
+            "true",
+        )?,
+        FieldType::EnumMap {
+            key_variants,
+            value_variants: _,
+        } => {
+            let mut parts = Vec::new();
+            for key_index in 0..key_variants.len() {
+                parts.push(format!(
+                    "(= {} {})",
+                    render_map_presence_expr(model, left, step, key_index, Some(ty))?,
+                    render_map_presence_expr(model, right, step, key_index, Some(ty))?,
+                ));
+                parts.push(format!(
+                    "(= {} {})",
+                    render_map_value_expr(model, left, step, key_index, Some(ty))?,
+                    render_map_value_expr(model, right, step, key_index, Some(ty))?,
+                ));
+            }
+            if parts.is_empty() {
+                "true".to_string()
+            } else {
+                format!("(and {})", parts.join(" "))
+            }
+        }
+        _ => {
+            return Err(format!(
+                "composite equality requires a relation/map field type, got `{ty:?}`"
+            ))
+        }
+    };
+    if negate {
+        Ok(format!("(not {equality})"))
+    } else {
+        Ok(equality)
+    }
 }
 
 fn extract_enum_index(rendered_right: &str, expr: &ExprIr) -> Result<u64, String> {
@@ -706,10 +1177,304 @@ fn enum_variant_mask(index: u64) -> u64 {
     1u64.checked_shl(index as u32).unwrap_or(0)
 }
 
+fn relation_literal_contains(
+    bits: u64,
+    right_len: usize,
+    left_index: usize,
+    right_index: usize,
+) -> bool {
+    let bit_index = left_index
+        .checked_mul(right_len)
+        .and_then(|value| value.checked_add(right_index))
+        .unwrap_or(usize::MAX);
+    bits & enum_variant_mask(bit_index as u64) != 0
+}
+
+fn decode_map_literal(
+    bits: u64,
+    value_len: usize,
+    key_index: usize,
+) -> Result<Option<u64>, String> {
+    let mut found = None;
+    for value_index in 0..value_len {
+        if relation_literal_contains(bits, value_len, key_index, value_index) {
+            if found.replace(value_index as u64).is_some() {
+                return Err(format!(
+                    "map literal encoded multiple values for key index `{key_index}`"
+                ));
+            }
+        }
+    }
+    Ok(found)
+}
+
+fn render_all<I>(parts: I, op: &str, empty: &str) -> Result<String, String>
+where
+    I: IntoIterator<Item = Result<String, String>>,
+{
+    let rendered = parts.into_iter().collect::<Result<Vec<_>, _>>()?;
+    if rendered.is_empty() {
+        Ok(empty.to_string())
+    } else {
+        Ok(format!("({op} {})", rendered.join(" ")))
+    }
+}
+
+fn render_any<I>(parts: I, empty: &str) -> Result<String, String>
+where
+    I: IntoIterator<Item = Result<String, String>>,
+{
+    render_all(parts, "or", empty)
+}
+
+fn bool_literal(value: bool) -> &'static str {
+    if value {
+        "true"
+    } else {
+        "false"
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::{build_invariant_bmc_query, SmtCliDialect, SmtSolveStatus};
-    use crate::frontend::compile_model;
+    use crate::{
+        frontend::compile_model,
+        ir::{
+            ActionIr, BinaryOp, ExprIr, FieldType, InitAssignment, ModelIr, PropertyIr,
+            PropertyKind, SourceSpan, StateField, UpdateIr, Value,
+        },
+    };
+
+    fn relation_map_model() -> ModelIr {
+        let span = SourceSpan { line: 1, column: 1 };
+        let memberships = "memberships".to_string();
+        let pending = "pending".to_string();
+        let plans = "plans".to_string();
+        let alpha_registered = "alpha_registered".to_string();
+        let enterprise_alpha = "enterprise_alpha".to_string();
+        let pair_alice_alpha = ExprIr::Literal(Value::PairVariant {
+            left_label: "Alice".to_string(),
+            left_index: 0,
+            right_label: "Alpha".to_string(),
+            right_index: 0,
+        });
+        let pair_beta_free = ExprIr::Literal(Value::PairVariant {
+            left_label: "Beta".to_string(),
+            left_index: 1,
+            right_label: "Free".to_string(),
+            right_index: 0,
+        });
+        let pair_alpha_enterprise = ExprIr::Literal(Value::PairVariant {
+            left_label: "Alpha".to_string(),
+            left_index: 0,
+            right_label: "Enterprise".to_string(),
+            right_index: 1,
+        });
+        let alpha = ExprIr::Literal(Value::EnumVariant {
+            label: "Alpha".to_string(),
+            index: 0,
+        });
+        let beta = ExprIr::Literal(Value::EnumVariant {
+            label: "Beta".to_string(),
+            index: 1,
+        });
+
+        ModelIr {
+            model_id: "RelationMapOps".to_string(),
+            state_fields: vec![
+                StateField {
+                    id: memberships.clone(),
+                    name: memberships.clone(),
+                    ty: FieldType::EnumRelation {
+                        left_variants: vec!["Alice".to_string(), "Bob".to_string()],
+                        right_variants: vec!["Alpha".to_string(), "Beta".to_string()],
+                    },
+                    span: span.clone(),
+                },
+                StateField {
+                    id: pending.clone(),
+                    name: pending.clone(),
+                    ty: FieldType::EnumRelation {
+                        left_variants: vec!["Alice".to_string(), "Bob".to_string()],
+                        right_variants: vec!["Alpha".to_string(), "Beta".to_string()],
+                    },
+                    span: span.clone(),
+                },
+                StateField {
+                    id: plans.clone(),
+                    name: plans.clone(),
+                    ty: FieldType::EnumMap {
+                        key_variants: vec!["Alpha".to_string(), "Beta".to_string()],
+                        value_variants: vec!["Free".to_string(), "Enterprise".to_string()],
+                    },
+                    span: span.clone(),
+                },
+                StateField {
+                    id: alpha_registered.clone(),
+                    name: alpha_registered.clone(),
+                    ty: FieldType::Bool,
+                    span: span.clone(),
+                },
+                StateField {
+                    id: enterprise_alpha.clone(),
+                    name: enterprise_alpha.clone(),
+                    ty: FieldType::Bool,
+                    span: span.clone(),
+                },
+            ],
+            init: vec![
+                InitAssignment {
+                    field: memberships.clone(),
+                    value: Value::UInt(0),
+                    span: span.clone(),
+                },
+                InitAssignment {
+                    field: pending.clone(),
+                    value: Value::UInt(1),
+                    span: span.clone(),
+                },
+                InitAssignment {
+                    field: plans.clone(),
+                    value: Value::UInt(5),
+                    span: span.clone(),
+                },
+                InitAssignment {
+                    field: alpha_registered.clone(),
+                    value: Value::Bool(false),
+                    span: span.clone(),
+                },
+                InitAssignment {
+                    field: enterprise_alpha.clone(),
+                    value: Value::Bool(false),
+                    span: span.clone(),
+                },
+            ],
+            actions: vec![
+                ActionIr {
+                    action_id: "SYNC".to_string(),
+                    label: "SYNC".to_string(),
+                    reads: vec![memberships.clone(), pending.clone(), plans.clone()],
+                    writes: vec![
+                        memberships.clone(),
+                        pending.clone(),
+                        alpha_registered.clone(),
+                        enterprise_alpha.clone(),
+                    ],
+                    path_tags: Vec::new(),
+                    guard: ExprIr::Binary {
+                        op: BinaryOp::RelationIntersects,
+                        left: Box::new(ExprIr::FieldRef(pending.clone())),
+                        right: Box::new(ExprIr::FieldRef(pending.clone())),
+                    },
+                    updates: vec![
+                        UpdateIr {
+                            field: memberships.clone(),
+                            value: ExprIr::Binary {
+                                op: BinaryOp::RelationInsert,
+                                left: Box::new(ExprIr::FieldRef(memberships.clone())),
+                                right: Box::new(pair_alice_alpha.clone()),
+                            },
+                        },
+                        UpdateIr {
+                            field: pending.clone(),
+                            value: ExprIr::Binary {
+                                op: BinaryOp::RelationRemove,
+                                left: Box::new(ExprIr::FieldRef(pending.clone())),
+                                right: Box::new(pair_alice_alpha.clone()),
+                            },
+                        },
+                        UpdateIr {
+                            field: alpha_registered.clone(),
+                            value: ExprIr::Binary {
+                                op: BinaryOp::MapContainsKey,
+                                left: Box::new(ExprIr::FieldRef(plans.clone())),
+                                right: Box::new(alpha.clone()),
+                            },
+                        },
+                        UpdateIr {
+                            field: enterprise_alpha.clone(),
+                            value: ExprIr::Binary {
+                                op: BinaryOp::MapContainsEntry,
+                                left: Box::new(ExprIr::FieldRef(plans.clone())),
+                                right: Box::new(pair_beta_free.clone()),
+                            },
+                        },
+                    ],
+                },
+                ActionIr {
+                    action_id: "UPGRADE".to_string(),
+                    label: "UPGRADE".to_string(),
+                    reads: vec![plans.clone(), memberships.clone()],
+                    writes: vec![
+                        plans.clone(),
+                        alpha_registered.clone(),
+                        enterprise_alpha.clone(),
+                    ],
+                    path_tags: Vec::new(),
+                    guard: ExprIr::Binary {
+                        op: BinaryOp::And,
+                        left: Box::new(ExprIr::Binary {
+                            op: BinaryOp::MapContainsKey,
+                            left: Box::new(ExprIr::FieldRef(plans.clone())),
+                            right: Box::new(alpha.clone()),
+                        }),
+                        right: Box::new(ExprIr::Unary {
+                            op: crate::ir::UnaryOp::Not,
+                            expr: Box::new(ExprIr::Binary {
+                                op: BinaryOp::MapContainsEntry,
+                                left: Box::new(ExprIr::FieldRef(plans.clone())),
+                                right: Box::new(pair_alpha_enterprise.clone()),
+                            }),
+                        }),
+                    },
+                    updates: vec![
+                        UpdateIr {
+                            field: plans.clone(),
+                            value: ExprIr::Binary {
+                                op: BinaryOp::MapPut,
+                                left: Box::new(ExprIr::Binary {
+                                    op: BinaryOp::MapRemoveKey,
+                                    left: Box::new(ExprIr::FieldRef(plans.clone())),
+                                    right: Box::new(beta.clone()),
+                                }),
+                                right: Box::new(pair_alpha_enterprise.clone()),
+                            },
+                        },
+                        UpdateIr {
+                            field: alpha_registered.clone(),
+                            value: ExprIr::Literal(Value::Bool(true)),
+                        },
+                        UpdateIr {
+                            field: enterprise_alpha.clone(),
+                            value: ExprIr::Binary {
+                                op: BinaryOp::RelationContains,
+                                left: Box::new(ExprIr::FieldRef(memberships.clone())),
+                                right: Box::new(pair_alice_alpha.clone()),
+                            },
+                        },
+                    ],
+                },
+            ],
+            properties: vec![PropertyIr {
+                property_id: "P_SAFE".to_string(),
+                kind: PropertyKind::Invariant,
+                expr: ExprIr::Binary {
+                    op: BinaryOp::Or,
+                    left: Box::new(ExprIr::Binary {
+                        op: BinaryOp::RelationContains,
+                        left: Box::new(ExprIr::FieldRef(memberships)),
+                        right: Box::new(pair_alice_alpha),
+                    }),
+                    right: Box::new(ExprIr::Binary {
+                        op: BinaryOp::MapContainsEntry,
+                        left: Box::new(ExprIr::FieldRef(plans)),
+                        right: Box::new(pair_alpha_enterprise),
+                    }),
+                },
+            }],
+        }
+    }
 
     #[test]
     fn bmc_query_declares_actions_and_negates_terminal_property() {
@@ -774,6 +1539,53 @@ mod tests {
         assert!(query.check_smtlib.contains("(assert (<= 0 spend_0))"));
         assert!(query.check_smtlib.contains("(assert (<= spend_0 5000))"));
         assert!(query.check_smtlib.contains("(assert (<= spend_1 5000))"));
+    }
+
+    #[test]
+    fn relation_map_encoding_uses_slot_symbols_and_constraints() {
+        let query = build_invariant_bmc_query(&relation_map_model(), &["P_SAFE".to_string()], 1)
+            .expect("relation/map model should encode");
+        assert!(query
+            .check_smtlib
+            .contains("(declare-fun memberships_0_pair_0_0 () Bool)"));
+        assert!(query
+            .check_smtlib
+            .contains("(declare-fun plans_0_key_0_present () Bool)"));
+        assert!(query
+            .check_smtlib
+            .contains("(declare-fun plans_0_key_0_value () Int)"));
+        assert!(query
+            .check_smtlib
+            .contains("(assert (=> (not plans_0_key_0_present) (= plans_0_key_0_value 0)))"));
+        assert!(query
+            .check_smtlib
+            .contains("(= memberships_0_pair_0_0 false)"));
+        assert!(query.check_smtlib.contains("(= pending_0_pair_0_0 true)"));
+        assert!(query
+            .check_smtlib
+            .contains("(= plans_0_key_0_present true)"));
+        assert!(query
+            .check_smtlib
+            .contains("(= plans_0_key_1_present true)"));
+        assert!(query.check_smtlib.contains("(= plans_0_key_1_value 0)"));
+        assert!(query
+            .check_smtlib
+            .contains("(or (and pending_0_pair_0_0 pending_0_pair_0_0)"));
+        assert!(query
+            .check_smtlib
+            .contains("(and plans_0_key_1_present (= plans_0_key_1_value 0))"));
+        assert!(query
+            .check_smtlib
+            .contains("(= memberships_1_pair_0_0 true)"));
+        assert!(query.check_smtlib.contains("(= pending_1_pair_0_0 false)"));
+        assert!(query
+            .check_smtlib
+            .contains("(= plans_1_key_0_present true)"));
+        assert!(query.check_smtlib.contains("(= plans_1_key_0_value 1)"));
+        assert!(query
+            .check_smtlib
+            .contains("(= plans_1_key_1_present false)"));
+        assert!(query.check_smtlib.contains("(= plans_1_key_1_value 0)"));
     }
 
     #[test]

--- a/tests/e2e_relation_map_cvc5.rs
+++ b/tests/e2e_relation_map_cvc5.rs
@@ -1,0 +1,230 @@
+use std::process::Command;
+
+use valid::{
+    engine::{CheckOutcome, PropertySelection, RunPlan, RunStatus},
+    map_contains_entry, map_contains_key, map_put, map_remove,
+    modeling::{lower_machine_model, VerifiedMachine},
+    rel_contains, rel_insert, rel_intersects, rel_remove,
+    solver::{run_with_adapter, AdapterConfig},
+    valid_actions, valid_model, valid_state, FiniteMap, FiniteRelation, ValidEnum,
+};
+
+fn cvc5_path() -> Option<String> {
+    let output = Command::new("sh")
+        .arg("-c")
+        .arg("command -v cvc5")
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let path = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if path.is_empty() {
+        None
+    } else {
+        Some(path)
+    }
+}
+
+fn run_model<M: VerifiedMachine>(
+    property_id: &str,
+    backend: AdapterConfig,
+) -> (RunStatus, Vec<String>) {
+    let model = lower_machine_model::<M>().expect("machine model should lower");
+    let mut plan = RunPlan::default();
+    plan.property_selection = PropertySelection::ExactlyOne(property_id.to_string());
+    plan.search_bounds.max_depth = Some(4);
+    plan.detect_deadlocks = false;
+    let normalized = run_with_adapter(&model, &plan, &backend).expect("adapter should run");
+    let actions = normalized
+        .trace
+        .as_ref()
+        .map(|trace| {
+            trace
+                .steps
+                .iter()
+                .filter_map(|step| step.action_id.clone())
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+    match normalized.outcome {
+        CheckOutcome::Completed(result) => (result.status, actions),
+        CheckOutcome::Errored(error) => panic!("unexpected error: {:?}", error.diagnostics),
+    }
+}
+
+#[allow(dead_code)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, ValidEnum)]
+enum Member {
+    Alice,
+    Bob,
+}
+
+#[allow(dead_code)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, ValidEnum)]
+enum Tenant {
+    Alpha,
+    Beta,
+}
+
+#[allow(dead_code)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, ValidEnum)]
+enum Plan {
+    Free,
+    Enterprise,
+}
+
+valid_state! {
+    struct RelationMapState {
+        memberships: FiniteRelation<Member, Tenant> [relation],
+        pending: FiniteRelation<Member, Tenant> [relation],
+        plans: FiniteMap<Tenant, Plan> [map],
+        export_enabled: bool,
+        cross_tenant_access: bool,
+    }
+}
+
+valid_actions! {
+    enum RelationMapAction {
+        GrantMembership => "GRANT_MEMBERSHIP" [reads = ["pending", "memberships"], writes = ["pending", "memberships"]],
+        UpgradeAlpha => "UPGRADE_ALPHA" [reads = ["plans"], writes = ["plans"]],
+        RetireBeta => "RETIRE_BETA" [reads = ["plans"], writes = ["plans"]],
+        EnableExport => "ENABLE_EXPORT" [reads = ["memberships", "plans"], writes = ["export_enabled", "cross_tenant_access"]],
+        OpenLeak => "OPEN_LEAK" [reads = ["memberships", "plans"], writes = ["export_enabled", "cross_tenant_access"]],
+    }
+}
+
+valid_model! {
+    model RelationMapSafeModel<RelationMapState, RelationMapAction>;
+    init [RelationMapState {
+        memberships: FiniteRelation::empty(),
+        pending: rel_insert(FiniteRelation::empty(), Member::Alice, Tenant::Alpha),
+        plans: map_put(
+            map_put(FiniteMap::empty(), Tenant::Alpha, Plan::Free),
+            Tenant::Beta,
+            Plan::Free,
+        ),
+        export_enabled: false,
+        cross_tenant_access: false,
+    }];
+    transitions {
+        on GrantMembership {
+            when |state| rel_intersects(state.pending, state.pending)
+            => [RelationMapState {
+                memberships: rel_insert(state.memberships, Member::Alice, Tenant::Alpha),
+                pending: rel_remove(state.pending, Member::Alice, Tenant::Alpha),
+                plans: state.plans,
+                export_enabled: state.export_enabled,
+                cross_tenant_access: state.cross_tenant_access,
+            }];
+        }
+        on UpgradeAlpha {
+            when |state|
+                map_contains_key(state.plans, Tenant::Alpha)
+                && !map_contains_entry(state.plans, Tenant::Alpha, Plan::Enterprise)
+            => [RelationMapState {
+                memberships: state.memberships,
+                pending: state.pending,
+                plans: map_put(state.plans, Tenant::Alpha, Plan::Enterprise),
+                export_enabled: state.export_enabled,
+                cross_tenant_access: state.cross_tenant_access,
+            }];
+        }
+        on RetireBeta {
+            when |state| map_contains_entry(state.plans, Tenant::Beta, Plan::Free)
+            => [RelationMapState {
+                memberships: state.memberships,
+                pending: state.pending,
+                plans: map_remove(state.plans, Tenant::Beta),
+                export_enabled: state.export_enabled,
+                cross_tenant_access: state.cross_tenant_access,
+            }];
+        }
+        on EnableExport {
+            when |state|
+                rel_contains(state.memberships, Member::Alice, Tenant::Alpha)
+                && map_contains_entry(state.plans, Tenant::Alpha, Plan::Enterprise)
+            => [RelationMapState {
+                memberships: state.memberships,
+                pending: state.pending,
+                plans: state.plans,
+                export_enabled: true,
+                cross_tenant_access: false,
+            }];
+        }
+    }
+    properties {
+        invariant P_NO_CROSS_TENANT_ACCESS |state| state.cross_tenant_access == false;
+    }
+}
+
+valid_model! {
+    model RelationMapRegressionModel<RelationMapState, RelationMapAction>;
+    init [RelationMapState {
+        memberships: FiniteRelation::empty(),
+        pending: FiniteRelation::empty(),
+        plans: map_put(FiniteMap::empty(), Tenant::Beta, Plan::Enterprise),
+        export_enabled: false,
+        cross_tenant_access: false,
+    }];
+    transitions {
+        on OpenLeak {
+            when |state|
+                map_contains_key(state.plans, Tenant::Beta)
+                && !rel_contains(state.memberships, Member::Alice, Tenant::Alpha)
+            => [RelationMapState {
+                memberships: state.memberships,
+                pending: state.pending,
+                plans: state.plans,
+                export_enabled: true,
+                cross_tenant_access: true,
+            }];
+        }
+    }
+    properties {
+        invariant P_NO_CROSS_TENANT_ACCESS |state| state.cross_tenant_access == false;
+    }
+}
+
+#[test]
+fn relation_map_safe_model_matches_explicit_and_cvc5() {
+    let Some(cvc5) = cvc5_path() else {
+        return;
+    };
+
+    let explicit =
+        run_model::<RelationMapSafeModel>("P_NO_CROSS_TENANT_ACCESS", AdapterConfig::Explicit);
+    let smt = run_model::<RelationMapSafeModel>(
+        "P_NO_CROSS_TENANT_ACCESS",
+        AdapterConfig::SmtCvc5 {
+            executable: cvc5,
+            args: vec!["--lang".to_string(), "smt2".to_string()],
+        },
+    );
+
+    assert_eq!(explicit.0, RunStatus::Pass);
+    assert_eq!(explicit, smt);
+}
+
+#[test]
+fn relation_map_regression_matches_explicit_and_cvc5() {
+    let Some(cvc5) = cvc5_path() else {
+        return;
+    };
+
+    let explicit = run_model::<RelationMapRegressionModel>(
+        "P_NO_CROSS_TENANT_ACCESS",
+        AdapterConfig::Explicit,
+    );
+    let smt = run_model::<RelationMapRegressionModel>(
+        "P_NO_CROSS_TENANT_ACCESS",
+        AdapterConfig::SmtCvc5 {
+            executable: cvc5,
+            args: vec!["--lang".to_string(), "smt2".to_string()],
+        },
+    );
+
+    assert_eq!(explicit.0, RunStatus::Fail);
+    assert_eq!(explicit.1, vec!["OPEN_LEAK".to_string()]);
+    assert_eq!(explicit, smt);
+}


### PR DESCRIPTION
## Summary
- encode FiniteRelation fields as per-pair boolean SMT variables and FiniteMap fields as per-key presence/value SMT variables
- lower relation/map init values, carries, updates, equality, and helper operations into slot-level SMT constraints for cvc5
- add unit and real-cvc5 parity tests to check the generated constraints and compare smt-cvc5 with the explicit engine

## Testing
- cargo test -q -p valid

Closes #8
