### PR TITLE
CLI: エージェント消費向け設計改善

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,6 +30,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
 
 [[package]]
+name = "itoa"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+
+[[package]]
 name = "leb128"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -169,6 +175,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_json"
+version = "1.0.149"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+dependencies = [
+ "itoa 1.0.17",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -245,6 +264,8 @@ name = "valid"
 version = "0.1.0"
 dependencies = [
  "regex",
+ "serde",
+ "serde_json",
  "valid_derive",
  "varisat",
 ]
@@ -260,7 +281,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebe609851d1e9196674ac295f656bd8601200a1077343d22b345013497807caf"
 dependencies = [
  "anyhow",
- "itoa",
+ "itoa 0.4.8",
  "leb128",
  "log",
  "ordered-float",
@@ -300,7 +321,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d1dee4e21be1f04c0a939f7ae710cced47233a578de08a1b3c7d50848402636"
 dependencies = [
  "anyhow",
- "itoa",
+ "itoa 0.4.8",
  "thiserror",
  "varisat-formula",
 ]
@@ -339,3 +360,9 @@ name = "vec_mut_scan"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ed610a8d5e63d9c0e31300e8fdb55104c5f21e422743a9dc74848fa8317fd2"
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,4 +37,6 @@ path = "benchmarks/registries/iam_enterprise_registry.rs"
 [dependencies]
 valid_derive = { path = "packages/valid_derive" }
 regex = "1"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 varisat = { version = "0.2", optional = true }

--- a/packages/valid/src/bin/cargo-valid.rs
+++ b/packages/valid/src/bin/cargo-valid.rs
@@ -1,10 +1,11 @@
-use std::process::Command;
 use std::{
     env, fs,
+    io::{self, Read},
     path::{Path, PathBuf},
-    process,
+    process::{self, Command},
 };
 
+use serde_json::{json, Value};
 use valid::{
     api::{
         check_source, explain_source, explicit_analysis_warning, inspect_source, lint_source,
@@ -19,9 +20,14 @@ use valid::{
         render_benchmark_text,
     },
     bundled_models::{coverage_bundled_model, list_bundled_models},
+    cli::{
+        child_stream_to_json, detect_json_flag, detect_progress_json_flag, message_diagnostic,
+        parse_batch_request, render_batch_response, render_cli_error_json, render_commands_json,
+        render_commands_text, render_schema_json, usage_diagnostic, BatchResult, ExitCode,
+        ProgressReporter, Surface,
+    },
     coverage::{render_coverage_json, render_coverage_text},
-    engine::CheckOutcome,
-    evidence::{render_diagnostics_json, render_outcome_json, render_outcome_text},
+    evidence::{render_outcome_json, render_outcome_text},
     project::{
         load_project_config, render_project_config_template, render_registry_source_template,
         ProjectConfig,
@@ -38,7 +44,15 @@ use valid::{
 };
 
 fn main() {
-    let parsed = maybe_auto_discover_external(parse_cli(env::args().skip(1).collect()));
+    let raw_args = env::args().skip(1).collect::<Vec<_>>();
+    let parsed = parse_cli(raw_args.clone());
+    match parsed.command.as_str() {
+        "commands" => cmd_commands(parsed.json),
+        "schema" => cmd_schema(&parsed),
+        "batch" => cmd_batch(&parsed),
+        _ => {}
+    }
+    let parsed = maybe_auto_discover_external(parsed);
     if parsed.command == "init" {
         cmd_init(&parsed);
     }
@@ -60,6 +74,7 @@ fn main() {
 
     let local_args = ParsedArgs {
         json: parsed.json,
+        progress_json: parsed.progress_json,
         model: parsed.model,
         repeat: parsed.repeat,
         baseline_mode: parsed.baseline_mode,
@@ -101,7 +116,7 @@ fn main() {
 }
 
 fn primary_usage() -> String {
-    "usage: cargo valid [--manifest-path <path>] [--registry <path>|--file <path>|--example <name>|--bin <name>] <init|models|inspect|graph|readiness|migrate|benchmark|verify|suite|explain|coverage|orchestrate|generate-tests|replay|clean> [model] [--json] [--format=<mermaid|dot|svg|text|json>] [--view=<overview|logic>] [--property=<id>] [--backend=<explicit|mock-bmc|sat-varisat|smt-cvc5|command>] [--solver-exec <path>] [--solver-arg <arg>] [--focus-action=<id>] [--actions=a,b,c] [--strategy=<counterexample|transition|witness|guard|boundary|path|random>] [--repeat=<n>] [--baseline[=compare|record|ignore]] [--threshold-percent=<n>] [--write[=<path>]] [--check]".to_string()
+    "usage: cargo valid [--manifest-path <path>] [--registry <path>|--file <path>|--example <name>|--bin <name>] <init|models|inspect|graph|readiness|migrate|benchmark|verify|suite|explain|coverage|orchestrate|generate-tests|replay|clean|commands|schema|batch> [model] [--json] [--progress=json] [--format=<mermaid|dot|svg|text|json>] [--view=<overview|logic>] [--property=<id>] [--backend=<explicit|mock-bmc|sat-varisat|smt-cvc5|command>] [--solver-exec <path>] [--solver-arg <arg>] [--focus-action=<id>] [--actions=a,b,c] [--strategy=<counterexample|transition|witness|guard|boundary|path|random>] [--repeat=<n>] [--baseline[=compare|record|ignore]] [--threshold-percent=<n>] [--write[=<path>]] [--check]".to_string()
 }
 
 fn internal_bundled_mode_enabled() -> bool {
@@ -122,13 +137,18 @@ fn run_external_registry(parsed: CliArgs) -> ! {
     let status = build_external_command(&parsed)
         .status()
         .unwrap_or_else(|err| {
-            eprintln!("failed to execute target registry: {err}");
-            process::exit(3);
+            message_exit(
+                &parsed.command,
+                parsed.json,
+                &format!("failed to execute target registry: {err}"),
+                None,
+            );
         });
-    process::exit(status.code().unwrap_or(1));
+    process::exit(to_exit_code(status.code().unwrap_or(ExitCode::Error.code())).code());
 }
 
 fn run_external_benchmark(parsed: CliArgs) -> ! {
+    let progress = ProgressReporter::new("benchmark", parsed.progress_json);
     let models = if parsed.benchmark_models.is_empty() {
         if parsed.suite_models.is_empty() {
             fetch_external_models(&parsed)
@@ -138,10 +158,13 @@ fn run_external_benchmark(parsed: CliArgs) -> ! {
     } else {
         parsed.benchmark_models.clone()
     };
-    let mut aggregate_status = 0;
+    let total = models.len();
+    let mut aggregate_status = ExitCode::Success;
     let mut json_runs = Vec::new();
+    progress.start(Some(total));
 
-    for model in models {
+    for (index, model) in models.into_iter().enumerate() {
+        progress.item_start(index, total, &model);
         let output = build_external_command(&CliArgs {
             command: "benchmark".to_string(),
             model: Some(model.clone()),
@@ -158,6 +181,7 @@ fn run_external_benchmark(parsed: CliArgs) -> ! {
             actions: Vec::new(),
             focus_action_id: None,
             json: parsed.json,
+            progress_json: false,
             manifest_path: parsed.manifest_path.clone(),
             example: parsed.example.clone(),
             bin: parsed.bin.clone(),
@@ -169,13 +193,17 @@ fn run_external_benchmark(parsed: CliArgs) -> ! {
         })
         .output()
         .unwrap_or_else(|err| {
-            eprintln!("failed to execute target registry: {err}");
-            process::exit(3);
+            message_exit(
+                "benchmark",
+                parsed.json,
+                &format!("failed to execute target registry: {err}"),
+                None,
+            );
         });
-        let code = output.status.code().unwrap_or(1);
-        aggregate_status = aggregate_exit_code(aggregate_status, code);
+        let code = to_exit_code(output.status.code().unwrap_or(ExitCode::Error.code()));
+        aggregate_status = aggregate_status.aggregate(code);
         if parsed.json {
-            json_runs.push(String::from_utf8_lossy(&output.stdout).trim().to_string());
+            json_runs.push(preferred_child_json(&output));
         } else {
             println!("== {model} ==");
             print!("{}", String::from_utf8_lossy(&output.stdout));
@@ -184,33 +212,38 @@ fn run_external_benchmark(parsed: CliArgs) -> ! {
                 eprint!("{stderr}");
             }
         }
+        progress.item_complete(index, total, &model, code.code());
     }
 
     if parsed.json {
-        let body = format!("{{\"runs\":[{}]}}", json_runs.join(","));
-        if let Some(path) = write_benchmark_artifact("project-benchmark-suite", &body) {
-            println!(
-                "{{\"artifact_path\":\"{}\",\"runs\":[{}]}}",
-                path.replace('\\', "\\\\"),
-                json_runs.join(",")
-            );
-        } else {
-            println!("{body}");
+        let mut body = json!({ "runs": json_runs });
+        let body_string = serde_json::to_string(&body).expect("benchmark suite json");
+        if let Some(path) = write_benchmark_artifact("project-benchmark-suite", &body_string) {
+            body["artifact_path"] = Value::String(path);
         }
+        println!(
+            "{}",
+            serde_json::to_string(&body).expect("benchmark suite output")
+        );
     }
-    process::exit(aggregate_status);
+    progress.finish(aggregate_status);
+    process::exit(aggregate_status.code());
 }
 
 fn run_external_all(parsed: CliArgs) -> ! {
+    let progress = ProgressReporter::new("all", parsed.progress_json);
     let models = if parsed.suite_models.is_empty() {
         fetch_external_models(&parsed)
     } else {
         parsed.suite_models.clone()
     };
-    let mut aggregate_status = 0;
+    let total = models.len();
+    let mut aggregate_status = ExitCode::Success;
     let mut json_runs = Vec::new();
+    progress.start(Some(total));
 
-    for model in models {
+    for (index, model) in models.into_iter().enumerate() {
+        progress.item_start(index, total, &model);
         let mut command = build_external_command(&CliArgs {
             command: "check".to_string(),
             model: Some(model.clone()),
@@ -220,13 +253,14 @@ fn run_external_all(parsed: CliArgs) -> ! {
             strategy: None,
             format: parsed.format.clone(),
             view: parsed.view.clone(),
-            property_id: None,
+            property_id: parsed.property_id.clone(),
             backend: parsed.backend.clone(),
             solver_executable: parsed.solver_executable.clone(),
             solver_args: parsed.solver_args.clone(),
             actions: Vec::new(),
             focus_action_id: None,
             json: parsed.json,
+            progress_json: false,
             manifest_path: parsed.manifest_path.clone(),
             example: parsed.example.clone(),
             bin: parsed.bin.clone(),
@@ -237,14 +271,17 @@ fn run_external_all(parsed: CliArgs) -> ! {
             check: false,
         });
         let output = command.output().unwrap_or_else(|err| {
-            eprintln!("failed to execute target registry: {err}");
-            process::exit(3);
+            message_exit(
+                "all",
+                parsed.json,
+                &format!("failed to execute target registry: {err}"),
+                None,
+            );
         });
-        let code = output.status.code().unwrap_or(1);
-        aggregate_status = aggregate_exit_code(aggregate_status, code);
+        let code = to_exit_code(output.status.code().unwrap_or(ExitCode::Error.code()));
+        aggregate_status = aggregate_status.aggregate(code);
         if parsed.json {
-            let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
-            json_runs.push(stdout);
+            json_runs.push(preferred_child_json(&output));
         } else {
             println!("== {model} ==");
             print!("{}", String::from_utf8_lossy(&output.stdout));
@@ -253,12 +290,17 @@ fn run_external_all(parsed: CliArgs) -> ! {
                 eprint!("{stderr}");
             }
         }
+        progress.item_complete(index, total, &model, code.code());
     }
 
     if parsed.json {
-        println!("{{\"runs\":[{}]}}", json_runs.join(","));
+        println!(
+            "{}",
+            serde_json::to_string(&json!({ "runs": json_runs })).expect("suite json")
+        );
     }
-    process::exit(aggregate_status);
+    progress.finish(aggregate_status);
+    process::exit(aggregate_status.code());
 }
 
 fn build_external_command(parsed: &CliArgs) -> Command {
@@ -337,6 +379,9 @@ fn build_external_command(parsed: &CliArgs) -> Command {
     if parsed.json {
         command.arg("--json");
     }
+    if parsed.progress_json {
+        command.arg("--progress=json");
+    }
     command
 }
 
@@ -357,6 +402,7 @@ fn fetch_external_models(parsed: &CliArgs) -> Vec<String> {
         actions: Vec::new(),
         focus_action_id: None,
         json: true,
+        progress_json: false,
         manifest_path: parsed.manifest_path.clone(),
         example: parsed.example.clone(),
         bin: parsed.bin.clone(),
@@ -368,17 +414,22 @@ fn fetch_external_models(parsed: &CliArgs) -> Vec<String> {
     })
     .output()
     .unwrap_or_else(|err| {
-        eprintln!("failed to execute target registry: {err}");
-        process::exit(3);
+        message_exit(
+            "list",
+            true,
+            &format!("failed to execute target registry: {err}"),
+            None,
+        );
     });
     if !output.status.success() {
         eprint!("{}", String::from_utf8_lossy(&output.stderr));
-        process::exit(output.status.code().unwrap_or(3));
+        process::exit(to_exit_code(output.status.code().unwrap_or(ExitCode::Error.code())).code());
     }
     parse_models_json(&String::from_utf8_lossy(&output.stdout))
 }
 
 fn cmd_all(parsed: ParsedArgs) {
+    let progress = ProgressReporter::new("all", parsed.progress_json);
     let models = if parsed.suite_models.is_empty() {
         list_bundled_models()
     } else {
@@ -388,10 +439,13 @@ fn cmd_all(parsed: ParsedArgs) {
             .map(String::as_str)
             .collect::<Vec<_>>()
     };
-    let mut aggregate_status = 0;
+    let total = models.len();
+    let mut aggregate_status = ExitCode::Success;
     let mut json_runs = Vec::new();
+    progress.start(Some(total));
 
-    for model in models {
+    for (index, model) in models.into_iter().enumerate() {
+        progress.item_start(index, total, model);
         let request = CheckRequest {
             request_id: format!("cargo-valid-check-{model}"),
             source_name: normalized_model_ref(model),
@@ -402,20 +456,22 @@ fn cmd_all(parsed: ParsedArgs) {
             solver_args: parsed.solver_args.clone(),
         };
         let outcome = check_source(&request);
-        let exit_code = outcome_exit_code(&outcome);
-        aggregate_status = aggregate_exit_code(aggregate_status, exit_code);
+        let exit_code = ExitCode::from_check_outcome(&outcome);
+        aggregate_status = aggregate_status.aggregate(exit_code);
         if parsed.json {
             json_runs.push(render_outcome_json(model, &outcome));
         } else {
             println!("== {model} ==");
             print!("{}", render_outcome_text(&outcome));
         }
+        progress.item_complete(index, total, model, exit_code.code());
     }
 
     if parsed.json {
         println!("{{\"runs\":[{}]}}", json_runs.join(","));
     }
-    process::exit(aggregate_status);
+    progress.finish(aggregate_status);
+    process::exit(aggregate_status.code());
 }
 
 fn cmd_list(parsed: ParsedArgs) {
@@ -437,6 +493,8 @@ fn cmd_list(parsed: ParsedArgs) {
 }
 
 fn cmd_inspect(parsed: ParsedArgs) {
+    let progress = ProgressReporter::new("inspect", parsed.progress_json);
+    progress.start(None);
     let model = parsed
         .model
         .unwrap_or_else(|| usage_exit("usage: cargo valid inspect <model> [--json]"));
@@ -452,21 +510,15 @@ fn cmd_inspect(parsed: ParsedArgs) {
             } else {
                 print!("{}", render_inspect_text(&response));
             }
+            progress.finish(ExitCode::Success);
         }
-        Err(diagnostics) => {
-            if parsed.json {
-                println!("{}", render_diagnostics_json(&diagnostics));
-            } else {
-                for diagnostic in diagnostics {
-                    eprintln!("{}", diagnostic.message);
-                }
-            }
-            process::exit(3);
-        }
+        Err(diagnostics) => diagnostics_exit("inspect", parsed.json, &diagnostics),
     }
 }
 
 fn cmd_graph(parsed: ParsedArgs) {
+    let progress = ProgressReporter::new("graph", parsed.progress_json);
+    progress.start(None);
     let model = parsed.model.unwrap_or_else(|| {
         usage_exit(
             "usage: cargo valid graph <model> [--format=mermaid|dot|svg|text|json] [--view=overview|logic]",
@@ -483,6 +535,7 @@ fn cmd_graph(parsed: ParsedArgs) {
         .as_deref()
         .or(env_default_format.as_deref())
         .unwrap_or("mermaid");
+    let json_output = parsed.json || default_format == "json";
     let view = GraphView::parse(parsed.view.as_deref());
     match inspect_source(&request) {
         Ok(response) => match default_format {
@@ -492,20 +545,14 @@ fn cmd_graph(parsed: ParsedArgs) {
             "svg" => println!("{}", render_model_svg_with_view(&response, view)),
             _ => println!("{}", render_model_mermaid_with_view(&response, view)),
         },
-        Err(diagnostics) => {
-            if parsed.json || matches!(parsed.format.as_deref(), Some("json")) {
-                println!("{}", render_diagnostics_json(&diagnostics));
-            } else {
-                for diagnostic in diagnostics {
-                    eprintln!("{}", diagnostic.message);
-                }
-            }
-            process::exit(3);
-        }
+        Err(diagnostics) => diagnostics_exit("graph", json_output, &diagnostics),
     }
+    progress.finish(ExitCode::Success);
 }
 
 fn cmd_lint(parsed: ParsedArgs) {
+    let progress = ProgressReporter::new("lint", parsed.progress_json);
+    progress.start(None);
     let model = parsed
         .model
         .unwrap_or_else(|| usage_exit("usage: cargo valid lint <model> [--json]"));
@@ -525,22 +572,21 @@ fn cmd_lint(parsed: ParsedArgs) {
                 .findings
                 .iter()
                 .any(|finding| matches!(finding.severity.as_str(), "warn" | "error"));
-            process::exit(if has_findings { 2 } else { 0 });
-        }
-        Err(diagnostics) => {
-            if parsed.json {
-                println!("{}", render_diagnostics_json(&diagnostics));
+            let exit_code = if has_findings {
+                ExitCode::Fail
             } else {
-                for diagnostic in diagnostics {
-                    eprintln!("{}", diagnostic.message);
-                }
-            }
-            process::exit(3);
+                ExitCode::Success
+            };
+            progress.finish(exit_code);
+            process::exit(exit_code.code());
         }
+        Err(diagnostics) => diagnostics_exit("lint", parsed.json, &diagnostics),
     }
 }
 
 fn cmd_benchmark(parsed: ParsedArgs) {
+    let progress = ProgressReporter::new("benchmark", parsed.progress_json);
+    progress.start(None);
     let model = parsed.model.unwrap_or_else(|| {
         usage_exit("usage: cargo valid benchmark <model> [--json] [--property=<id>] [--repeat=<n>] [--baseline[=compare|record|ignore]] [--threshold-percent=<n>]")
     });
@@ -612,27 +658,28 @@ fn cmd_benchmark(parsed: ParsedArgs) {
     }
     let exit_code = if baseline_mode == "ignore" {
         if summary.error_count > 0 {
-            3
-        } else if summary.fail_count > 0 {
-            2
+            ExitCode::Error
+        } else if summary.fail_count > 0 || regression_detected {
+            ExitCode::Fail
         } else if summary.unknown_count > 0 {
-            4
-        } else if regression_detected {
-            5
+            ExitCode::Unknown
         } else {
-            0
+            ExitCode::Success
         }
     } else if summary.error_count > 0 {
-        3
+        ExitCode::Error
     } else if regression_detected {
-        5
+        ExitCode::Fail
     } else {
-        0
+        ExitCode::Success
     };
-    process::exit(exit_code);
+    progress.finish(exit_code);
+    process::exit(exit_code.code());
 }
 
 fn cmd_migrate(parsed: ParsedArgs) {
+    let progress = ProgressReporter::new("migrate", parsed.progress_json);
+    progress.start(None);
     let model = parsed.model.unwrap_or_else(|| {
         usage_exit("usage: cargo valid migrate <model> [--json] [--write[=<path>]] [--check]")
     });
@@ -670,32 +717,26 @@ fn cmd_migrate(parsed: ParsedArgs) {
             }
             let exit_code = if parsed.check {
                 match migration.check.as_ref().map(|check| check.status.as_str()) {
-                    Some("already-declarative") => 0,
-                    Some("no-candidates") => 2,
-                    Some("candidate-complete") | Some("partial") => 6,
-                    _ => 3,
+                    Some("already-declarative") => ExitCode::Success,
+                    Some("no-candidates") => ExitCode::Unknown,
+                    Some("candidate-complete") | Some("partial") => ExitCode::Fail,
+                    _ => ExitCode::Error,
                 }
             } else if migration.snippets.is_empty() {
-                2
+                ExitCode::Unknown
             } else {
-                0
+                ExitCode::Success
             };
-            process::exit(exit_code);
+            progress.finish(exit_code);
+            process::exit(exit_code.code());
         }
-        Err(diagnostics) => {
-            if parsed.json {
-                println!("{}", render_diagnostics_json(&diagnostics));
-            } else {
-                for diagnostic in diagnostics {
-                    eprintln!("{}", diagnostic.message);
-                }
-            }
-            process::exit(3);
-        }
+        Err(diagnostics) => diagnostics_exit("migrate", parsed.json, &diagnostics),
     }
 }
 
 fn cmd_check(parsed: ParsedArgs) {
+    let progress = ProgressReporter::new("check", parsed.progress_json);
+    progress.start(None);
     let model = parsed.model.unwrap_or_else(|| usage_exit("usage: cargo valid check <model> [--json] [--property=<id>] [--backend=<explicit|mock-bmc|sat-varisat|smt-cvc5|command>] [--solver-exec <path>] [--solver-arg <arg>]"));
     let inspect_request = InspectRequest {
         request_id: "cargo-valid-check-preflight".to_string(),
@@ -705,7 +746,11 @@ fn cmd_check(parsed: ParsedArgs) {
     if matches!(parsed.backend.as_deref(), None | Some("explicit")) {
         if let Ok(inspect) = inspect_source(&inspect_request) {
             if let Some(warning) = explicit_analysis_warning(&inspect) {
-                eprintln!("{warning}");
+                if parsed.json {
+                    eprintln!("{}", valid::cli::render_cli_warning_json("check", &warning));
+                } else {
+                    eprintln!("{warning}");
+                }
             }
         }
     }
@@ -724,17 +769,14 @@ fn cmd_check(parsed: ParsedArgs) {
     } else {
         print!("{}", render_outcome_text(&outcome));
     }
-    process::exit(match outcome {
-        CheckOutcome::Completed(result) => match result.status {
-            valid::engine::RunStatus::Pass => 0,
-            valid::engine::RunStatus::Fail => 2,
-            valid::engine::RunStatus::Unknown => 4,
-        },
-        CheckOutcome::Errored(_) => 3,
-    });
+    let exit_code = ExitCode::from_check_outcome(&outcome);
+    progress.finish(exit_code);
+    process::exit(exit_code.code());
 }
 
 fn cmd_explain(parsed: ParsedArgs) {
+    let progress = ProgressReporter::new("explain", parsed.progress_json);
+    progress.start(None);
     let model = parsed
         .model
         .unwrap_or_else(|| usage_exit("usage: cargo valid explain <model> [--json]"));
@@ -754,36 +796,31 @@ fn cmd_explain(parsed: ParsedArgs) {
             } else {
                 print!("{}", render_explain_text(&response));
             }
+            progress.finish(ExitCode::Success);
         }
-        Err(error) => {
-            if parsed.json {
-                println!("{}", render_diagnostics_json(&error.diagnostics));
-            } else {
-                for diagnostic in error.diagnostics {
-                    eprintln!("{}", diagnostic.message);
-                }
-            }
-            process::exit(3);
-        }
+        Err(error) => diagnostics_exit("explain", parsed.json, &error.diagnostics),
     }
 }
 
 fn cmd_coverage(parsed: ParsedArgs) {
+    let progress = ProgressReporter::new("coverage", parsed.progress_json);
+    progress.start(None);
     let model = parsed
         .model
         .unwrap_or_else(|| usage_exit("usage: cargo valid coverage <model> [--json]"));
-    let report = coverage_bundled_model(&normalized_model_ref(&model)).unwrap_or_else(|message| {
-        eprintln!("{message}");
-        process::exit(3);
-    });
+    let report = coverage_bundled_model(&normalized_model_ref(&model))
+        .unwrap_or_else(|message| message_exit("coverage", parsed.json, &message, None));
     if parsed.json {
         println!("{}", render_coverage_json(&report));
     } else {
         println!("{}", render_coverage_text(&report));
     }
+    progress.finish(ExitCode::Success);
 }
 
 fn cmd_orchestrate(parsed: ParsedArgs) {
+    let progress = ProgressReporter::new("orchestrate", parsed.progress_json);
+    progress.start(None);
     let model = parsed.model.unwrap_or_else(|| usage_exit("usage: cargo valid orchestrate <model> [--json] [--backend=<explicit|mock-bmc|sat-varisat|smt-cvc5|command>] [--solver-exec <path>] [--solver-arg <arg>]"));
     let request = OrchestrateRequest {
         request_id: "cargo-valid-orchestrate".to_string(),
@@ -821,21 +858,15 @@ fn cmd_orchestrate(parsed: ParsedArgs) {
                     println!("property_id: {} status: {}", run.property_id, run.status);
                 }
             }
+            progress.finish(ExitCode::Success);
         }
-        Err(error) => {
-            if parsed.json {
-                println!("{}", render_diagnostics_json(&error.diagnostics));
-            } else {
-                for diagnostic in error.diagnostics {
-                    eprintln!("{}", diagnostic.message);
-                }
-            }
-            process::exit(3);
-        }
+        Err(error) => diagnostics_exit("orchestrate", parsed.json, &error.diagnostics),
     }
 }
 
 fn cmd_testgen(parsed: ParsedArgs) {
+    let progress = ProgressReporter::new("testgen", parsed.progress_json);
+    progress.start(None);
     let model = parsed.model.unwrap_or_else(|| usage_exit("usage: cargo valid testgen <model> [--json] [--strategy=<counterexample|transition|witness|guard|boundary|path|random>]"));
     let request = TestgenRequest {
         request_id: "cargo-valid-testgen".to_string(),
@@ -890,21 +921,15 @@ fn cmd_testgen(parsed: ParsedArgs) {
                     }
                 }
             }
+            progress.finish(ExitCode::Success);
         }
-        Err(error) => {
-            if parsed.json {
-                println!("{}", render_diagnostics_json(&error.diagnostics));
-            } else {
-                for diagnostic in error.diagnostics {
-                    eprintln!("{}", diagnostic.message);
-                }
-            }
-            process::exit(3);
-        }
+        Err(error) => diagnostics_exit("testgen", parsed.json, &error.diagnostics),
     }
 }
 
 fn cmd_replay(parsed: ParsedArgs) {
+    let progress = ProgressReporter::new("replay", parsed.progress_json);
+    progress.start(None);
     let model = parsed
         .model
         .unwrap_or_else(|| usage_exit("usage: cargo valid replay <model> [--json] [--property=<id>] [--focus-action=<id>] [--actions=a,b,c]"));
@@ -914,14 +939,14 @@ fn cmd_replay(parsed: ParsedArgs) {
         &parsed.actions,
         parsed.focus_action_id.as_deref(),
     )
-    .unwrap_or_else(|message| {
-        eprintln!("{message}");
-        process::exit(3);
-    });
+    .unwrap_or_else(|message| message_exit("replay", parsed.json, &message, None));
     println!("{output}");
+    progress.finish(ExitCode::Success);
 }
 
 fn cmd_clean(parsed: &CliArgs) -> ! {
+    let progress = ProgressReporter::new("clean", parsed.progress_json);
+    progress.start(None);
     let scope = parsed.model.as_deref().unwrap_or("all");
     let root = clean_root(parsed);
     let mut removed = Vec::new();
@@ -937,7 +962,7 @@ fn cmd_clean(parsed: &CliArgs) -> ! {
             removed.extend(clean_artifacts(&root));
         }
         other => usage_exit(&format!(
-            "usage: cargo valid clean [generated|artifacts|all] [--json]\nunknown clean scope `{other}`"
+            "usage: cargo valid clean [generated|artifacts|all] [--json] [--progress=json]\nunknown clean scope `{other}`"
         )),
     }
     if parsed.json {
@@ -960,12 +985,14 @@ fn cmd_clean(parsed: &CliArgs) -> ! {
             }
         }
     }
-    process::exit(0);
+    progress.finish(ExitCode::Success);
+    process::exit(ExitCode::Success.code());
 }
 
 #[derive(Default)]
 struct ParsedArgs {
     json: bool,
+    progress_json: bool,
     model: Option<String>,
     repeat: usize,
     baseline_mode: Option<String>,
@@ -1005,6 +1032,7 @@ struct CliArgs {
     actions: Vec<String>,
     focus_action_id: Option<String>,
     json: bool,
+    progress_json: bool,
     suite_models: Vec<String>,
     benchmark_models: Vec<String>,
     write_path: Option<String>,
@@ -1013,6 +1041,8 @@ struct CliArgs {
 
 fn parse_cli(args: Vec<String>) -> CliArgs {
     let mut parsed = CliArgs::default();
+    parsed.json = detect_json_flag(&args);
+    parsed.progress_json = detect_progress_json_flag(&args);
     let normalized_args = if matches!(args.first().map(String::as_str), Some("valid")) {
         args.into_iter().skip(1).collect::<Vec<_>>()
     } else {
@@ -1033,6 +1063,8 @@ fn parse_cli(args: Vec<String>) -> CliArgs {
             }
             "--solver-arg" => parsed.solver_args.push(next_arg(&mut iter, "--solver-arg")),
             "--json" => parsed.json = true,
+            "--progress=json" => parsed.progress_json = true,
+            _ if arg.starts_with("--progress=") => usage_exit("`--progress` only supports `json`"),
             "--check" => parsed.check = true,
             "--write" => parsed.write_path = Some(String::new()),
             _ if arg.starts_with("--write=") => {
@@ -1132,7 +1164,10 @@ struct ExternalTarget {
 }
 
 fn maybe_auto_discover_external(mut parsed: CliArgs) -> CliArgs {
-    if matches!(parsed.command.as_str(), "clean" | "init" | "help") {
+    if matches!(
+        parsed.command.as_str(),
+        "clean" | "init" | "help" | "commands" | "schema" | "batch"
+    ) {
         return parsed;
     }
     let current_dir = project_root(&parsed);
@@ -1194,8 +1229,7 @@ fn maybe_auto_discover_external(mut parsed: CliArgs) -> CliArgs {
         }
         Ok(None) => {}
         Err(message) => {
-            eprintln!("{message}");
-            process::exit(3);
+            message_exit("cargo-valid", parsed.json, &message, None);
         }
     }
     if parsed.file.is_some() || parsed.example.is_some() || parsed.bin.is_some() {
@@ -1316,30 +1350,199 @@ fn parse_models_json(stdout: &str) -> Vec<String> {
         .collect()
 }
 
-fn outcome_exit_code(outcome: &CheckOutcome) -> i32 {
-    match outcome {
-        CheckOutcome::Completed(result) => match result.status {
-            valid::engine::RunStatus::Pass => 0,
-            valid::engine::RunStatus::Fail => 2,
-            valid::engine::RunStatus::Unknown => 4,
-        },
-        CheckOutcome::Errored(_) => 3,
-    }
-}
-
-fn aggregate_exit_code(current: i32, next: i32) -> i32 {
-    match (current, next) {
-        (3, _) | (_, 3) => 3,
-        (2, _) | (_, 2) => 2,
-        (4, _) | (_, 4) => 4,
-        (5, _) | (_, 5) => 5,
-        _ => 0,
-    }
-}
-
 fn usage_exit(usage: &str) -> ! {
-    eprintln!("{usage}");
-    process::exit(3);
+    if detect_json_flag(&env::args().skip(1).collect::<Vec<_>>()) {
+        eprintln!(
+            "{}",
+            render_cli_error_json(
+                "cargo-valid",
+                &[usage_diagnostic("invalid command arguments", usage)],
+                Some(usage),
+            )
+        );
+    } else {
+        eprintln!("{usage}");
+    }
+    process::exit(ExitCode::Error.code());
+}
+
+fn to_exit_code(code: i32) -> ExitCode {
+    match code {
+        0 => ExitCode::Success,
+        1 => ExitCode::Fail,
+        2 => ExitCode::Unknown,
+        4 => ExitCode::Unknown,
+        5 | 6 => ExitCode::Fail,
+        _ => ExitCode::Error,
+    }
+}
+
+fn preferred_child_json(output: &process::Output) -> Value {
+    if !String::from_utf8_lossy(&output.stdout).trim().is_empty() {
+        child_stream_to_json(&output.stdout)
+    } else {
+        child_stream_to_json(&output.stderr)
+    }
+}
+
+fn message_exit(command: &str, json: bool, message: &str, usage: Option<&str>) -> ! {
+    if json {
+        eprintln!(
+            "{}",
+            render_cli_error_json(command, &[message_diagnostic(message)], usage)
+        );
+    } else {
+        if let Some(usage) = usage {
+            eprintln!("{usage}");
+        }
+        eprintln!("{message}");
+    }
+    process::exit(ExitCode::Error.code());
+}
+
+fn diagnostics_exit(
+    command: &str,
+    json: bool,
+    diagnostics: &[valid::support::diagnostics::Diagnostic],
+) -> ! {
+    if json {
+        eprintln!("{}", render_cli_error_json(command, diagnostics, None));
+    } else {
+        for diagnostic in diagnostics {
+            eprintln!("{}", diagnostic.message);
+        }
+    }
+    process::exit(ExitCode::Error.code());
+}
+
+fn cmd_commands(json: bool) {
+    if json {
+        println!("{}", render_commands_json(Surface::CargoValid));
+    } else {
+        println!("{}", render_commands_text(Surface::CargoValid));
+    }
+    process::exit(ExitCode::Success.code());
+}
+
+fn cmd_schema(parsed: &CliArgs) -> ! {
+    let command = parsed.model.as_deref().unwrap_or_else(|| {
+        message_exit(
+            "schema",
+            true,
+            "missing command name",
+            Some("usage: cargo valid schema <command>"),
+        )
+    });
+    match render_schema_json(Surface::CargoValid, &normalize_command(command)) {
+        Ok(body) => println!("{body}"),
+        Err(message) => message_exit(
+            "schema",
+            true,
+            &message,
+            Some("usage: cargo valid schema <command>"),
+        ),
+    }
+    process::exit(ExitCode::Success.code());
+}
+
+fn cmd_batch(parsed: &CliArgs) -> ! {
+    let progress = ProgressReporter::new("batch", parsed.progress_json);
+    let mut stdin = String::new();
+    io::stdin()
+        .read_to_string(&mut stdin)
+        .unwrap_or_else(|err| {
+            message_exit(
+                "batch",
+                parsed.json,
+                &format!("failed to read stdin: {err}"),
+                None,
+            )
+        });
+    let request = parse_batch_request(&stdin).unwrap_or_else(|message| {
+        message_exit(
+            "batch",
+            true,
+            &message,
+            Some("usage: cargo valid batch [--json] [--progress=json] < batch.json"),
+        )
+    });
+    let total = request.operations.len();
+    progress.start(Some(total));
+    let current_exe = env::current_exe().unwrap_or_else(|err| {
+        message_exit(
+            "batch",
+            parsed.json,
+            &format!("failed to resolve current executable: {err}"),
+            None,
+        )
+    });
+    let mut aggregate = ExitCode::Success;
+    let mut results = Vec::new();
+    for (index, operation) in request.operations.into_iter().enumerate() {
+        progress.item_start(index, total, &operation.command);
+        let mut command_args = Vec::new();
+        if let Some(manifest_path) = &parsed.manifest_path {
+            command_args.push("--manifest-path".to_string());
+            command_args.push(manifest_path.clone());
+        }
+        if let Some(file) = &parsed.file {
+            command_args.push("--file".to_string());
+            command_args.push(file.clone());
+        }
+        if let Some(example) = &parsed.example {
+            command_args.push("--example".to_string());
+            command_args.push(example.clone());
+        }
+        if let Some(bin) = &parsed.bin {
+            command_args.push("--bin".to_string());
+            command_args.push(bin.clone());
+        }
+        command_args.push(operation.command.clone());
+        let mut operation_args = operation.args.clone();
+        if operation.json
+            && !operation_args
+                .iter()
+                .any(|arg| arg == "--json" || arg.starts_with("--format="))
+        {
+            if operation.command == "graph" {
+                operation_args.push("--format=json".to_string());
+            } else {
+                operation_args.push("--json".to_string());
+            }
+        }
+        command_args.extend(operation_args.clone());
+        let output = Command::new(&current_exe)
+            .args(&command_args)
+            .output()
+            .unwrap_or_else(|err| {
+                message_exit(
+                    "batch",
+                    true,
+                    &format!(
+                        "failed to execute batch operation `{}`: {err}",
+                        operation.command
+                    ),
+                    None,
+                )
+            });
+        let exit_code = output.status.code().unwrap_or(ExitCode::Error.code());
+        aggregate = aggregate.aggregate(to_exit_code(exit_code));
+        results.push(BatchResult {
+            index,
+            command: operation.command.clone(),
+            args: operation_args,
+            exit_code,
+            stdout: child_stream_to_json(&output.stdout),
+            stderr: child_stream_to_json(&output.stderr),
+        });
+        progress.item_complete(index, total, &operation.command, exit_code);
+        if exit_code != 0 && !request.continue_on_error {
+            break;
+        }
+    }
+    progress.finish(aggregate);
+    println!("{}", render_batch_response(aggregate, results));
+    process::exit(aggregate.code());
 }
 
 fn clean_root(parsed: &CliArgs) -> PathBuf {
@@ -1347,47 +1550,77 @@ fn clean_root(parsed: &CliArgs) -> PathBuf {
 }
 
 fn cmd_init(parsed: &CliArgs) -> ! {
+    let progress = ProgressReporter::new("init", parsed.progress_json);
+    progress.start(None);
     let root = project_root(parsed);
     let cargo_toml = root.join("Cargo.toml");
     if !cargo_toml.exists() {
-        eprintln!("expected Cargo.toml in {}", root.display());
-        process::exit(3);
+        message_exit(
+            "init",
+            parsed.json,
+            &format!("expected Cargo.toml in {}", root.display()),
+            None,
+        );
     }
     let config_path = root.join("valid.toml");
     if config_path.exists() {
-        eprintln!("`{}` already exists", config_path.display());
-        process::exit(3);
+        message_exit(
+            "init",
+            parsed.json,
+            &format!("`{}` already exists", config_path.display()),
+            None,
+        );
     }
     let registry = parsed.file.as_deref().unwrap_or("examples/valid_models.rs");
     let body = render_project_config_template(registry);
     let registry_path = root.join(registry);
     if let Some(parent) = registry_path.parent() {
         fs::create_dir_all(parent).unwrap_or_else(|err| {
-            eprintln!("failed to create `{}`: {err}", parent.display());
-            process::exit(3);
+            message_exit(
+                "init",
+                parsed.json,
+                &format!("failed to create `{}`: {err}", parent.display()),
+                None,
+            )
         });
     }
     if !registry_path.exists() {
         fs::write(&registry_path, render_registry_source_template()).unwrap_or_else(|err| {
-            eprintln!("failed to write `{}`: {err}", registry_path.display());
-            process::exit(3);
+            message_exit(
+                "init",
+                parsed.json,
+                &format!("failed to write `{}`: {err}", registry_path.display()),
+                None,
+            )
         });
     }
     let generated_dir = root.join("generated-tests");
     fs::create_dir_all(&generated_dir).unwrap_or_else(|err| {
-        eprintln!("failed to create `{}`: {err}", generated_dir.display());
-        process::exit(3);
+        message_exit(
+            "init",
+            parsed.json,
+            &format!("failed to create `{}`: {err}", generated_dir.display()),
+            None,
+        )
     });
     let gitkeep = generated_dir.join(".gitkeep");
     if !gitkeep.exists() {
         fs::write(&gitkeep, "").unwrap_or_else(|err| {
-            eprintln!("failed to write `{}`: {err}", gitkeep.display());
-            process::exit(3);
+            message_exit(
+                "init",
+                parsed.json,
+                &format!("failed to write `{}`: {err}", gitkeep.display()),
+                None,
+            )
         });
     }
     fs::write(&config_path, body).unwrap_or_else(|err| {
-        eprintln!("failed to write `{}`: {err}", config_path.display());
-        process::exit(3);
+        message_exit(
+            "init",
+            parsed.json,
+            &format!("failed to write `{}`: {err}", config_path.display()),
+            None,
+        )
     });
     if parsed.json {
         println!(
@@ -1403,7 +1636,8 @@ fn cmd_init(parsed: &CliArgs) -> ! {
         println!("scaffolded_registry: {}", registry_path.display());
         println!("generated_tests_dir: {}", generated_dir.display());
     }
-    process::exit(0);
+    progress.finish(ExitCode::Success);
+    process::exit(ExitCode::Success.code());
 }
 
 fn clean_generated_tests(root: &Path) -> Vec<String> {

--- a/packages/valid/src/bin/valid.rs
+++ b/packages/valid/src/bin/valid.rs
@@ -1,4 +1,8 @@
-use std::{env, fs, process};
+use std::{
+    env, fs,
+    io::{self, Read},
+    process::{self, Command},
+};
 
 use valid::{
     api::{
@@ -13,15 +17,19 @@ use valid::{
         OrchestrateRequest, TestgenRequest,
     },
     bundled_models::{coverage_bundled_model, is_bundled_model_ref},
+    cli::{
+        child_stream_to_json, detect_json_flag, detect_progress_json_flag, message_diagnostic,
+        parse_batch_request, render_batch_response, render_cli_error_json, render_commands_json,
+        render_commands_text, render_schema_json, usage_diagnostic, BatchResult, ExitCode,
+        ProgressReporter, Surface,
+    },
     contract::{
         build_lock_file, compare_snapshot, parse_lock_file, render_drift_json, render_lock_json,
         snapshot_model, write_lock_file,
     },
     coverage::{collect_coverage, render_coverage_json, render_coverage_text},
     engine::CheckOutcome,
-    evidence::{
-        render_diagnostics_json, render_outcome_json, render_outcome_text, write_outcome_artifacts,
-    },
+    evidence::{render_outcome_json, render_outcome_text, write_outcome_artifacts},
     frontend::compile_model,
     reporter::{
         render_model_dot_with_view, render_model_mermaid_with_view, render_model_svg_with_view,
@@ -32,28 +40,34 @@ use valid::{
 };
 
 fn main() {
-    let mut args = env::args().skip(1);
-    let command = normalize_command(&args.next().unwrap_or_default());
-
+    let args = env::args().skip(1).collect::<Vec<_>>();
+    let command = normalize_command(args.first().map(String::as_str).unwrap_or_default());
+    let remaining = args.into_iter().skip(1).collect::<Vec<_>>();
     match command.as_str() {
-        "check" => cmd_check(args.collect()),
-        "inspect" => cmd_inspect(args.collect()),
-        "graph" => cmd_graph(args.collect()),
-        "lint" => cmd_lint(args.collect()),
-        "capabilities" => cmd_capabilities(args.collect()),
-        "explain" => cmd_explain(args.collect()),
-        "minimize" => cmd_minimize(args.collect()),
-        "contract" => cmd_contract(args.collect()),
-        "trace" => cmd_trace(args.collect()),
-        "orchestrate" => cmd_orchestrate(args.collect()),
-        "testgen" => cmd_testgen(args.collect()),
-        "replay" => cmd_replay(args.collect()),
-        "coverage" => cmd_coverage(args.collect()),
-        "clean" => cmd_clean(args.collect()),
-        "selfcheck" => cmd_selfcheck(),
+        "check" => cmd_check(remaining),
+        "inspect" => cmd_inspect(remaining),
+        "graph" => cmd_graph(remaining),
+        "lint" => cmd_lint(remaining),
+        "capabilities" => cmd_capabilities(remaining),
+        "explain" => cmd_explain(remaining),
+        "minimize" => cmd_minimize(remaining),
+        "contract" => cmd_contract(remaining),
+        "trace" => cmd_trace(remaining),
+        "orchestrate" => cmd_orchestrate(remaining),
+        "testgen" => cmd_testgen(remaining),
+        "replay" => cmd_replay(remaining),
+        "coverage" => cmd_coverage(remaining),
+        "clean" => cmd_clean(remaining),
+        "selfcheck" => cmd_selfcheck(remaining),
+        "commands" => cmd_commands(remaining),
+        "schema" => cmd_schema(remaining),
+        "batch" => cmd_batch(remaining),
         _ => {
-            eprintln!("usage: valid <inspect|graph|readiness|verify|capabilities|explain|minimize|contract|trace|orchestrate|generate-tests|replay|coverage|clean|selfcheck> ...");
-            process::exit(3);
+            usage_exit(
+                "valid",
+                detect_json_flag(&remaining),
+                "usage: valid <inspect|graph|readiness|verify|capabilities|explain|minimize|contract|trace|orchestrate|generate-tests|replay|coverage|clean|selfcheck|commands|schema|batch> ...",
+            );
         }
     }
 }
@@ -72,9 +86,11 @@ fn normalize_command(command: &str) -> String {
 fn cmd_check(args: Vec<String>) {
     let parsed = parse_common_args(
         args,
-        "usage: valid check <model-file> [--json] [--property=<id>] [--backend=<explicit|mock-bmc|sat-varisat|smt-cvc5|command>] [--solver-exec <path>] [--solver-arg <arg>]",
+        "usage: valid check <model-file> [--json] [--progress=json] [--property=<id>] [--backend=<explicit|mock-bmc|sat-varisat|smt-cvc5|command>] [--solver-exec <path>] [--solver-arg <arg>]",
     );
-    let source = read_source(&parsed.path);
+    let progress = ProgressReporter::new("check", parsed.progress_json);
+    progress.start(None);
+    let source = read_source(&parsed.path, "check", parsed.json);
     let request = CheckRequest {
         request_id: "req-local-0001".to_string(),
         source_name: parsed.path.clone(),
@@ -85,8 +101,7 @@ fn cmd_check(args: Vec<String>) {
         solver_args: parsed.solver_args,
     };
     if let Err(message) = validate_check_request(&request) {
-        eprintln!("{message}");
-        process::exit(3);
+        message_exit("check", parsed.json, &message, None);
     }
     let outcome = check_source(&request);
     let _ = write_outcome_artifacts(
@@ -100,23 +115,19 @@ fn cmd_check(args: Vec<String>) {
         print!("{}", render_outcome_text(&outcome));
         println!("model_ref: {}", parsed.path);
     }
-    let code = match outcome {
-        CheckOutcome::Completed(result) => match result.status {
-            valid::engine::RunStatus::Pass => 0,
-            valid::engine::RunStatus::Fail => 2,
-            valid::engine::RunStatus::Unknown => 4,
-        },
-        CheckOutcome::Errored(_) => 3,
-    };
-    process::exit(code);
+    let code = ExitCode::from_check_outcome(&outcome);
+    progress.finish(code);
+    process::exit(code.code());
 }
 
 fn cmd_explain(args: Vec<String>) {
     let parsed = parse_common_args(
         args,
-        "usage: valid explain <model-file> [--json] [--property=<id>] [--backend=<explicit|mock-bmc|sat-varisat|smt-cvc5|command>] [--solver-exec <path>] [--solver-arg <arg>]",
+        "usage: valid explain <model-file> [--json] [--progress=json] [--property=<id>] [--backend=<explicit|mock-bmc|sat-varisat|smt-cvc5|command>] [--solver-exec <path>] [--solver-arg <arg>]",
     );
-    let source = read_source(&parsed.path);
+    let progress = ProgressReporter::new("explain", parsed.progress_json);
+    progress.start(None);
+    let source = read_source(&parsed.path, "explain", parsed.json);
     match explain_source(&CheckRequest {
         request_id: "req-local-explain".to_string(),
         source_name: parsed.path.clone(),
@@ -128,22 +139,17 @@ fn cmd_explain(args: Vec<String>) {
     }) {
         Ok(response) => {
             if let Err(message) = validate_explain_response(&response) {
-                eprintln!("{message}");
-                process::exit(3);
+                message_exit("explain", parsed.json, &message, None);
             }
             if parsed.json {
                 println!("{}", render_explain_json(&response));
             } else {
                 print!("{}", render_explain_text(&response));
             }
+            progress.finish(ExitCode::Success);
         }
         Err(error) => {
-            if parsed.json {
-                println!("{}", render_diagnostics_json(&error.diagnostics));
-            } else {
-                print_diagnostics(&error.diagnostics);
-            }
-            process::exit(3);
+            diagnostics_exit("explain", parsed.json, &error.diagnostics, None);
         }
     }
 }
@@ -151,9 +157,11 @@ fn cmd_explain(args: Vec<String>) {
 fn cmd_minimize(args: Vec<String>) {
     let parsed = parse_common_args(
         args,
-        "usage: valid minimize <model-file> [--json] [--property=<id>] [--backend=<explicit|mock-bmc|sat-varisat|smt-cvc5|command>] [--solver-exec <path>] [--solver-arg <arg>]",
+        "usage: valid minimize <model-file> [--json] [--progress=json] [--property=<id>] [--backend=<explicit|mock-bmc|sat-varisat|smt-cvc5|command>] [--solver-exec <path>] [--solver-arg <arg>]",
     );
-    let source = read_source(&parsed.path);
+    let progress = ProgressReporter::new("minimize", parsed.progress_json);
+    progress.start(None);
+    let source = read_source(&parsed.path, "minimize", parsed.json);
     match minimize_source(&MinimizeRequest {
         request_id: "req-local-minimize".to_string(),
         source_name: parsed.path.clone(),
@@ -165,8 +173,7 @@ fn cmd_minimize(args: Vec<String>) {
     }) {
         Ok(response) => {
             if let Err(message) = validate_minimize_response(&response) {
-                eprintln!("{message}");
-                process::exit(3);
+                message_exit("minimize", parsed.json, &message, None);
             }
             if parsed.json {
                 println!(
@@ -183,49 +190,44 @@ fn cmd_minimize(args: Vec<String>) {
                 println!("original_steps: {}", response.original_steps);
                 println!("minimized_steps: {}", response.minimized_steps);
             }
+            progress.finish(ExitCode::Success);
         }
         Err(error) => {
-            if parsed.json {
-                println!("{}", render_diagnostics_json(&error.diagnostics));
-            } else {
-                print_diagnostics(&error.diagnostics);
-            }
-            process::exit(3);
+            diagnostics_exit("minimize", parsed.json, &error.diagnostics, None);
         }
     }
 }
 
 fn cmd_inspect(args: Vec<String>) {
-    let parsed = parse_common_args(args, "usage: valid inspect <model-file> [--json]");
-    let source = read_source(&parsed.path);
+    let parsed = parse_common_args(
+        args,
+        "usage: valid inspect <model-file> [--json] [--progress=json]",
+    );
+    let progress = ProgressReporter::new("inspect", parsed.progress_json);
+    progress.start(None);
+    let source = read_source(&parsed.path, "inspect", parsed.json);
     let request = InspectRequest {
         request_id: "req-local-inspect".to_string(),
         source_name: parsed.path.clone(),
         source,
     };
     if let Err(message) = validate_inspect_request(&request) {
-        eprintln!("{message}");
-        process::exit(3);
+        message_exit("inspect", parsed.json, &message, None);
     }
     match inspect_source(&request) {
         Ok(response) => {
             if let Err(message) = validate_inspect_response(&response) {
-                eprintln!("{message}");
-                process::exit(3);
+                message_exit("inspect", parsed.json, &message, None);
             }
             if parsed.json {
                 println!("{}", render_inspect_json(&response));
             } else {
                 print!("{}", render_inspect_text(&response));
             }
+            progress.finish(ExitCode::Success);
         }
         Err(diagnostics) => {
-            if parsed.json {
-                println!("{}", render_diagnostics_json(&diagnostics));
-            } else {
-                print_diagnostics(&diagnostics);
-            }
-            process::exit(3);
+            diagnostics_exit("inspect", parsed.json, &diagnostics, None);
         }
     }
 }
@@ -233,13 +235,16 @@ fn cmd_inspect(args: Vec<String>) {
 fn cmd_graph(args: Vec<String>) {
     let parsed = parse_common_args_with(
         args,
-        "usage: valid graph <model-file> [--format=mermaid|dot|svg|text|json] [--view=overview|logic]",
+        "usage: valid graph <model-file> [--format=mermaid|dot|svg|text|json] [--view=overview|logic] [--json] [--progress=json]",
         |_arg, _parsed| false,
     );
+    let json_output = parsed.json || matches!(parsed.format.as_deref(), Some("json"));
+    let progress = ProgressReporter::new("graph", parsed.progress_json);
+    progress.start(None);
     let source = if is_bundled_model_ref(&parsed.path) {
         String::new()
     } else {
-        read_source(&parsed.path)
+        read_source(&parsed.path, "graph", json_output)
     };
     let request = InspectRequest {
         request_id: "req-local-graph".to_string(),
@@ -261,28 +266,26 @@ fn cmd_graph(args: Vec<String>) {
             "svg" => println!("{}", render_model_svg_with_view(&response, view)),
             _ => println!("{}", render_model_mermaid_with_view(&response, view)),
         },
-        Err(diagnostics) => {
-            if parsed.json || matches!(parsed.format.as_deref(), Some("json")) {
-                println!("{}", render_diagnostics_json(&diagnostics));
-            } else {
-                print_diagnostics(&diagnostics);
-            }
-            process::exit(3);
-        }
+        Err(diagnostics) => diagnostics_exit("graph", json_output, &diagnostics, None),
     }
+    progress.finish(ExitCode::Success);
 }
 
 fn cmd_lint(args: Vec<String>) {
-    let parsed = parse_common_args(args, "usage: valid lint <model-file> [--json]");
-    let source = read_source(&parsed.path);
+    let parsed = parse_common_args(
+        args,
+        "usage: valid lint <model-file> [--json] [--progress=json]",
+    );
+    let progress = ProgressReporter::new("lint", parsed.progress_json);
+    progress.start(None);
+    let source = read_source(&parsed.path, "lint", parsed.json);
     let request = InspectRequest {
         request_id: "req-local-lint".to_string(),
         source_name: parsed.path.clone(),
         source,
     };
     if let Err(message) = validate_inspect_request(&request) {
-        eprintln!("{message}");
-        process::exit(3);
+        message_exit("lint", parsed.json, &message, None);
     }
     match lint_source(&request) {
         Ok(response) => {
@@ -295,15 +298,16 @@ fn cmd_lint(args: Vec<String>) {
                 .findings
                 .iter()
                 .any(|finding| matches!(finding.severity.as_str(), "warn" | "error"));
-            process::exit(if has_findings { 2 } else { 0 });
+            let exit_code = if has_findings {
+                ExitCode::Fail
+            } else {
+                ExitCode::Success
+            };
+            progress.finish(exit_code);
+            process::exit(exit_code.code());
         }
         Err(diagnostics) => {
-            if parsed.json {
-                println!("{}", render_diagnostics_json(&diagnostics));
-            } else {
-                print_diagnostics(&diagnostics);
-            }
-            process::exit(3);
+            diagnostics_exit("lint", parsed.json, &diagnostics, None);
         }
     }
 }
@@ -311,9 +315,11 @@ fn cmd_lint(args: Vec<String>) {
 fn cmd_capabilities(args: Vec<String>) {
     let parsed = parse_common_args_with(
         args,
-        "usage: valid capabilities [--json] [--backend=<explicit|mock-bmc|sat-varisat|smt-cvc5|command>] [--solver-exec <path>] [--solver-arg <arg>]",
+        "usage: valid capabilities [--json] [--progress=json] [--backend=<explicit|mock-bmc|sat-varisat|smt-cvc5|command>] [--solver-exec <path>] [--solver-arg <arg>]",
         |_arg, _parsed| false,
     );
+    let progress = ProgressReporter::new("capabilities", parsed.progress_json);
+    progress.start(None);
     let request = CapabilitiesRequest {
         request_id: "req-local-capabilities".to_string(),
         backend: parsed.backend,
@@ -321,14 +327,12 @@ fn cmd_capabilities(args: Vec<String>) {
         solver_args: parsed.solver_args,
     };
     if let Err(message) = validate_capabilities_request(&request) {
-        eprintln!("{message}");
-        process::exit(3);
+        message_exit("capabilities", parsed.json, &message, None);
     }
     match capabilities_response(&request) {
         Ok(response) => {
             if let Err(message) = validate_capabilities_response(&response) {
-                eprintln!("{message}");
-                process::exit(3);
+                message_exit("capabilities", parsed.json, &message, None);
             }
             if parsed.json {
                 print_capabilities_json(&response);
@@ -353,66 +357,106 @@ fn cmd_capabilities(args: Vec<String>) {
                     response.capabilities.selfcheck_compatible
                 );
             }
+            progress.finish(ExitCode::Success);
         }
         Err(message) => {
-            eprintln!("{message}");
-            process::exit(3);
+            message_exit("capabilities", parsed.json, &message, None);
         }
     }
 }
 
 fn cmd_contract(args: Vec<String>) {
-    let mut args = args.into_iter();
+    let json = detect_json_flag(&args);
+    let progress = ProgressReporter::from_args("contract", &args);
+    progress.start(None);
+    let positional = args
+        .into_iter()
+        .filter(|arg| !arg.starts_with("--"))
+        .collect::<Vec<_>>();
+    let mut args = positional.into_iter();
     let sub = args.next().unwrap_or_else(|| "snapshot".to_string());
     let path = args.next().unwrap_or_else(|| {
-        eprintln!("usage: valid contract <snapshot|lock|drift> <model-file> [lock-file]");
-        process::exit(3);
+        usage_exit(
+            "contract",
+            json,
+            "usage: valid contract <snapshot|lock|drift> <model-file> [lock-file] [--json] [--progress=json]",
+        )
     });
-    let source = read_source(&path);
-    let model = compile_model(&source).unwrap_or_else(|diagnostics| {
-        print_diagnostics(&diagnostics);
-        process::exit(3);
-    });
+    let source = read_source(&path, "contract", json);
+    let model = compile_model(&source)
+        .unwrap_or_else(|diagnostics| diagnostics_exit("contract", json, &diagnostics, None));
     let snapshot = snapshot_model(&model);
     match sub.as_str() {
         "snapshot" => {
-            println!("model_id: {}", snapshot.model_id);
-            println!("contract_hash: {}", snapshot.contract_hash);
-            println!("state_fields: {}", snapshot.state_fields.join(", "));
+            if json {
+                println!(
+                    "{}",
+                    serde_json::json!({
+                        "model_id": snapshot.model_id,
+                        "contract_hash": snapshot.contract_hash,
+                        "state_fields": snapshot.state_fields,
+                    })
+                );
+            } else {
+                println!("model_id: {}", snapshot.model_id);
+                println!("contract_hash: {}", snapshot.contract_hash);
+                println!("state_fields: {}", snapshot.state_fields.join(", "));
+            }
+            progress.finish(ExitCode::Success);
         }
         "lock" => {
             let lock = build_lock_file(vec![snapshot]);
             let output = args.next().unwrap_or_else(|| "valid.lock.json".to_string());
-            write_lock_file(&output, &lock).unwrap_or_else(|err| {
-                eprintln!("{err}");
-                process::exit(3);
-            });
+            write_lock_file(&output, &lock)
+                .unwrap_or_else(|err| message_exit("contract", json, &err.to_string(), None));
             println!("{}", render_lock_json(&lock));
+            progress.finish(ExitCode::Success);
         }
         "drift" => {
             let lock_path = args.next().unwrap_or_else(|| {
-                eprintln!("usage: valid contract drift <model-file> <lock-file>");
-                process::exit(3);
+                usage_exit(
+                    "contract",
+                    json,
+                    "usage: valid contract drift <model-file> <lock-file> [--json] [--progress=json]",
+                )
             });
-            let lock_body = read_source(&lock_path);
+            let lock_body = read_source(&lock_path, "contract", json);
             let lock = parse_lock_file(&lock_body).unwrap_or_else(|err| {
-                eprintln!("failed to parse lock file: {err}");
-                process::exit(3);
+                message_exit(
+                    "contract",
+                    json,
+                    &format!("failed to parse lock file: {err}"),
+                    None,
+                )
             });
             let expected = lock
                 .entries
                 .into_iter()
                 .find(|entry| entry.model_id == snapshot.model_id)
                 .unwrap_or_else(|| {
-                    eprintln!("model `{}` not found in lock file", snapshot.model_id);
-                    process::exit(3);
+                    message_exit(
+                        "contract",
+                        json,
+                        &format!("model `{}` not found in lock file", snapshot.model_id),
+                        None,
+                    )
                 });
             let drift = compare_snapshot(&expected, &snapshot);
             println!("{}", render_drift_json(&drift));
+            let exit_code = if drift.status == "unchanged" {
+                ExitCode::Success
+            } else {
+                ExitCode::Fail
+            };
+            progress.finish(exit_code);
+            process::exit(exit_code.code());
         }
         _ => {
-            eprintln!("usage: valid contract <snapshot|lock|drift> <model-file> [lock-file]");
-            process::exit(3);
+            usage_exit(
+                "contract",
+                json,
+                "usage: valid contract <snapshot|lock|drift> <model-file> [lock-file] [--json] [--progress=json]",
+            );
         }
     }
 }
@@ -420,13 +464,15 @@ fn cmd_contract(args: Vec<String>) {
 fn cmd_testgen(args: Vec<String>) {
     let parsed = parse_common_args(
         args,
-        "usage: valid testgen <model-file> [--json] [--property=<id>] [--strategy=<counterexample|transition|witness|guard|boundary|path|random>] [--backend=<explicit|mock-bmc|sat-varisat|smt-cvc5|command>] [--solver-exec <path>] [--solver-arg <arg>]",
+        "usage: valid testgen <model-file> [--json] [--progress=json] [--property=<id>] [--strategy=<counterexample|transition|witness|guard|boundary|path|random>] [--backend=<explicit|mock-bmc|sat-varisat|smt-cvc5|command>] [--solver-exec <path>] [--solver-arg <arg>]",
     );
+    let progress = ProgressReporter::new("testgen", parsed.progress_json);
+    progress.start(None);
     let strategy = parsed
         .extra
         .clone()
         .unwrap_or_else(|| "counterexample".to_string());
-    let source = read_source(&parsed.path);
+    let source = read_source(&parsed.path, "testgen", parsed.json);
     let request = TestgenRequest {
         request_id: "req-local-testgen".to_string(),
         source_name: parsed.path.clone(),
@@ -438,14 +484,12 @@ fn cmd_testgen(args: Vec<String>) {
         solver_args: parsed.solver_args.clone(),
     };
     if let Err(message) = validate_testgen_request(&request) {
-        eprintln!("{message}");
-        process::exit(3);
+        message_exit("testgen", parsed.json, &message, None);
     }
     match testgen_source(&request) {
         Ok(response) => {
             if let Err(message) = validate_testgen_response(&response) {
-                eprintln!("{message}");
-                process::exit(3);
+                message_exit("testgen", parsed.json, &message, None);
             }
             if parsed.json {
                 println!(
@@ -495,10 +539,10 @@ fn cmd_testgen(args: Vec<String>) {
                     println!("  {path}");
                 }
             }
+            progress.finish(ExitCode::Success);
         }
         Err(error) => {
-            print_diagnostics(&error.diagnostics);
-            process::exit(3);
+            diagnostics_exit("testgen", parsed.json, &error.diagnostics, None);
         }
     }
 }
@@ -506,17 +550,20 @@ fn cmd_testgen(args: Vec<String>) {
 fn cmd_trace(args: Vec<String>) {
     let parsed = parse_common_args_with(
         args,
-        "usage: valid trace <model-file> [--format=mermaid-state|mermaid-sequence|json] [--property=<id>] [--backend=<explicit|mock-bmc|sat-varisat|smt-cvc5|command>] [--solver-exec <path>] [--solver-arg <arg>]",
+        "usage: valid trace <model-file> [--format=mermaid-state|mermaid-sequence|json] [--property=<id>] [--backend=<explicit|mock-bmc|sat-varisat|smt-cvc5|command>] [--solver-exec <path>] [--solver-arg <arg>] [--json] [--progress=json]",
         |arg, options| {
             let _ = (arg, options);
             false
         },
     );
+    let progress = ProgressReporter::new("trace", parsed.progress_json);
+    progress.start(None);
     let format = parsed
         .format
         .clone()
         .unwrap_or_else(|| "mermaid-state".to_string());
-    let source = read_source(&parsed.path);
+    let json_output = parsed.json || format == "json";
+    let source = read_source(&parsed.path, "trace", json_output);
     let outcome = check_source(&CheckRequest {
         request_id: "req-local-trace".to_string(),
         source_name: parsed.path.clone(),
@@ -529,25 +576,24 @@ fn cmd_trace(args: Vec<String>) {
     let trace = match outcome {
         CheckOutcome::Completed(result) => result.trace,
         CheckOutcome::Errored(error) => {
-            print_diagnostics(&error.diagnostics);
-            process::exit(3);
+            diagnostics_exit("trace", json_output, &error.diagnostics, None);
         }
     }
     .unwrap_or_else(|| {
-        eprintln!("no trace available");
-        process::exit(3);
+        message_exit("trace", json_output, "no trace available", None);
     });
     match format.as_str() {
         "json" => println!("{}", valid::evidence::render_trace_json(&trace)),
         "mermaid-sequence" => println!("{}", render_trace_sequence_mermaid(&trace)),
         _ => println!("{}", render_trace_mermaid(&trace)),
     }
+    progress.finish(ExitCode::Success);
 }
 
 fn cmd_replay(args: Vec<String>) {
     let parsed = parse_common_args_with(
         args,
-        "usage: valid replay <model-file> [--json] [--property=<id>] [--focus-action=<id>] [--actions=a,b,c]",
+        "usage: valid replay <model-file> [--json] [--progress=json] [--property=<id>] [--focus-action=<id>] [--actions=a,b,c]",
         |arg, parsed| {
             if let Some(value) = arg.strip_prefix("--actions=") {
                 parsed.actions = value
@@ -564,6 +610,8 @@ fn cmd_replay(args: Vec<String>) {
             }
         },
     );
+    let progress = ProgressReporter::new("replay", parsed.progress_json);
+    progress.start(None);
     let output = if is_bundled_model_ref(&parsed.path) {
         valid::bundled_models::replay_bundled_model(
             &parsed.path,
@@ -572,11 +620,9 @@ fn cmd_replay(args: Vec<String>) {
             parsed.focus_action_id.as_deref(),
         )
     } else {
-        let source = read_source(&parsed.path);
-        let model = compile_model(&source).unwrap_or_else(|diagnostics| {
-            print_diagnostics(&diagnostics);
-            process::exit(3);
-        });
+        let source = read_source(&parsed.path, "replay", true);
+        let model = compile_model(&source)
+            .unwrap_or_else(|diagnostics| diagnostics_exit("replay", true, &diagnostics, None));
         let property_id = parsed
             .property_id
             .as_deref()
@@ -588,10 +634,7 @@ fn cmd_replay(args: Vec<String>) {
             })
             .unwrap_or("P_SAFE");
         let terminal = valid::kernel::replay::replay_actions(&model, &parsed.actions)
-            .unwrap_or_else(|error| {
-                print_diagnostics(&[error]);
-                process::exit(3);
-            });
+            .unwrap_or_else(|error| diagnostics_exit("replay", true, &[error], None));
         let focus_enabled = parsed.focus_action_id.as_deref().map(|action_id| {
             valid::kernel::transition::apply_action(&model, &terminal, action_id)
                 .ok()
@@ -603,8 +646,12 @@ fn cmd_replay(args: Vec<String>) {
             .iter()
             .find(|candidate| candidate.property_id == property_id)
             .unwrap_or_else(|| {
-                eprintln!("unknown property `{property_id}`");
-                process::exit(3);
+                message_exit(
+                    "replay",
+                    true,
+                    &format!("unknown property `{property_id}`"),
+                    None,
+                )
             });
         let property_holds = matches!(
             valid::kernel::eval::eval_expr(&model, &terminal, &property.expr),
@@ -632,19 +679,19 @@ fn cmd_replay(args: Vec<String>) {
             &path_tags.into_iter().collect::<Vec<_>>(),
         ))
     }
-    .unwrap_or_else(|message| {
-        eprintln!("{message}");
-        process::exit(3);
-    });
+    .unwrap_or_else(|message| message_exit("replay", true, &message, None));
     println!("{output}");
+    progress.finish(ExitCode::Success);
 }
 
 fn cmd_orchestrate(args: Vec<String>) {
     let parsed = parse_common_args(
         args,
-        "usage: valid orchestrate <model-file> [--json] [--backend=<explicit|mock-bmc|sat-varisat|smt-cvc5|command>] [--solver-exec <path>] [--solver-arg <arg>]",
+        "usage: valid orchestrate <model-file> [--json] [--progress=json] [--backend=<explicit|mock-bmc|sat-varisat|smt-cvc5|command>] [--solver-exec <path>] [--solver-arg <arg>]",
     );
-    let source = read_source(&parsed.path);
+    let progress = ProgressReporter::new("orchestrate", parsed.progress_json);
+    progress.start(None);
+    let source = read_source(&parsed.path, "orchestrate", parsed.json);
     let request = OrchestrateRequest {
         request_id: "req-local-orchestrate".to_string(),
         source_name: parsed.path.clone(),
@@ -654,14 +701,12 @@ fn cmd_orchestrate(args: Vec<String>) {
         solver_args: parsed.solver_args,
     };
     if let Err(message) = validate_orchestrate_request(&request) {
-        eprintln!("{message}");
-        process::exit(3);
+        message_exit("orchestrate", parsed.json, &message, None);
     }
     match orchestrate_source(&request) {
         Ok(response) => {
             if let Err(message) = validate_orchestrate_response(&response) {
-                eprintln!("{message}");
-                process::exit(3);
+                message_exit("orchestrate", parsed.json, &message, None);
             }
             if parsed.json {
                 let body = response
@@ -693,14 +738,10 @@ fn cmd_orchestrate(args: Vec<String>) {
                     println!("{}", render_coverage_text(report));
                 }
             }
+            progress.finish(ExitCode::Success);
         }
         Err(error) => {
-            if parsed.json {
-                println!("{}", render_diagnostics_json(&error.diagnostics));
-            } else {
-                print_diagnostics(&error.diagnostics);
-            }
-            process::exit(3);
+            diagnostics_exit("orchestrate", parsed.json, &error.diagnostics, None);
         }
     }
 }
@@ -708,24 +749,24 @@ fn cmd_orchestrate(args: Vec<String>) {
 fn cmd_coverage(args: Vec<String>) {
     let parsed = parse_common_args(
         args,
-        "usage: valid coverage <model-file> [--property=<id>] [--backend=<explicit|mock-bmc|sat-varisat|smt-cvc5|command>] [--solver-exec <path>] [--solver-arg <arg>]",
+        "usage: valid coverage <model-file> [--json] [--progress=json] [--property=<id>] [--backend=<explicit|mock-bmc|sat-varisat|smt-cvc5|command>] [--solver-exec <path>] [--solver-arg <arg>]",
     );
+    let progress = ProgressReporter::new("coverage", parsed.progress_json);
+    progress.start(None);
     if is_bundled_model_ref(&parsed.path) {
-        let report = coverage_bundled_model(&parsed.path).unwrap_or_else(|message| {
-            eprintln!("{message}");
-            process::exit(3);
-        });
+        let report = coverage_bundled_model(&parsed.path)
+            .unwrap_or_else(|message| message_exit("coverage", parsed.json, &message, None));
         if parsed.json {
             println!("{}", render_coverage_json(&report));
         } else {
             println!("{}", render_coverage_text(&report));
         }
+        progress.finish(ExitCode::Success);
         return;
     }
-    let source = read_source(&parsed.path);
+    let source = read_source(&parsed.path, "coverage", parsed.json);
     let model = compile_model(&source).unwrap_or_else(|diagnostics| {
-        print_diagnostics(&diagnostics);
-        process::exit(3);
+        diagnostics_exit("coverage", parsed.json, &diagnostics, None)
     });
     let outcome = check_source(&CheckRequest {
         request_id: "req-local-coverage".to_string(),
@@ -745,10 +786,10 @@ fn cmd_coverage(args: Vec<String>) {
             } else {
                 println!("{}", render_coverage_text(&report));
             }
+            progress.finish(ExitCode::Success);
         }
         CheckOutcome::Errored(error) => {
-            print_diagnostics(&error.diagnostics);
-            process::exit(3);
+            diagnostics_exit("coverage", parsed.json, &error.diagnostics, None);
         }
     }
 }
@@ -756,6 +797,7 @@ fn cmd_coverage(args: Vec<String>) {
 #[derive(Default)]
 struct ParsedArgs {
     json: bool,
+    progress_json: bool,
     path: String,
     backend: Option<String>,
     solver_executable: Option<String>,
@@ -784,10 +826,21 @@ where
     F: FnMut(&str, &mut ParsedArgs) -> bool,
 {
     let mut parsed = ParsedArgs::default();
+    parsed.json = detect_json_flag(&args);
+    parsed.progress_json = detect_progress_json_flag(&args);
     let mut iter = args.into_iter();
     while let Some(arg) = iter.next() {
         if arg == "--json" {
             parsed.json = true;
+        } else if arg == "--progress=json" {
+            parsed.progress_json = true;
+        } else if arg.starts_with("--progress=") {
+            message_exit(
+                "valid",
+                parsed.json,
+                "unsupported progress mode",
+                Some(usage),
+            );
         } else if let Some(value) = arg.strip_prefix("--format=") {
             parsed.format = Some(value.to_string());
         } else if let Some(value) = arg.strip_prefix("--view=") {
@@ -797,34 +850,31 @@ where
         } else if let Some(value) = arg.strip_prefix("--property=") {
             parsed.property_id = Some(value.to_string());
         } else if arg == "--solver-exec" {
-            parsed.solver_executable = Some(iter.next().unwrap_or_else(|| {
-                eprintln!("{usage}");
-                process::exit(3);
-            }));
+            parsed.solver_executable = Some(
+                iter.next()
+                    .unwrap_or_else(|| usage_exit("valid", parsed.json, usage)),
+            );
         } else if arg == "--solver-arg" {
-            parsed.solver_args.push(iter.next().unwrap_or_else(|| {
-                eprintln!("{usage}");
-                process::exit(3);
-            }));
+            parsed.solver_args.push(
+                iter.next()
+                    .unwrap_or_else(|| usage_exit("valid", parsed.json, usage)),
+            );
         } else if extra_handler(&arg, &mut parsed) {
             continue;
         } else if parsed.path.is_empty() {
             parsed.path = arg;
         } else {
-            eprintln!("{usage}");
-            process::exit(3);
+            usage_exit("valid", parsed.json, usage);
         }
     }
     if parsed.path.is_empty() && !usage.contains("valid capabilities") {
-        eprintln!("{usage}");
-        process::exit(3);
+        usage_exit("valid", parsed.json, usage);
     }
     parsed
 }
 
-fn cmd_selfcheck() {
-    let args = env::args().skip(2).collect::<Vec<_>>();
-    let json = args.iter().any(|arg| arg == "--json");
+fn cmd_selfcheck(args: Vec<String>) {
+    let json = detect_json_flag(&args);
     let report = run_smoke_selfcheck();
     let _ = write_selfcheck_artifact(&report);
     if json {
@@ -840,10 +890,10 @@ fn cmd_selfcheck() {
 }
 
 fn cmd_clean(args: Vec<String>) {
-    let json = args.iter().any(|arg| arg == "--json");
+    let json = detect_json_flag(&args);
     let scope = args
         .iter()
-        .find(|arg| !arg.starts_with("--"))
+        .find(|arg| !arg.starts_with("--") && arg.as_str() != "clean")
         .map(String::as_str)
         .unwrap_or("all");
     let root = env::current_dir().unwrap_or_else(|_| ".".into());
@@ -856,8 +906,12 @@ fn cmd_clean(args: Vec<String>) {
         "generated" | "generated-tests" => removed.extend(clean_generated_tests(&root)),
         "artifacts" => removed.extend(clean_artifacts(&root)),
         other => {
-            eprintln!("usage: valid clean [generated|artifacts|all] [--json]\nunknown clean scope `{other}`");
-            process::exit(3);
+            message_exit(
+                "clean",
+                json,
+                &format!("unknown clean scope `{other}`"),
+                Some("usage: valid clean [generated|artifacts|all] [--json] [--progress=json]"),
+            );
         }
     }
     if json {
@@ -882,17 +936,29 @@ fn cmd_clean(args: Vec<String>) {
     }
 }
 
-fn read_source(path: &str) -> String {
+fn read_source(path: &str, command: &str, json: bool) -> String {
     if is_bundled_model_ref(path) {
         return String::new();
     }
     fs::read_to_string(path).unwrap_or_else(|err| {
-        eprintln!("error [frontend.parse]: failed to read `{path}`: {err}");
-        process::exit(3);
+        message_exit(
+            command,
+            json,
+            &format!("failed to read `{path}`: {err}"),
+            None,
+        )
     })
 }
 
-fn print_diagnostics(diagnostics: &[valid::support::diagnostics::Diagnostic]) {
+fn print_diagnostics(
+    command: &str,
+    json: bool,
+    diagnostics: &[valid::support::diagnostics::Diagnostic],
+) {
+    if json {
+        eprintln!("{}", render_cli_error_json(command, diagnostics, None));
+        return;
+    }
     for diagnostic in diagnostics {
         eprintln!("error: {}", diagnostic.message);
         eprintln!("  segment: {}", diagnostic.segment.as_str());
@@ -995,4 +1061,160 @@ fn print_capabilities_json(response: &CapabilitiesResponse) {
         response.capabilities.supports_witness,
         response.capabilities.selfcheck_compatible
     );
+}
+
+fn usage_exit(command: &str, json: bool, usage: &str) -> ! {
+    if json {
+        eprintln!(
+            "{}",
+            render_cli_error_json(
+                command,
+                &[usage_diagnostic("invalid command arguments", usage)],
+                Some(usage),
+            )
+        );
+    } else {
+        eprintln!("{usage}");
+    }
+    process::exit(ExitCode::Error.code());
+}
+
+fn message_exit(command: &str, json: bool, message: &str, usage: Option<&str>) -> ! {
+    if json {
+        eprintln!(
+            "{}",
+            render_cli_error_json(command, &[message_diagnostic(message)], usage)
+        );
+    } else {
+        if let Some(usage) = usage {
+            eprintln!("{usage}");
+        }
+        eprintln!("{message}");
+    }
+    process::exit(ExitCode::Error.code());
+}
+
+fn diagnostics_exit(
+    command: &str,
+    json: bool,
+    diagnostics: &[valid::support::diagnostics::Diagnostic],
+    usage: Option<&str>,
+) -> ! {
+    if json {
+        eprintln!("{}", render_cli_error_json(command, diagnostics, usage));
+    } else {
+        print_diagnostics(command, false, diagnostics);
+        if let Some(usage) = usage {
+            eprintln!("{usage}");
+        }
+    }
+    process::exit(ExitCode::Error.code());
+}
+
+fn cmd_commands(args: Vec<String>) {
+    if detect_json_flag(&args) {
+        println!("{}", render_commands_json(Surface::Valid));
+    } else {
+        println!("{}", render_commands_text(Surface::Valid));
+    }
+}
+
+fn cmd_schema(args: Vec<String>) {
+    let command = args
+        .iter()
+        .find(|arg| !arg.starts_with("--"))
+        .cloned()
+        .unwrap_or_else(|| usage_exit("schema", true, "usage: valid schema <command>"));
+    match render_schema_json(Surface::Valid, &normalize_command(&command)) {
+        Ok(body) => println!("{body}"),
+        Err(message) => message_exit(
+            "schema",
+            true,
+            &message,
+            Some("usage: valid schema <command>"),
+        ),
+    }
+}
+
+fn cmd_batch(args: Vec<String>) {
+    let json = detect_json_flag(&args);
+    let progress = ProgressReporter::from_args("batch", &args);
+    let mut stdin = String::new();
+    io::stdin()
+        .read_to_string(&mut stdin)
+        .unwrap_or_else(|err| {
+            message_exit("batch", json, &format!("failed to read stdin: {err}"), None)
+        });
+    let request = parse_batch_request(&stdin).unwrap_or_else(|message| {
+        message_exit(
+            "batch",
+            true,
+            &message,
+            Some("usage: valid batch [--json] [--progress=json] < batch.json"),
+        )
+    });
+    let total = request.operations.len();
+    progress.start(Some(total));
+    let current_exe = env::current_exe().unwrap_or_else(|err| {
+        message_exit(
+            "batch",
+            json,
+            &format!("failed to resolve current executable: {err}"),
+            None,
+        )
+    });
+    let mut aggregate = ExitCode::Success;
+    let mut results = Vec::new();
+    for (index, operation) in request.operations.into_iter().enumerate() {
+        progress.item_start(index, total, &operation.command);
+        let mut child_args = vec![operation.command.clone()];
+        child_args.extend(operation.args.clone());
+        if operation.json
+            && !child_args
+                .iter()
+                .any(|arg| arg == "--json" || arg.starts_with("--format="))
+        {
+            if matches!(operation.command.as_str(), "graph" | "trace") {
+                child_args.push("--format=json".to_string());
+            } else {
+                child_args.push("--json".to_string());
+            }
+        }
+        let output = Command::new(&current_exe)
+            .args(&child_args)
+            .output()
+            .unwrap_or_else(|err| {
+                message_exit(
+                    "batch",
+                    true,
+                    &format!(
+                        "failed to execute batch operation `{}`: {err}",
+                        operation.command
+                    ),
+                    None,
+                )
+            });
+        let exit_code = output.status.code().unwrap_or(ExitCode::Error.code());
+        aggregate = aggregate.aggregate(match exit_code {
+            0 => ExitCode::Success,
+            1 => ExitCode::Fail,
+            2 => ExitCode::Unknown,
+            _ => ExitCode::Error,
+        });
+        results.push(BatchResult {
+            index,
+            command: operation.command.clone(),
+            args: child_args.into_iter().skip(1).collect(),
+            exit_code,
+            stdout: child_stream_to_json(&output.stdout),
+            stderr: child_stream_to_json(&output.stderr),
+        });
+        progress.item_complete(index, total, &operation.command, exit_code);
+        if exit_code != 0 && !request.continue_on_error {
+            break;
+        }
+    }
+    progress.finish(aggregate);
+    println!("{}", render_batch_response(aggregate, results));
+    process::exit(aggregate.code());
 }

--- a/packages/valid/src/cli.rs
+++ b/packages/valid/src/cli.rs
@@ -1,0 +1,1997 @@
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Map, Value};
+
+use crate::{
+    engine::{CheckOutcome, RunStatus},
+    support::diagnostics::{Diagnostic, DiagnosticSegment, ErrorCode},
+};
+
+pub const CLI_SCHEMA_VERSION: &str = "1.0.0";
+
+const RUN_RESULT_SCHEMA: &str = include_str!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/docs/rdd/09_reference/schemas/run_result.schema.json"
+));
+const EVIDENCE_TRACE_SCHEMA: &str = include_str!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/docs/rdd/09_reference/schemas/evidence_trace.schema.json"
+));
+const COVERAGE_REPORT_SCHEMA: &str = include_str!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/docs/rdd/09_reference/schemas/coverage_report.schema.json"
+));
+const CONTRACT_SNAPSHOT_SCHEMA: &str = include_str!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/docs/rdd/09_reference/schemas/contract_snapshot.schema.json"
+));
+const CONTRACT_LOCK_SCHEMA: &str = include_str!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/docs/rdd/09_reference/schemas/contract_lock.schema.json"
+));
+const CONTRACT_DRIFT_SCHEMA: &str = include_str!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/docs/rdd/09_reference/schemas/contract_drift.schema.json"
+));
+const SELF_CHECK_SCHEMA: &str = include_str!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/docs/rdd/09_reference/schemas/selfcheck_report.schema.json"
+));
+const INSPECT_REQUEST_SCHEMA: &str = include_str!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/docs/rdd/09_reference/schemas/ai_inspect_request.schema.json"
+));
+const INSPECT_RESPONSE_SCHEMA: &str = include_str!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/docs/rdd/09_reference/schemas/ai_inspect_response.schema.json"
+));
+const CHECK_REQUEST_SCHEMA: &str = include_str!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/docs/rdd/09_reference/schemas/ai_check_request.schema.json"
+));
+const EXPLAIN_RESPONSE_SCHEMA: &str = include_str!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/docs/rdd/09_reference/schemas/ai_explain_response.schema.json"
+));
+const MINIMIZE_RESPONSE_SCHEMA: &str = include_str!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/docs/rdd/09_reference/schemas/ai_minimize_response.schema.json"
+));
+const TESTGEN_REQUEST_SCHEMA: &str = include_str!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/docs/rdd/09_reference/schemas/ai_testgen_request.schema.json"
+));
+const TESTGEN_RESPONSE_SCHEMA: &str = include_str!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/docs/rdd/09_reference/schemas/ai_testgen_response.schema.json"
+));
+const ORCHESTRATE_REQUEST_SCHEMA: &str = include_str!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/docs/rdd/09_reference/schemas/ai_orchestrate_request.schema.json"
+));
+const ORCHESTRATE_RESPONSE_SCHEMA: &str = include_str!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/docs/rdd/09_reference/schemas/ai_orchestrate_response.schema.json"
+));
+const CAPABILITIES_REQUEST_SCHEMA: &str = include_str!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/docs/rdd/09_reference/schemas/ai_capabilities_request.schema.json"
+));
+const CAPABILITIES_RESPONSE_SCHEMA: &str = include_str!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/docs/rdd/09_reference/schemas/ai_capabilities_response.schema.json"
+));
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum ExitCode {
+    Success,
+    Fail,
+    Unknown,
+    Error,
+}
+
+impl ExitCode {
+    pub fn code(self) -> i32 {
+        match self {
+            Self::Success => 0,
+            Self::Fail => 1,
+            Self::Unknown => 2,
+            Self::Error => 3,
+        }
+    }
+
+    pub fn status_label(self) -> &'static str {
+        match self {
+            Self::Success => "SUCCESS",
+            Self::Fail => "FAIL",
+            Self::Unknown => "UNKNOWN",
+            Self::Error => "ERROR",
+        }
+    }
+
+    pub fn aggregate(self, next: Self) -> Self {
+        match (self, next) {
+            (Self::Error, _) | (_, Self::Error) => Self::Error,
+            (Self::Fail, _) | (_, Self::Fail) => Self::Fail,
+            (Self::Unknown, _) | (_, Self::Unknown) => Self::Unknown,
+            _ => Self::Success,
+        }
+    }
+
+    pub fn from_check_outcome(outcome: &CheckOutcome) -> Self {
+        match outcome {
+            CheckOutcome::Completed(result) => match result.status {
+                RunStatus::Pass => Self::Success,
+                RunStatus::Fail => Self::Fail,
+                RunStatus::Unknown => Self::Unknown,
+            },
+            CheckOutcome::Errored(_) => Self::Error,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum Surface {
+    Valid,
+    CargoValid,
+    Registry,
+}
+
+impl Surface {
+    pub fn slug(self) -> &'static str {
+        match self {
+            Self::Valid => "valid",
+            Self::CargoValid => "cargo-valid",
+            Self::Registry => "registry",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Serialize)]
+pub struct ArgSpec {
+    pub name: &'static str,
+    pub syntax: &'static str,
+    pub value_type: &'static str,
+    pub required: bool,
+    pub multiple: bool,
+    pub positional: bool,
+    pub description: &'static str,
+    pub values: &'static [&'static str],
+}
+
+#[derive(Clone, Copy)]
+pub struct SchemaRef {
+    pub id: &'static str,
+    pub builder: fn() -> Value,
+}
+
+#[derive(Clone, Copy)]
+pub struct CommandSpec {
+    pub name: &'static str,
+    pub aliases: &'static [&'static str],
+    pub description: &'static str,
+    pub usage: &'static str,
+    pub positional: &'static [ArgSpec],
+    pub options: &'static [ArgSpec],
+    pub request_schema: Option<SchemaRef>,
+    pub response_schema: Option<SchemaRef>,
+    pub supports_json: bool,
+    pub supports_progress: bool,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct BatchRequest {
+    #[serde(default = "schema_version_string")]
+    pub schema_version: String,
+    #[serde(default = "default_continue_on_error")]
+    pub continue_on_error: bool,
+    pub operations: Vec<BatchOperation>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct BatchOperation {
+    pub command: String,
+    #[serde(default)]
+    pub args: Vec<String>,
+    #[serde(default = "default_true")]
+    pub json: bool,
+}
+
+#[derive(Debug, Serialize)]
+pub struct BatchResponse {
+    pub schema_version: String,
+    pub status: &'static str,
+    pub exit_code: i32,
+    pub results: Vec<BatchResult>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct BatchResult {
+    pub index: usize,
+    pub command: String,
+    pub args: Vec<String>,
+    pub exit_code: i32,
+    pub stdout: Value,
+    pub stderr: Value,
+}
+
+pub struct ProgressReporter {
+    command: String,
+    enabled: bool,
+}
+
+impl ProgressReporter {
+    pub fn new(command: impl Into<String>, enabled: bool) -> Self {
+        Self {
+            command: command.into(),
+            enabled,
+        }
+    }
+
+    pub fn from_args(command: impl Into<String>, args: &[String]) -> Self {
+        Self::new(command, detect_progress_json_flag(args))
+    }
+
+    pub fn enabled(&self) -> bool {
+        self.enabled
+    }
+
+    pub fn emit(&self, event: &str, extra: Value) {
+        if !self.enabled {
+            return;
+        }
+        let mut object = Map::new();
+        object.insert(
+            "schema_version".to_string(),
+            Value::String(CLI_SCHEMA_VERSION.to_string()),
+        );
+        object.insert("kind".to_string(), Value::String("progress".to_string()));
+        object.insert("command".to_string(), Value::String(self.command.clone()));
+        object.insert("event".to_string(), Value::String(event.to_string()));
+        if let Value::Object(extra_map) = extra {
+            for (key, value) in extra_map {
+                object.insert(key, value);
+            }
+        }
+        eprintln!(
+            "{}",
+            serde_json::to_string(&Value::Object(object)).expect("progress json")
+        );
+    }
+
+    pub fn start(&self, total: Option<usize>) {
+        self.emit("start", json!({ "total": total }));
+    }
+
+    pub fn item_start(&self, index: usize, total: usize, target: &str) {
+        self.emit(
+            "item_start",
+            json!({ "index": index, "total": total, "target": target }),
+        );
+    }
+
+    pub fn item_complete(&self, index: usize, total: usize, target: &str, exit_code: i32) {
+        self.emit(
+            "item_complete",
+            json!({
+                "index": index,
+                "total": total,
+                "target": target,
+                "exit_code": exit_code
+            }),
+        );
+    }
+
+    pub fn finish(&self, exit_code: ExitCode) {
+        self.emit(
+            "finish",
+            json!({
+                "status": exit_code.status_label(),
+                "exit_code": exit_code.code()
+            }),
+        );
+    }
+}
+
+const MODEL_FILE_ARG: ArgSpec = ArgSpec {
+    name: "model_file",
+    syntax: "<model-file>",
+    value_type: "string",
+    required: true,
+    multiple: false,
+    positional: true,
+    description: "Path or model reference to inspect.",
+    values: &[],
+};
+const MODEL_ARG: ArgSpec = ArgSpec {
+    name: "model",
+    syntax: "<model>",
+    value_type: "string",
+    required: true,
+    multiple: false,
+    positional: true,
+    description: "Registered model name.",
+    values: &[],
+};
+const JSON_ARG: ArgSpec = ArgSpec {
+    name: "json",
+    syntax: "--json",
+    value_type: "boolean",
+    required: false,
+    multiple: false,
+    positional: false,
+    description: "Emit JSON on stdout and structured errors on stderr.",
+    values: &[],
+};
+const PROGRESS_ARG: ArgSpec = ArgSpec {
+    name: "progress",
+    syntax: "--progress=json",
+    value_type: "string",
+    required: false,
+    multiple: false,
+    positional: false,
+    description: "Emit structured progress events on stderr.",
+    values: &["json"],
+};
+const PROPERTY_ARG: ArgSpec = ArgSpec {
+    name: "property_id",
+    syntax: "--property=<id>",
+    value_type: "string",
+    required: false,
+    multiple: false,
+    positional: false,
+    description: "Restrict execution to one property.",
+    values: &[],
+};
+const BACKEND_ARG: ArgSpec = ArgSpec {
+    name: "backend",
+    syntax: "--backend=<explicit|mock-bmc|sat-varisat|smt-cvc5|command>",
+    value_type: "string",
+    required: false,
+    multiple: false,
+    positional: false,
+    description: "Select the verification backend.",
+    values: &["explicit", "mock-bmc", "sat-varisat", "smt-cvc5", "command"],
+};
+const SOLVER_EXEC_ARG: ArgSpec = ArgSpec {
+    name: "solver_executable",
+    syntax: "--solver-exec <path>",
+    value_type: "string",
+    required: false,
+    multiple: false,
+    positional: false,
+    description: "Executable path for external solver backends.",
+    values: &[],
+};
+const SOLVER_ARG_ARG: ArgSpec = ArgSpec {
+    name: "solver_args",
+    syntax: "--solver-arg <arg>",
+    value_type: "string",
+    required: false,
+    multiple: true,
+    positional: false,
+    description: "Additional solver argument. Can be repeated.",
+    values: &[],
+};
+const FORMAT_ARG: ArgSpec = ArgSpec {
+    name: "format",
+    syntax: "--format=<mermaid|dot|svg|text|json>",
+    value_type: "string",
+    required: false,
+    multiple: false,
+    positional: false,
+    description: "Graph or report output format.",
+    values: &["mermaid", "dot", "svg", "text", "json"],
+};
+const TRACE_FORMAT_ARG: ArgSpec = ArgSpec {
+    name: "format",
+    syntax: "--format=<mermaid-state|mermaid-sequence|json>",
+    value_type: "string",
+    required: false,
+    multiple: false,
+    positional: false,
+    description: "Trace output format.",
+    values: &["mermaid-state", "mermaid-sequence", "json"],
+};
+const VIEW_ARG: ArgSpec = ArgSpec {
+    name: "view",
+    syntax: "--view=<overview|logic>",
+    value_type: "string",
+    required: false,
+    multiple: false,
+    positional: false,
+    description: "Graph view to render.",
+    values: &["overview", "logic"],
+};
+const STRATEGY_ARG: ArgSpec = ArgSpec {
+    name: "strategy",
+    syntax: "--strategy=<counterexample|transition|witness|guard|boundary|path|random>",
+    value_type: "string",
+    required: false,
+    multiple: false,
+    positional: false,
+    description: "Test generation strategy.",
+    values: &[
+        "counterexample",
+        "transition",
+        "witness",
+        "guard",
+        "boundary",
+        "path",
+        "random",
+    ],
+};
+const ACTIONS_ARG: ArgSpec = ArgSpec {
+    name: "actions",
+    syntax: "--actions=a,b,c",
+    value_type: "array",
+    required: false,
+    multiple: false,
+    positional: false,
+    description: "Comma-separated action ids for replay.",
+    values: &[],
+};
+const FOCUS_ACTION_ARG: ArgSpec = ArgSpec {
+    name: "focus_action_id",
+    syntax: "--focus-action=<id>",
+    value_type: "string",
+    required: false,
+    multiple: false,
+    positional: false,
+    description: "Optional focus action id for replay.",
+    values: &[],
+};
+const REPEAT_ARG: ArgSpec = ArgSpec {
+    name: "repeat",
+    syntax: "--repeat=<n>",
+    value_type: "integer",
+    required: false,
+    multiple: false,
+    positional: false,
+    description: "Benchmark iteration count.",
+    values: &[],
+};
+const BASELINE_ARG: ArgSpec = ArgSpec {
+    name: "baseline_mode",
+    syntax: "--baseline[=compare|record|ignore]",
+    value_type: "string",
+    required: false,
+    multiple: false,
+    positional: false,
+    description: "Benchmark baseline mode.",
+    values: &["compare", "record", "ignore"],
+};
+const THRESHOLD_ARG: ArgSpec = ArgSpec {
+    name: "threshold_percent",
+    syntax: "--threshold-percent=<n>",
+    value_type: "integer",
+    required: false,
+    multiple: false,
+    positional: false,
+    description: "Allowed benchmark regression threshold percentage.",
+    values: &[],
+};
+const WRITE_ARG: ArgSpec = ArgSpec {
+    name: "write_path",
+    syntax: "--write[=<path>]",
+    value_type: "string",
+    required: false,
+    multiple: false,
+    positional: false,
+    description: "Optional file path for generated output.",
+    values: &[],
+};
+const CHECK_ARG: ArgSpec = ArgSpec {
+    name: "check",
+    syntax: "--check",
+    value_type: "boolean",
+    required: false,
+    multiple: false,
+    positional: false,
+    description: "Enable migration check mode.",
+    values: &[],
+};
+const MANIFEST_ARG: ArgSpec = ArgSpec {
+    name: "manifest_path",
+    syntax: "--manifest-path <path>",
+    value_type: "string",
+    required: false,
+    multiple: false,
+    positional: false,
+    description: "Cargo manifest path for project execution.",
+    values: &[],
+};
+const REGISTRY_ARG: ArgSpec = ArgSpec {
+    name: "registry",
+    syntax: "--registry <path>",
+    value_type: "string",
+    required: false,
+    multiple: false,
+    positional: false,
+    description: "Rust registry source file to execute.",
+    values: &[],
+};
+const FILE_ARG: ArgSpec = ArgSpec {
+    name: "file",
+    syntax: "--file <path>",
+    value_type: "string",
+    required: false,
+    multiple: false,
+    positional: false,
+    description: "Rust registry source file to execute.",
+    values: &[],
+};
+const EXAMPLE_ARG: ArgSpec = ArgSpec {
+    name: "example",
+    syntax: "--example <name>",
+    value_type: "string",
+    required: false,
+    multiple: false,
+    positional: false,
+    description: "Cargo example name to execute.",
+    values: &[],
+};
+const BIN_ARG: ArgSpec = ArgSpec {
+    name: "bin",
+    syntax: "--bin <name>",
+    value_type: "string",
+    required: false,
+    multiple: false,
+    positional: false,
+    description: "Cargo binary name to execute.",
+    values: &[],
+};
+const CLEAN_SCOPE_ARG: ArgSpec = ArgSpec {
+    name: "scope",
+    syntax: "[generated|artifacts|all]",
+    value_type: "string",
+    required: false,
+    multiple: false,
+    positional: true,
+    description: "Clean scope.",
+    values: &["generated", "generated-tests", "artifacts", "all"],
+};
+const CONTRACT_SUBCOMMAND_ARG: ArgSpec = ArgSpec {
+    name: "mode",
+    syntax: "<snapshot|lock|drift|check>",
+    value_type: "string",
+    required: false,
+    multiple: false,
+    positional: true,
+    description: "Contract operation.",
+    values: &["snapshot", "lock", "drift", "check"],
+};
+const LOCK_FILE_ARG: ArgSpec = ArgSpec {
+    name: "lock_file",
+    syntax: "[lock-file]",
+    value_type: "string",
+    required: false,
+    multiple: false,
+    positional: true,
+    description: "Lock file path for contract operations.",
+    values: &[],
+};
+const COMMAND_NAME_ARG: ArgSpec = ArgSpec {
+    name: "command",
+    syntax: "<command>",
+    value_type: "string",
+    required: true,
+    multiple: false,
+    positional: true,
+    description: "Command name to describe.",
+    values: &[],
+};
+
+const CHECK_OPTIONS: &[ArgSpec] = &[
+    JSON_ARG,
+    PROGRESS_ARG,
+    PROPERTY_ARG,
+    BACKEND_ARG,
+    SOLVER_EXEC_ARG,
+    SOLVER_ARG_ARG,
+];
+const GRAPH_OPTIONS: &[ArgSpec] = &[FORMAT_ARG, VIEW_ARG, JSON_ARG, PROGRESS_ARG];
+const LINT_OPTIONS: &[ArgSpec] = &[JSON_ARG, PROGRESS_ARG];
+const CAPABILITY_OPTIONS: &[ArgSpec] = &[
+    JSON_ARG,
+    PROGRESS_ARG,
+    BACKEND_ARG,
+    SOLVER_EXEC_ARG,
+    SOLVER_ARG_ARG,
+];
+const EXPLAIN_OPTIONS: &[ArgSpec] = &[
+    JSON_ARG,
+    PROGRESS_ARG,
+    PROPERTY_ARG,
+    BACKEND_ARG,
+    SOLVER_EXEC_ARG,
+    SOLVER_ARG_ARG,
+];
+const MINIMIZE_OPTIONS: &[ArgSpec] = &[
+    JSON_ARG,
+    PROGRESS_ARG,
+    PROPERTY_ARG,
+    BACKEND_ARG,
+    SOLVER_EXEC_ARG,
+    SOLVER_ARG_ARG,
+];
+const ORCHESTRATE_OPTIONS: &[ArgSpec] = &[
+    JSON_ARG,
+    PROGRESS_ARG,
+    BACKEND_ARG,
+    SOLVER_EXEC_ARG,
+    SOLVER_ARG_ARG,
+];
+const TESTGEN_OPTIONS: &[ArgSpec] = &[
+    JSON_ARG,
+    PROGRESS_ARG,
+    PROPERTY_ARG,
+    STRATEGY_ARG,
+    BACKEND_ARG,
+    SOLVER_EXEC_ARG,
+    SOLVER_ARG_ARG,
+];
+const REPLAY_OPTIONS: &[ArgSpec] = &[
+    JSON_ARG,
+    PROGRESS_ARG,
+    PROPERTY_ARG,
+    FOCUS_ACTION_ARG,
+    ACTIONS_ARG,
+];
+const COVERAGE_OPTIONS: &[ArgSpec] = &[
+    JSON_ARG,
+    PROGRESS_ARG,
+    PROPERTY_ARG,
+    BACKEND_ARG,
+    SOLVER_EXEC_ARG,
+    SOLVER_ARG_ARG,
+];
+const TRACE_OPTIONS: &[ArgSpec] = &[
+    TRACE_FORMAT_ARG,
+    JSON_ARG,
+    PROGRESS_ARG,
+    PROPERTY_ARG,
+    BACKEND_ARG,
+    SOLVER_EXEC_ARG,
+    SOLVER_ARG_ARG,
+];
+const CLEAN_OPTIONS: &[ArgSpec] = &[JSON_ARG, PROGRESS_ARG];
+const SCHEMA_OPTIONS: &[ArgSpec] = &[JSON_ARG];
+const COMMANDS_OPTIONS: &[ArgSpec] = &[JSON_ARG];
+const BATCH_OPTIONS: &[ArgSpec] = &[JSON_ARG, PROGRESS_ARG];
+const BENCHMARK_OPTIONS: &[ArgSpec] = &[
+    JSON_ARG,
+    PROGRESS_ARG,
+    PROPERTY_ARG,
+    REPEAT_ARG,
+    BASELINE_ARG,
+    THRESHOLD_ARG,
+    BACKEND_ARG,
+    SOLVER_EXEC_ARG,
+    SOLVER_ARG_ARG,
+];
+const MIGRATE_OPTIONS: &[ArgSpec] = &[JSON_ARG, PROGRESS_ARG, WRITE_ARG, CHECK_ARG];
+const VALID_COMMANDS: &[CommandSpec] = &[
+    CommandSpec {
+        name: "check",
+        aliases: &["verify"],
+        description: "Run model verification.",
+        usage: "valid check <model-file> [--json] [--progress=json] [--property=<id>] [--backend=<explicit|mock-bmc|sat-varisat|smt-cvc5|command>] [--solver-exec <path>] [--solver-arg <arg>]",
+        positional: &[MODEL_FILE_ARG],
+        options: CHECK_OPTIONS,
+        request_schema: Some(SchemaRef { id: "schema.ai.check_request", builder: check_request_schema }),
+        response_schema: Some(SchemaRef { id: "schema.run_result", builder: run_result_schema }),
+        supports_json: true,
+        supports_progress: true,
+    },
+    CommandSpec {
+        name: "inspect",
+        aliases: &[],
+        description: "Inspect compiled model metadata.",
+        usage: "valid inspect <model-file> [--json] [--progress=json]",
+        positional: &[MODEL_FILE_ARG],
+        options: &[JSON_ARG, PROGRESS_ARG],
+        request_schema: Some(SchemaRef { id: "schema.ai.inspect_request", builder: inspect_request_schema }),
+        response_schema: Some(SchemaRef { id: "schema.ai.inspect_response", builder: inspect_response_schema }),
+        supports_json: true,
+        supports_progress: true,
+    },
+    CommandSpec {
+        name: "graph",
+        aliases: &["diagram"],
+        description: "Render the model graph.",
+        usage: "valid graph <model-file> [--format=mermaid|dot|svg|text|json] [--view=overview|logic] [--json] [--progress=json]",
+        positional: &[MODEL_FILE_ARG],
+        options: GRAPH_OPTIONS,
+        request_schema: Some(SchemaRef { id: "schema.ai.inspect_request", builder: inspect_request_schema }),
+        response_schema: Some(SchemaRef { id: "schema.ai.inspect_response", builder: inspect_response_schema }),
+        supports_json: true,
+        supports_progress: true,
+    },
+    CommandSpec {
+        name: "lint",
+        aliases: &["readiness"],
+        description: "Run model readiness checks.",
+        usage: "valid lint <model-file> [--json] [--progress=json]",
+        positional: &[MODEL_FILE_ARG],
+        options: LINT_OPTIONS,
+        request_schema: Some(SchemaRef { id: "schema.ai.inspect_request", builder: inspect_request_schema }),
+        response_schema: Some(SchemaRef { id: "schema.cli.lint_response", builder: lint_response_schema }),
+        supports_json: true,
+        supports_progress: true,
+    },
+    CommandSpec {
+        name: "capabilities",
+        aliases: &[],
+        description: "Report backend capabilities.",
+        usage: "valid capabilities [--json] [--progress=json] [--backend=<explicit|mock-bmc|sat-varisat|smt-cvc5|command>] [--solver-exec <path>] [--solver-arg <arg>]",
+        positional: &[],
+        options: CAPABILITY_OPTIONS,
+        request_schema: Some(SchemaRef { id: "schema.ai.capabilities_request", builder: capabilities_request_schema }),
+        response_schema: Some(SchemaRef { id: "schema.ai.capabilities_response", builder: capabilities_response_schema }),
+        supports_json: true,
+        supports_progress: true,
+    },
+    CommandSpec {
+        name: "explain",
+        aliases: &[],
+        description: "Explain a failing property.",
+        usage: "valid explain <model-file> [--json] [--progress=json] [--property=<id>] [--backend=<...>] [--solver-exec <path>] [--solver-arg <arg>]",
+        positional: &[MODEL_FILE_ARG],
+        options: EXPLAIN_OPTIONS,
+        request_schema: Some(SchemaRef { id: "schema.ai.check_request", builder: check_request_schema }),
+        response_schema: Some(SchemaRef { id: "schema.ai.explain_response", builder: explain_response_schema }),
+        supports_json: true,
+        supports_progress: true,
+    },
+    CommandSpec {
+        name: "minimize",
+        aliases: &[],
+        description: "Minimize a counterexample trace.",
+        usage: "valid minimize <model-file> [--json] [--progress=json] [--property=<id>] [--backend=<...>] [--solver-exec <path>] [--solver-arg <arg>]",
+        positional: &[MODEL_FILE_ARG],
+        options: MINIMIZE_OPTIONS,
+        request_schema: None,
+        response_schema: Some(SchemaRef { id: "schema.ai.minimize_response", builder: minimize_response_schema }),
+        supports_json: true,
+        supports_progress: true,
+    },
+    CommandSpec {
+        name: "contract",
+        aliases: &[],
+        description: "Manage contract snapshots and drift.",
+        usage: "valid contract <snapshot|lock|drift> <model-file> [lock-file] [--json] [--progress=json]",
+        positional: &[CONTRACT_SUBCOMMAND_ARG, MODEL_FILE_ARG, LOCK_FILE_ARG],
+        options: &[JSON_ARG, PROGRESS_ARG],
+        request_schema: None,
+        response_schema: Some(SchemaRef { id: "schema.cli.contract_response", builder: valid_contract_response_schema }),
+        supports_json: true,
+        supports_progress: true,
+    },
+    CommandSpec {
+        name: "trace",
+        aliases: &[],
+        description: "Render a verification trace.",
+        usage: "valid trace <model-file> [--format=mermaid-state|mermaid-sequence|json] [--property=<id>] [--json] [--progress=json] [--backend=<...>] [--solver-exec <path>] [--solver-arg <arg>]",
+        positional: &[MODEL_FILE_ARG],
+        options: TRACE_OPTIONS,
+        request_schema: Some(SchemaRef { id: "schema.ai.check_request", builder: check_request_schema }),
+        response_schema: Some(SchemaRef { id: "schema.evidence_trace", builder: evidence_trace_schema }),
+        supports_json: true,
+        supports_progress: true,
+    },
+    CommandSpec {
+        name: "orchestrate",
+        aliases: &[],
+        description: "Run all properties for one model.",
+        usage: "valid orchestrate <model-file> [--json] [--progress=json] [--backend=<...>] [--solver-exec <path>] [--solver-arg <arg>]",
+        positional: &[MODEL_FILE_ARG],
+        options: ORCHESTRATE_OPTIONS,
+        request_schema: Some(SchemaRef { id: "schema.ai.orchestrate_request", builder: orchestrate_request_schema }),
+        response_schema: Some(SchemaRef { id: "schema.ai.orchestrate_response", builder: orchestrate_response_schema }),
+        supports_json: true,
+        supports_progress: true,
+    },
+    CommandSpec {
+        name: "testgen",
+        aliases: &["generate-tests"],
+        description: "Generate replayable test vectors.",
+        usage: "valid testgen <model-file> [--json] [--progress=json] [--property=<id>] [--strategy=<...>] [--backend=<...>] [--solver-exec <path>] [--solver-arg <arg>]",
+        positional: &[MODEL_FILE_ARG],
+        options: TESTGEN_OPTIONS,
+        request_schema: Some(SchemaRef { id: "schema.ai.testgen_request", builder: testgen_request_schema }),
+        response_schema: Some(SchemaRef { id: "schema.ai.testgen_response", builder: testgen_response_schema }),
+        supports_json: true,
+        supports_progress: true,
+    },
+    CommandSpec {
+        name: "replay",
+        aliases: &[],
+        description: "Replay a sequence of actions.",
+        usage: "valid replay <model-file> [--json] [--progress=json] [--property=<id>] [--focus-action=<id>] [--actions=a,b,c]",
+        positional: &[MODEL_FILE_ARG],
+        options: REPLAY_OPTIONS,
+        request_schema: None,
+        response_schema: Some(SchemaRef { id: "schema.cli.replay_response", builder: replay_response_schema }),
+        supports_json: true,
+        supports_progress: true,
+    },
+    CommandSpec {
+        name: "coverage",
+        aliases: &[],
+        description: "Compute coverage from executed traces.",
+        usage: "valid coverage <model-file> [--json] [--progress=json] [--property=<id>] [--backend=<...>] [--solver-exec <path>] [--solver-arg <arg>]",
+        positional: &[MODEL_FILE_ARG],
+        options: COVERAGE_OPTIONS,
+        request_schema: Some(SchemaRef { id: "schema.ai.check_request", builder: check_request_schema }),
+        response_schema: Some(SchemaRef { id: "schema.coverage_report", builder: coverage_report_schema }),
+        supports_json: true,
+        supports_progress: true,
+    },
+    CommandSpec {
+        name: "clean",
+        aliases: &[],
+        description: "Remove generated artifacts.",
+        usage: "valid clean [generated|artifacts|all] [--json] [--progress=json]",
+        positional: &[CLEAN_SCOPE_ARG],
+        options: CLEAN_OPTIONS,
+        request_schema: None,
+        response_schema: Some(SchemaRef { id: "schema.cli.clean_response", builder: clean_response_schema }),
+        supports_json: true,
+        supports_progress: true,
+    },
+    CommandSpec {
+        name: "selfcheck",
+        aliases: &[],
+        description: "Run built-in smoke selfcheck.",
+        usage: "valid selfcheck [--json] [--progress=json]",
+        positional: &[],
+        options: &[JSON_ARG, PROGRESS_ARG],
+        request_schema: None,
+        response_schema: Some(SchemaRef { id: "schema.selfcheck_report", builder: selfcheck_schema }),
+        supports_json: true,
+        supports_progress: true,
+    },
+    CommandSpec {
+        name: "commands",
+        aliases: &[],
+        description: "List command metadata.",
+        usage: "valid commands --json",
+        positional: &[],
+        options: COMMANDS_OPTIONS,
+        request_schema: None,
+        response_schema: Some(SchemaRef { id: "schema.cli.commands_response", builder: commands_response_schema }),
+        supports_json: true,
+        supports_progress: false,
+    },
+    CommandSpec {
+        name: "schema",
+        aliases: &[],
+        description: "Return machine-readable schemas for a command.",
+        usage: "valid schema <command>",
+        positional: &[COMMAND_NAME_ARG],
+        options: SCHEMA_OPTIONS,
+        request_schema: None,
+        response_schema: Some(SchemaRef { id: "schema.cli.schema_response", builder: schema_response_schema }),
+        supports_json: true,
+        supports_progress: false,
+    },
+    CommandSpec {
+        name: "batch",
+        aliases: &[],
+        description: "Execute multiple CLI operations from one JSON request on stdin.",
+        usage: "valid batch [--json] [--progress=json] < batch.json",
+        positional: &[],
+        options: BATCH_OPTIONS,
+        request_schema: Some(SchemaRef { id: "schema.cli.batch_request", builder: batch_request_schema }),
+        response_schema: Some(SchemaRef { id: "schema.cli.batch_response", builder: batch_response_schema }),
+        supports_json: true,
+        supports_progress: true,
+    },
+];
+
+const REGISTRY_COMMANDS: &[CommandSpec] = &[
+    CommandSpec {
+        name: "list",
+        aliases: &["models"],
+        description: "List registered models.",
+        usage: "<registry-bin> list [--json]",
+        positional: &[],
+        options: &[JSON_ARG],
+        request_schema: None,
+        response_schema: Some(SchemaRef { id: "schema.cli.list_response", builder: list_response_schema }),
+        supports_json: true,
+        supports_progress: false,
+    },
+    CommandSpec {
+        name: "inspect",
+        aliases: &[],
+        description: "Inspect a registered model.",
+        usage: "<registry-bin> inspect <model> [--json] [--progress=json]",
+        positional: &[MODEL_ARG],
+        options: &[JSON_ARG, PROGRESS_ARG],
+        request_schema: Some(SchemaRef { id: "schema.ai.inspect_request", builder: inspect_request_schema }),
+        response_schema: Some(SchemaRef { id: "schema.ai.inspect_response", builder: inspect_response_schema }),
+        supports_json: true,
+        supports_progress: true,
+    },
+    CommandSpec {
+        name: "graph",
+        aliases: &["diagram"],
+        description: "Render a registered model graph.",
+        usage: "<registry-bin> graph <model> [--format=mermaid|dot|svg|text|json] [--view=<overview|logic>] [--json] [--progress=json]",
+        positional: &[MODEL_ARG],
+        options: GRAPH_OPTIONS,
+        request_schema: Some(SchemaRef { id: "schema.ai.inspect_request", builder: inspect_request_schema }),
+        response_schema: Some(SchemaRef { id: "schema.ai.inspect_response", builder: inspect_response_schema }),
+        supports_json: true,
+        supports_progress: true,
+    },
+    CommandSpec {
+        name: "lint",
+        aliases: &["readiness"],
+        description: "Run readiness checks on a registered model.",
+        usage: "<registry-bin> lint <model> [--json] [--progress=json]",
+        positional: &[MODEL_ARG],
+        options: LINT_OPTIONS,
+        request_schema: Some(SchemaRef { id: "schema.ai.inspect_request", builder: inspect_request_schema }),
+        response_schema: Some(SchemaRef { id: "schema.cli.lint_response", builder: lint_response_schema }),
+        supports_json: true,
+        supports_progress: true,
+    },
+    CommandSpec {
+        name: "benchmark",
+        aliases: &["bench"],
+        description: "Benchmark a registered model.",
+        usage: "<registry-bin> benchmark <model> [--json] [--progress=json] [--property=<id>] [--repeat=<n>] [--baseline[=compare|record|ignore]] [--threshold-percent=<n>] [--backend=<...>] [--solver-exec <path>] [--solver-arg <arg>]",
+        positional: &[MODEL_ARG],
+        options: BENCHMARK_OPTIONS,
+        request_schema: None,
+        response_schema: Some(SchemaRef { id: "schema.cli.benchmark_response", builder: benchmark_response_schema }),
+        supports_json: true,
+        supports_progress: true,
+    },
+    CommandSpec {
+        name: "migrate",
+        aliases: &[],
+        description: "Generate declarative migration snippets.",
+        usage: "<registry-bin> migrate <model> [--json] [--progress=json] [--write[=<path>]] [--check]",
+        positional: &[MODEL_ARG],
+        options: MIGRATE_OPTIONS,
+        request_schema: None,
+        response_schema: Some(SchemaRef { id: "schema.cli.migration_response", builder: migration_response_schema }),
+        supports_json: true,
+        supports_progress: true,
+    },
+    CommandSpec {
+        name: "check",
+        aliases: &["verify"],
+        description: "Verify a registered model.",
+        usage: "<registry-bin> check <model> [--json] [--progress=json] [--property=<id>] [--backend=<...>] [--solver-exec <path>] [--solver-arg <arg>]",
+        positional: &[MODEL_ARG],
+        options: CHECK_OPTIONS,
+        request_schema: Some(SchemaRef { id: "schema.ai.check_request", builder: check_request_schema }),
+        response_schema: Some(SchemaRef { id: "schema.run_result", builder: run_result_schema }),
+        supports_json: true,
+        supports_progress: true,
+    },
+    CommandSpec {
+        name: "explain",
+        aliases: &[],
+        description: "Explain a failing registered model property.",
+        usage: "<registry-bin> explain <model> [--json] [--progress=json]",
+        positional: &[MODEL_ARG],
+        options: &[JSON_ARG, PROGRESS_ARG],
+        request_schema: Some(SchemaRef { id: "schema.ai.check_request", builder: check_request_schema }),
+        response_schema: Some(SchemaRef { id: "schema.ai.explain_response", builder: explain_response_schema }),
+        supports_json: true,
+        supports_progress: true,
+    },
+    CommandSpec {
+        name: "coverage",
+        aliases: &[],
+        description: "Return registered model coverage.",
+        usage: "<registry-bin> coverage <model> [--json] [--progress=json]",
+        positional: &[MODEL_ARG],
+        options: &[JSON_ARG, PROGRESS_ARG],
+        request_schema: None,
+        response_schema: Some(SchemaRef { id: "schema.coverage_report", builder: coverage_report_schema }),
+        supports_json: true,
+        supports_progress: true,
+    },
+    CommandSpec {
+        name: "orchestrate",
+        aliases: &[],
+        description: "Run all registered model properties.",
+        usage: "<registry-bin> orchestrate <model> [--json] [--progress=json] [--backend=<...>] [--solver-exec <path>] [--solver-arg <arg>]",
+        positional: &[MODEL_ARG],
+        options: ORCHESTRATE_OPTIONS,
+        request_schema: Some(SchemaRef { id: "schema.ai.orchestrate_request", builder: orchestrate_request_schema }),
+        response_schema: Some(SchemaRef { id: "schema.ai.orchestrate_response", builder: orchestrate_response_schema }),
+        supports_json: true,
+        supports_progress: true,
+    },
+    CommandSpec {
+        name: "testgen",
+        aliases: &["generate-tests"],
+        description: "Generate test vectors for a registered model.",
+        usage: "<registry-bin> testgen <model> [--json] [--progress=json] [--property=<id>] [--strategy=<...>]",
+        positional: &[MODEL_ARG],
+        options: &[JSON_ARG, PROGRESS_ARG, PROPERTY_ARG, STRATEGY_ARG],
+        request_schema: Some(SchemaRef { id: "schema.ai.testgen_request", builder: testgen_request_schema }),
+        response_schema: Some(SchemaRef { id: "schema.ai.testgen_response", builder: testgen_response_schema }),
+        supports_json: true,
+        supports_progress: true,
+    },
+    CommandSpec {
+        name: "replay",
+        aliases: &[],
+        description: "Replay registered model actions.",
+        usage: "<registry-bin> replay <model> [--json] [--progress=json] [--property=<id>] [--focus-action=<id>] [--actions=a,b,c]",
+        positional: &[MODEL_ARG],
+        options: REPLAY_OPTIONS,
+        request_schema: None,
+        response_schema: Some(SchemaRef { id: "schema.cli.replay_response", builder: replay_response_schema }),
+        supports_json: true,
+        supports_progress: true,
+    },
+    CommandSpec {
+        name: "contract",
+        aliases: &[],
+        description: "Check contracts for all registered models.",
+        usage: "<registry-bin> contract <snapshot|lock|drift|check> [lock-file] [--json] [--progress=json]",
+        positional: &[CONTRACT_SUBCOMMAND_ARG, LOCK_FILE_ARG],
+        options: &[JSON_ARG, PROGRESS_ARG],
+        request_schema: None,
+        response_schema: Some(SchemaRef { id: "schema.cli.contract_response", builder: registry_contract_response_schema }),
+        supports_json: true,
+        supports_progress: true,
+    },
+    CommandSpec {
+        name: "commands",
+        aliases: &[],
+        description: "List command metadata.",
+        usage: "<registry-bin> commands --json",
+        positional: &[],
+        options: COMMANDS_OPTIONS,
+        request_schema: None,
+        response_schema: Some(SchemaRef { id: "schema.cli.commands_response", builder: commands_response_schema }),
+        supports_json: true,
+        supports_progress: false,
+    },
+    CommandSpec {
+        name: "schema",
+        aliases: &[],
+        description: "Return machine-readable schemas for a command.",
+        usage: "<registry-bin> schema <command>",
+        positional: &[COMMAND_NAME_ARG],
+        options: SCHEMA_OPTIONS,
+        request_schema: None,
+        response_schema: Some(SchemaRef { id: "schema.cli.schema_response", builder: schema_response_schema }),
+        supports_json: true,
+        supports_progress: false,
+    },
+    CommandSpec {
+        name: "batch",
+        aliases: &[],
+        description: "Execute multiple registry commands from one JSON request on stdin.",
+        usage: "<registry-bin> batch [--json] [--progress=json] < batch.json",
+        positional: &[],
+        options: BATCH_OPTIONS,
+        request_schema: Some(SchemaRef { id: "schema.cli.batch_request", builder: batch_request_schema }),
+        response_schema: Some(SchemaRef { id: "schema.cli.batch_response", builder: batch_response_schema }),
+        supports_json: true,
+        supports_progress: true,
+    },
+];
+
+const CARGO_VALID_COMMANDS: &[CommandSpec] = &[
+    CommandSpec {
+        name: "init",
+        aliases: &[],
+        description: "Scaffold valid.toml and registry source.",
+        usage: "cargo valid init [--json] [--progress=json]",
+        positional: &[],
+        options: &[JSON_ARG, PROGRESS_ARG],
+        request_schema: None,
+        response_schema: Some(SchemaRef { id: "schema.cli.init_response", builder: init_response_schema }),
+        supports_json: true,
+        supports_progress: true,
+    },
+    CommandSpec {
+        name: "clean",
+        aliases: &[],
+        description: "Remove generated artifacts in a project.",
+        usage: "cargo valid clean [generated|artifacts|all] [--json] [--progress=json]",
+        positional: &[CLEAN_SCOPE_ARG],
+        options: &[JSON_ARG, PROGRESS_ARG, MANIFEST_ARG],
+        request_schema: None,
+        response_schema: Some(SchemaRef { id: "schema.cli.clean_response", builder: clean_response_schema }),
+        supports_json: true,
+        supports_progress: true,
+    },
+    CommandSpec {
+        name: "list",
+        aliases: &["models"],
+        description: "List bundled or project models.",
+        usage: "cargo valid models [--json]",
+        positional: &[],
+        options: &[JSON_ARG, MANIFEST_ARG, REGISTRY_ARG, FILE_ARG, EXAMPLE_ARG, BIN_ARG],
+        request_schema: None,
+        response_schema: Some(SchemaRef { id: "schema.cli.list_response", builder: list_response_schema }),
+        supports_json: true,
+        supports_progress: false,
+    },
+    CommandSpec {
+        name: "inspect",
+        aliases: &[],
+        description: "Inspect a bundled or project model.",
+        usage: "cargo valid inspect <model> [--json] [--progress=json]",
+        positional: &[MODEL_ARG],
+        options: &[JSON_ARG, PROGRESS_ARG, MANIFEST_ARG, REGISTRY_ARG, FILE_ARG, EXAMPLE_ARG, BIN_ARG],
+        request_schema: Some(SchemaRef { id: "schema.ai.inspect_request", builder: inspect_request_schema }),
+        response_schema: Some(SchemaRef { id: "schema.ai.inspect_response", builder: inspect_response_schema }),
+        supports_json: true,
+        supports_progress: true,
+    },
+    CommandSpec {
+        name: "graph",
+        aliases: &["diagram"],
+        description: "Render a model graph.",
+        usage: "cargo valid graph <model> [--format=mermaid|dot|svg|text|json] [--view=<overview|logic>] [--json] [--progress=json]",
+        positional: &[MODEL_ARG],
+        options: &[FORMAT_ARG, VIEW_ARG, JSON_ARG, PROGRESS_ARG, MANIFEST_ARG, REGISTRY_ARG, FILE_ARG, EXAMPLE_ARG, BIN_ARG],
+        request_schema: Some(SchemaRef { id: "schema.ai.inspect_request", builder: inspect_request_schema }),
+        response_schema: Some(SchemaRef { id: "schema.ai.inspect_response", builder: inspect_response_schema }),
+        supports_json: true,
+        supports_progress: true,
+    },
+    CommandSpec {
+        name: "lint",
+        aliases: &["readiness"],
+        description: "Run model readiness checks.",
+        usage: "cargo valid lint <model> [--json] [--progress=json]",
+        positional: &[MODEL_ARG],
+        options: &[JSON_ARG, PROGRESS_ARG, MANIFEST_ARG, REGISTRY_ARG, FILE_ARG, EXAMPLE_ARG, BIN_ARG],
+        request_schema: Some(SchemaRef { id: "schema.ai.inspect_request", builder: inspect_request_schema }),
+        response_schema: Some(SchemaRef { id: "schema.cli.lint_response", builder: lint_response_schema }),
+        supports_json: true,
+        supports_progress: true,
+    },
+    CommandSpec {
+        name: "benchmark",
+        aliases: &["bench"],
+        description: "Benchmark one model or suite.",
+        usage: "cargo valid benchmark <model> [--json] [--progress=json] [--property=<id>] [--repeat=<n>] [--baseline[=compare|record|ignore]] [--threshold-percent=<n>]",
+        positional: &[MODEL_ARG],
+        options: &[JSON_ARG, PROGRESS_ARG, PROPERTY_ARG, REPEAT_ARG, BASELINE_ARG, THRESHOLD_ARG, BACKEND_ARG, SOLVER_EXEC_ARG, SOLVER_ARG_ARG, MANIFEST_ARG, REGISTRY_ARG, FILE_ARG, EXAMPLE_ARG, BIN_ARG],
+        request_schema: None,
+        response_schema: Some(SchemaRef { id: "schema.cli.benchmark_response", builder: benchmark_response_schema }),
+        supports_json: true,
+        supports_progress: true,
+    },
+    CommandSpec {
+        name: "migrate",
+        aliases: &[],
+        description: "Generate migration snippets for step models.",
+        usage: "cargo valid migrate <model> [--json] [--progress=json] [--write[=<path>]] [--check]",
+        positional: &[MODEL_ARG],
+        options: &[JSON_ARG, PROGRESS_ARG, WRITE_ARG, CHECK_ARG, MANIFEST_ARG, REGISTRY_ARG, FILE_ARG, EXAMPLE_ARG, BIN_ARG],
+        request_schema: None,
+        response_schema: Some(SchemaRef { id: "schema.cli.migration_response", builder: migration_response_schema }),
+        supports_json: true,
+        supports_progress: true,
+    },
+    CommandSpec {
+        name: "check",
+        aliases: &["verify"],
+        description: "Verify a model.",
+        usage: "cargo valid verify <model> [--json] [--progress=json] [--property=<id>] [--backend=<...>] [--solver-exec <path>] [--solver-arg <arg>]",
+        positional: &[MODEL_ARG],
+        options: &[JSON_ARG, PROGRESS_ARG, PROPERTY_ARG, BACKEND_ARG, SOLVER_EXEC_ARG, SOLVER_ARG_ARG, MANIFEST_ARG, REGISTRY_ARG, FILE_ARG, EXAMPLE_ARG, BIN_ARG],
+        request_schema: Some(SchemaRef { id: "schema.ai.check_request", builder: check_request_schema }),
+        response_schema: Some(SchemaRef { id: "schema.run_result", builder: run_result_schema }),
+        supports_json: true,
+        supports_progress: true,
+    },
+    CommandSpec {
+        name: "all",
+        aliases: &["suite"],
+        description: "Run verification across multiple models.",
+        usage: "cargo valid suite [--json] [--progress=json]",
+        positional: &[],
+        options: &[JSON_ARG, PROGRESS_ARG, PROPERTY_ARG, BACKEND_ARG, SOLVER_EXEC_ARG, SOLVER_ARG_ARG, MANIFEST_ARG, REGISTRY_ARG, FILE_ARG, EXAMPLE_ARG, BIN_ARG],
+        request_schema: None,
+        response_schema: Some(SchemaRef { id: "schema.cli.batch_runs_response", builder: batch_runs_response_schema }),
+        supports_json: true,
+        supports_progress: true,
+    },
+    CommandSpec {
+        name: "explain",
+        aliases: &[],
+        description: "Explain a failing model property.",
+        usage: "cargo valid explain <model> [--json] [--progress=json]",
+        positional: &[MODEL_ARG],
+        options: &[JSON_ARG, PROGRESS_ARG, MANIFEST_ARG, REGISTRY_ARG, FILE_ARG, EXAMPLE_ARG, BIN_ARG],
+        request_schema: Some(SchemaRef { id: "schema.ai.check_request", builder: check_request_schema }),
+        response_schema: Some(SchemaRef { id: "schema.ai.explain_response", builder: explain_response_schema }),
+        supports_json: true,
+        supports_progress: true,
+    },
+    CommandSpec {
+        name: "coverage",
+        aliases: &[],
+        description: "Compute coverage for a model.",
+        usage: "cargo valid coverage <model> [--json] [--progress=json]",
+        positional: &[MODEL_ARG],
+        options: &[JSON_ARG, PROGRESS_ARG, MANIFEST_ARG, REGISTRY_ARG, FILE_ARG, EXAMPLE_ARG, BIN_ARG],
+        request_schema: None,
+        response_schema: Some(SchemaRef { id: "schema.coverage_report", builder: coverage_report_schema }),
+        supports_json: true,
+        supports_progress: true,
+    },
+    CommandSpec {
+        name: "orchestrate",
+        aliases: &[],
+        description: "Run all properties for one model.",
+        usage: "cargo valid orchestrate <model> [--json] [--progress=json] [--backend=<...>] [--solver-exec <path>] [--solver-arg <arg>]",
+        positional: &[MODEL_ARG],
+        options: &[JSON_ARG, PROGRESS_ARG, BACKEND_ARG, SOLVER_EXEC_ARG, SOLVER_ARG_ARG, MANIFEST_ARG, REGISTRY_ARG, FILE_ARG, EXAMPLE_ARG, BIN_ARG],
+        request_schema: Some(SchemaRef { id: "schema.ai.orchestrate_request", builder: orchestrate_request_schema }),
+        response_schema: Some(SchemaRef { id: "schema.ai.orchestrate_response", builder: orchestrate_response_schema }),
+        supports_json: true,
+        supports_progress: true,
+    },
+    CommandSpec {
+        name: "testgen",
+        aliases: &["generate-tests"],
+        description: "Generate test vectors for a model.",
+        usage: "cargo valid testgen <model> [--json] [--progress=json] [--property=<id>] [--strategy=<...>]",
+        positional: &[MODEL_ARG],
+        options: &[JSON_ARG, PROGRESS_ARG, PROPERTY_ARG, STRATEGY_ARG, MANIFEST_ARG, REGISTRY_ARG, FILE_ARG, EXAMPLE_ARG, BIN_ARG],
+        request_schema: Some(SchemaRef { id: "schema.ai.testgen_request", builder: testgen_request_schema }),
+        response_schema: Some(SchemaRef { id: "schema.ai.testgen_response", builder: testgen_response_schema }),
+        supports_json: true,
+        supports_progress: true,
+    },
+    CommandSpec {
+        name: "replay",
+        aliases: &[],
+        description: "Replay model actions.",
+        usage: "cargo valid replay <model> [--json] [--progress=json] [--property=<id>] [--focus-action=<id>] [--actions=a,b,c]",
+        positional: &[MODEL_ARG],
+        options: &[JSON_ARG, PROGRESS_ARG, PROPERTY_ARG, FOCUS_ACTION_ARG, ACTIONS_ARG, MANIFEST_ARG, REGISTRY_ARG, FILE_ARG, EXAMPLE_ARG, BIN_ARG],
+        request_schema: None,
+        response_schema: Some(SchemaRef { id: "schema.cli.replay_response", builder: replay_response_schema }),
+        supports_json: true,
+        supports_progress: true,
+    },
+    CommandSpec {
+        name: "commands",
+        aliases: &[],
+        description: "List command metadata.",
+        usage: "cargo valid commands --json",
+        positional: &[],
+        options: &[JSON_ARG],
+        request_schema: None,
+        response_schema: Some(SchemaRef { id: "schema.cli.commands_response", builder: commands_response_schema }),
+        supports_json: true,
+        supports_progress: false,
+    },
+    CommandSpec {
+        name: "schema",
+        aliases: &[],
+        description: "Return machine-readable schemas for a command.",
+        usage: "cargo valid schema <command>",
+        positional: &[COMMAND_NAME_ARG],
+        options: &[JSON_ARG],
+        request_schema: None,
+        response_schema: Some(SchemaRef { id: "schema.cli.schema_response", builder: schema_response_schema }),
+        supports_json: true,
+        supports_progress: false,
+    },
+    CommandSpec {
+        name: "batch",
+        aliases: &[],
+        description: "Execute multiple cargo-valid operations from one JSON request on stdin.",
+        usage: "cargo valid batch [--json] [--progress=json] < batch.json",
+        positional: &[],
+        options: &[JSON_ARG, PROGRESS_ARG],
+        request_schema: Some(SchemaRef { id: "schema.cli.batch_request", builder: batch_request_schema }),
+        response_schema: Some(SchemaRef { id: "schema.cli.batch_response", builder: batch_response_schema }),
+        supports_json: true,
+        supports_progress: true,
+    },
+];
+
+pub fn command_specs(surface: Surface) -> &'static [CommandSpec] {
+    match surface {
+        Surface::Valid => VALID_COMMANDS,
+        Surface::CargoValid => CARGO_VALID_COMMANDS,
+        Surface::Registry => REGISTRY_COMMANDS,
+    }
+}
+
+pub fn find_command_spec(surface: Surface, command: &str) -> Option<&'static CommandSpec> {
+    command_specs(surface)
+        .iter()
+        .find(|spec| spec.name == command || spec.aliases.iter().any(|alias| *alias == command))
+}
+
+pub fn render_commands_json(surface: Surface) -> String {
+    let commands = command_specs(surface)
+        .iter()
+        .map(|spec| {
+            json!({
+                "name": spec.name,
+                "aliases": spec.aliases,
+                "description": spec.description,
+                "usage": spec.usage,
+                "supports_json": spec.supports_json,
+                "supports_progress": spec.supports_progress,
+                "positional": spec.positional,
+                "options": spec.options,
+                "schemas": {
+                    "parameters": parameter_schema_id(surface, spec.name),
+                    "request": spec.request_schema.map(|schema| schema.id),
+                    "response": spec.response_schema.map(|schema| schema.id),
+                    "error": "schema.cli.error",
+                    "progress": if spec.supports_progress { Some("schema.cli.progress") } else { None },
+                }
+            })
+        })
+        .collect::<Vec<_>>();
+    serde_json::to_string(&json!({
+        "schema_version": CLI_SCHEMA_VERSION,
+        "surface": surface.slug(),
+        "commands": commands
+    }))
+    .expect("commands json")
+}
+
+pub fn render_commands_text(surface: Surface) -> String {
+    let mut lines = Vec::new();
+    for spec in command_specs(surface) {
+        let alias = if spec.aliases.is_empty() {
+            String::new()
+        } else {
+            format!(" (aliases: {})", spec.aliases.join(", "))
+        };
+        lines.push(format!("{}{} - {}", spec.name, alias, spec.description));
+    }
+    lines.join("\n")
+}
+
+pub fn render_schema_json(surface: Surface, command: &str) -> Result<String, String> {
+    let Some(spec) = find_command_spec(surface, command) else {
+        return Err(format!("unknown command `{command}`"));
+    };
+    let value = json!({
+        "schema_version": CLI_SCHEMA_VERSION,
+        "surface": surface.slug(),
+        "command": spec.name,
+        "aliases": spec.aliases,
+        "description": spec.description,
+        "usage": spec.usage,
+        "parameter_schema_id": parameter_schema_id(surface, spec.name),
+        "parameter_schema": parameter_schema(surface, spec),
+        "request_schema_id": spec.request_schema.map(|schema| schema.id),
+        "request_schema": spec.request_schema.map(|schema| (schema.builder)()),
+        "response_schema_id": spec.response_schema.map(|schema| schema.id),
+        "response_schema": spec.response_schema.map(|schema| (schema.builder)()),
+        "error_schema_id": "schema.cli.error",
+        "error_schema": cli_error_schema(),
+        "progress_schema_id": if spec.supports_progress { Some("schema.cli.progress") } else { None },
+        "progress_schema": if spec.supports_progress { Some(cli_progress_schema()) } else { None },
+    });
+    serde_json::to_string(&value).map_err(|err| err.to_string())
+}
+
+pub fn detect_json_flag(args: &[String]) -> bool {
+    args.iter().any(|arg| arg == "--json")
+}
+
+pub fn detect_progress_json_flag(args: &[String]) -> bool {
+    args.iter().any(|arg| arg == "--progress=json")
+}
+
+pub fn render_cli_error_json(
+    command: &str,
+    diagnostics: &[Diagnostic],
+    usage: Option<&str>,
+) -> String {
+    let mut value = json!({
+        "schema_version": CLI_SCHEMA_VERSION,
+        "kind": "cli_error",
+        "command": command,
+        "status": ExitCode::Error.status_label(),
+        "exit_code": ExitCode::Error.code(),
+        "diagnostics": diagnostics.iter().map(diagnostic_to_value).collect::<Vec<_>>(),
+    });
+    if let Some(usage) = usage {
+        value["usage"] = Value::String(usage.to_string());
+    }
+    serde_json::to_string(&value).expect("cli error json")
+}
+
+pub fn render_cli_warning_json(command: &str, message: &str) -> String {
+    serde_json::to_string(&json!({
+        "schema_version": CLI_SCHEMA_VERSION,
+        "kind": "warning",
+        "command": command,
+        "message": message
+    }))
+    .expect("cli warning json")
+}
+
+pub fn message_diagnostic(message: impl Into<String>) -> Diagnostic {
+    Diagnostic::new(
+        ErrorCode::SearchError,
+        DiagnosticSegment::EngineSearch,
+        message.into(),
+    )
+}
+
+pub fn usage_diagnostic(message: impl Into<String>, usage: &str) -> Diagnostic {
+    message_diagnostic(message).with_help(usage)
+}
+
+pub fn parse_batch_request(body: &str) -> Result<BatchRequest, String> {
+    let request: BatchRequest = serde_json::from_str(body).map_err(|err| err.to_string())?;
+    if request.operations.is_empty() {
+        return Err("batch request requires at least one operation".to_string());
+    }
+    if request.schema_version.trim().is_empty() {
+        return Err("schema_version must be a non-empty string".to_string());
+    }
+    Ok(request)
+}
+
+pub fn render_batch_response(exit_code: ExitCode, results: Vec<BatchResult>) -> String {
+    serde_json::to_string(&BatchResponse {
+        schema_version: CLI_SCHEMA_VERSION.to_string(),
+        status: exit_code.status_label(),
+        exit_code: exit_code.code(),
+        results,
+    })
+    .expect("batch response json")
+}
+
+pub fn child_stream_to_json(bytes: &[u8]) -> Value {
+    if bytes.is_empty() {
+        return Value::Null;
+    }
+    match serde_json::from_slice::<Value>(bytes) {
+        Ok(value) => value,
+        Err(_) => Value::String(String::from_utf8_lossy(bytes).trim().to_string()),
+    }
+}
+
+fn diagnostic_to_value(diagnostic: &Diagnostic) -> Value {
+    json!({
+        "error_code": diagnostic.error_code.as_str(),
+        "segment": diagnostic.segment.as_str(),
+        "severity": match diagnostic.severity {
+            crate::support::diagnostics::Severity::Info => "info",
+            crate::support::diagnostics::Severity::Warning => "warning",
+            crate::support::diagnostics::Severity::Error => "error",
+        },
+        "message": diagnostic.message,
+        "primary_span": diagnostic.primary_span.as_ref().map(|span| json!({
+            "source": span.source,
+            "line": span.line,
+            "column": span.column
+        })),
+        "conflicts": diagnostic.conflicts,
+        "help": diagnostic.help,
+        "best_practices": diagnostic.best_practices,
+    })
+}
+
+fn parameter_schema_id(surface: Surface, command: &str) -> String {
+    format!("schema.cli.{}.{}.parameters", surface.slug(), command)
+}
+
+fn parameter_schema(surface: Surface, spec: &CommandSpec) -> Value {
+    let mut properties = Map::new();
+    let mut required = Vec::new();
+    for arg in spec.positional.iter().chain(spec.options.iter()) {
+        properties.insert(arg.name.to_string(), arg_schema(arg));
+        if arg.required {
+            required.push(Value::String(arg.name.to_string()));
+        }
+    }
+    json!({
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$id": parameter_schema_id(surface, spec.name),
+        "type": "object",
+        "additionalProperties": false,
+        "required": required,
+        "properties": properties,
+    })
+}
+
+fn arg_schema(arg: &ArgSpec) -> Value {
+    let mut merged = match arg.value_type {
+        "boolean" => Map::from_iter([("type".to_string(), Value::String("boolean".to_string()))]),
+        "integer" => Map::from_iter([
+            ("type".to_string(), Value::String("integer".to_string())),
+            ("minimum".to_string(), Value::from(0)),
+        ]),
+        "array" => Map::from_iter([
+            ("type".to_string(), Value::String("array".to_string())),
+            ("items".to_string(), json!({ "type": "string" })),
+        ]),
+        _ => Map::from_iter([("type".to_string(), Value::String("string".to_string()))]),
+    };
+    merged.insert(
+        "description".to_string(),
+        Value::String(arg.description.to_string()),
+    );
+    merged.insert(
+        "x-cli-syntax".to_string(),
+        Value::String(arg.syntax.to_string()),
+    );
+    merged.insert("x-cli-positional".to_string(), Value::Bool(arg.positional));
+    if !arg.values.is_empty() {
+        merged.insert(
+            "enum".to_string(),
+            Value::Array(
+                arg.values
+                    .iter()
+                    .map(|value| Value::String((*value).to_string()))
+                    .collect(),
+            ),
+        );
+    }
+    Value::Object(merged)
+}
+
+fn schema_version_string() -> String {
+    CLI_SCHEMA_VERSION.to_string()
+}
+
+fn default_true() -> bool {
+    true
+}
+
+fn default_continue_on_error() -> bool {
+    true
+}
+
+fn parse_schema(body: &str) -> Value {
+    serde_json::from_str(body).expect("valid embedded schema")
+}
+
+fn run_result_schema() -> Value {
+    parse_schema(RUN_RESULT_SCHEMA)
+}
+
+fn evidence_trace_schema() -> Value {
+    parse_schema(EVIDENCE_TRACE_SCHEMA)
+}
+
+fn coverage_report_schema() -> Value {
+    parse_schema(COVERAGE_REPORT_SCHEMA)
+}
+
+fn contract_snapshot_schema() -> Value {
+    parse_schema(CONTRACT_SNAPSHOT_SCHEMA)
+}
+
+fn contract_lock_schema() -> Value {
+    parse_schema(CONTRACT_LOCK_SCHEMA)
+}
+
+fn contract_drift_schema() -> Value {
+    parse_schema(CONTRACT_DRIFT_SCHEMA)
+}
+
+fn selfcheck_schema() -> Value {
+    parse_schema(SELF_CHECK_SCHEMA)
+}
+
+fn inspect_request_schema() -> Value {
+    parse_schema(INSPECT_REQUEST_SCHEMA)
+}
+
+fn inspect_response_schema() -> Value {
+    parse_schema(INSPECT_RESPONSE_SCHEMA)
+}
+
+fn check_request_schema() -> Value {
+    parse_schema(CHECK_REQUEST_SCHEMA)
+}
+
+fn explain_response_schema() -> Value {
+    parse_schema(EXPLAIN_RESPONSE_SCHEMA)
+}
+
+fn minimize_response_schema() -> Value {
+    parse_schema(MINIMIZE_RESPONSE_SCHEMA)
+}
+
+fn testgen_request_schema() -> Value {
+    parse_schema(TESTGEN_REQUEST_SCHEMA)
+}
+
+fn testgen_response_schema() -> Value {
+    parse_schema(TESTGEN_RESPONSE_SCHEMA)
+}
+
+fn orchestrate_request_schema() -> Value {
+    parse_schema(ORCHESTRATE_REQUEST_SCHEMA)
+}
+
+fn orchestrate_response_schema() -> Value {
+    parse_schema(ORCHESTRATE_RESPONSE_SCHEMA)
+}
+
+fn capabilities_request_schema() -> Value {
+    parse_schema(CAPABILITIES_REQUEST_SCHEMA)
+}
+
+fn capabilities_response_schema() -> Value {
+    parse_schema(CAPABILITIES_RESPONSE_SCHEMA)
+}
+
+fn lint_response_schema() -> Value {
+    json!({
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$id": "schema.cli.lint_response",
+        "type": "object",
+        "required": ["schema_version", "request_id", "status", "model_id", "capabilities", "findings"],
+        "properties": {
+            "schema_version": { "type": "string" },
+            "request_id": { "type": "string" },
+            "status": { "type": "string" },
+            "model_id": { "type": "string" },
+            "capabilities": { "type": "object" },
+            "findings": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "required": ["severity", "code", "message"],
+                    "properties": {
+                        "severity": { "type": "string" },
+                        "code": { "type": "string" },
+                        "message": { "type": "string" },
+                        "field": { "type": ["string", "null"] },
+                        "action": { "type": ["string", "null"] }
+                    }
+                }
+            }
+        }
+    })
+}
+
+fn benchmark_response_schema() -> Value {
+    json!({
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$id": "schema.cli.benchmark_response",
+        "type": "object",
+        "required": ["summary", "baseline"],
+        "properties": {
+            "artifact_path": { "type": "string" },
+            "summary": {
+                "type": "object",
+                "required": ["schema_version", "request_id", "model_id", "backend", "repeat", "pass_count", "fail_count", "unknown_count", "error_count", "iterations"],
+                "properties": {
+                    "schema_version": { "type": "string" },
+                    "request_id": { "type": "string" },
+                    "model_id": { "type": "string" },
+                    "backend": { "type": "string" },
+                    "property_id": { "type": ["string", "null"] },
+                    "repeat": { "type": "integer", "minimum": 0 },
+                    "total_elapsed_ms": { "type": "integer", "minimum": 0 },
+                    "min_elapsed_ms": { "type": "integer", "minimum": 0 },
+                    "max_elapsed_ms": { "type": "integer", "minimum": 0 },
+                    "average_elapsed_ms": { "type": "integer", "minimum": 0 },
+                    "pass_count": { "type": "integer", "minimum": 0 },
+                    "fail_count": { "type": "integer", "minimum": 0 },
+                    "unknown_count": { "type": "integer", "minimum": 0 },
+                    "error_count": { "type": "integer", "minimum": 0 },
+                    "iterations": { "type": "array", "items": { "type": "object" } }
+                }
+            },
+            "baseline": { "type": ["object", "null"] }
+        }
+    })
+}
+
+fn migration_response_schema() -> Value {
+    json!({
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$id": "schema.cli.migration_response",
+        "type": "object",
+        "required": ["schema_version", "request_id", "status", "model_id", "snippets", "check"],
+        "properties": {
+            "written": { "type": "string" },
+            "schema_version": { "type": "string" },
+            "request_id": { "type": "string" },
+            "status": { "type": "string" },
+            "model_id": { "type": "string" },
+            "snippets": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "required": ["code", "snippet"],
+                    "properties": {
+                        "code": { "type": "string" },
+                        "action": { "type": ["string", "null"] },
+                        "snippet": { "type": "string" }
+                    }
+                }
+            },
+            "check": { "type": ["object", "null"] }
+        }
+    })
+}
+
+fn replay_response_schema() -> Value {
+    json!({
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$id": "schema.cli.replay_response",
+        "type": "object",
+        "required": ["schema_version", "status", "property_id", "replayed_actions", "terminal_state", "focus_action_enabled", "path_tags"],
+        "properties": {
+            "schema_version": { "type": "string" },
+            "status": { "type": "string" },
+            "property_id": { "type": "string" },
+            "replayed_actions": { "type": "array", "items": { "type": "string" } },
+            "terminal_state": { "type": "object" },
+            "focus_action_id": { "type": ["string", "null"] },
+            "focus_action_enabled": { "type": ["boolean", "null"] },
+            "property_holds": { "type": ["boolean", "null"] },
+            "path_tags": { "type": "array", "items": { "type": "string" } }
+        }
+    })
+}
+
+fn clean_response_schema() -> Value {
+    json!({
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$id": "schema.cli.clean_response",
+        "type": "object",
+        "required": ["status", "root", "removed"],
+        "properties": {
+            "status": { "type": "string", "enum": ["ok"] },
+            "root": { "type": "string" },
+            "removed": { "type": "array", "items": { "type": "string" } }
+        }
+    })
+}
+
+fn init_response_schema() -> Value {
+    json!({
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$id": "schema.cli.init_response",
+        "type": "object",
+        "required": ["status", "created", "registry", "scaffolded_registry", "generated_tests_dir"],
+        "properties": {
+            "status": { "type": "string", "enum": ["ok"] },
+            "created": { "type": "string" },
+            "registry": { "type": "string" },
+            "scaffolded_registry": { "type": "string" },
+            "generated_tests_dir": { "type": "string" }
+        }
+    })
+}
+
+fn list_response_schema() -> Value {
+    json!({
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$id": "schema.cli.list_response",
+        "type": "object",
+        "required": ["models"],
+        "properties": {
+            "models": { "type": "array", "items": { "type": "string" } }
+        }
+    })
+}
+
+fn batch_runs_response_schema() -> Value {
+    json!({
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$id": "schema.cli.batch_runs_response",
+        "type": "object",
+        "required": ["runs"],
+        "properties": {
+            "runs": {
+                "type": "array",
+                "items": run_result_schema()
+            }
+        }
+    })
+}
+
+fn valid_contract_response_schema() -> Value {
+    json!({
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$id": "schema.cli.contract_response",
+        "oneOf": [
+            contract_snapshot_schema(),
+            contract_lock_schema(),
+            contract_drift_schema()
+        ]
+    })
+}
+
+fn registry_contract_response_schema() -> Value {
+    json!({
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$id": "schema.cli.contract_response",
+        "oneOf": [
+            { "type": "object", "required": ["snapshots"], "properties": { "snapshots": { "type": "array", "items": contract_snapshot_schema() } } },
+            contract_lock_schema(),
+            { "type": "object", "required": ["reports"], "properties": { "reports": { "type": "array", "items": contract_drift_schema() } } }
+        ]
+    })
+}
+
+fn commands_response_schema() -> Value {
+    json!({
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$id": "schema.cli.commands_response",
+        "type": "object",
+        "required": ["schema_version", "surface", "commands"],
+        "properties": {
+            "schema_version": { "type": "string" },
+            "surface": { "type": "string" },
+            "commands": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "required": ["name", "aliases", "description", "usage", "supports_json", "supports_progress", "positional", "options", "schemas"],
+                    "properties": {
+                        "name": { "type": "string" },
+                        "aliases": { "type": "array", "items": { "type": "string" } },
+                        "description": { "type": "string" },
+                        "usage": { "type": "string" },
+                        "supports_json": { "type": "boolean" },
+                        "supports_progress": { "type": "boolean" },
+                        "positional": { "type": "array", "items": { "type": "object" } },
+                        "options": { "type": "array", "items": { "type": "object" } },
+                        "schemas": { "type": "object" }
+                    }
+                }
+            }
+        }
+    })
+}
+
+fn schema_response_schema() -> Value {
+    json!({
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$id": "schema.cli.schema_response",
+        "type": "object",
+        "required": ["schema_version", "surface", "command", "parameter_schema_id", "parameter_schema", "error_schema_id", "error_schema"],
+        "properties": {
+            "schema_version": { "type": "string" },
+            "surface": { "type": "string" },
+            "command": { "type": "string" },
+            "aliases": { "type": "array", "items": { "type": "string" } },
+            "description": { "type": "string" },
+            "usage": { "type": "string" },
+            "parameter_schema_id": { "type": "string" },
+            "parameter_schema": { "type": "object" },
+            "request_schema_id": { "type": ["string", "null"] },
+            "request_schema": { "type": ["object", "null"] },
+            "response_schema_id": { "type": ["string", "null"] },
+            "response_schema": { "type": ["object", "null"] },
+            "error_schema_id": { "type": "string" },
+            "error_schema": { "type": "object" },
+            "progress_schema_id": { "type": ["string", "null"] },
+            "progress_schema": { "type": ["object", "null"] }
+        }
+    })
+}
+
+fn cli_error_schema() -> Value {
+    json!({
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$id": "schema.cli.error",
+        "type": "object",
+        "required": ["schema_version", "kind", "command", "status", "exit_code", "diagnostics"],
+        "properties": {
+            "schema_version": { "type": "string" },
+            "kind": { "type": "string", "enum": ["cli_error"] },
+            "command": { "type": "string" },
+            "status": { "type": "string", "enum": ["ERROR"] },
+            "exit_code": { "type": "integer", "enum": [3] },
+            "usage": { "type": "string" },
+            "diagnostics": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "required": ["error_code", "segment", "severity", "message", "conflicts", "help", "best_practices"],
+                    "properties": {
+                        "error_code": { "type": "string" },
+                        "segment": { "type": "string" },
+                        "severity": { "type": "string" },
+                        "message": { "type": "string" },
+                        "primary_span": { "type": ["object", "null"] },
+                        "conflicts": { "type": "array", "items": { "type": "string" } },
+                        "help": { "type": "array", "items": { "type": "string" } },
+                        "best_practices": { "type": "array", "items": { "type": "string" } }
+                    }
+                }
+            }
+        }
+    })
+}
+
+fn cli_progress_schema() -> Value {
+    json!({
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$id": "schema.cli.progress",
+        "type": "object",
+        "required": ["schema_version", "kind", "command", "event"],
+        "properties": {
+            "schema_version": { "type": "string" },
+            "kind": { "type": "string", "enum": ["progress"] },
+            "command": { "type": "string" },
+            "event": { "type": "string" },
+            "total": { "type": ["integer", "null"] },
+            "index": { "type": "integer" },
+            "target": { "type": "string" },
+            "status": { "type": "string" },
+            "exit_code": { "type": "integer" }
+        }
+    })
+}
+
+fn batch_request_schema() -> Value {
+    json!({
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$id": "schema.cli.batch_request",
+        "type": "object",
+        "required": ["schema_version", "continue_on_error", "operations"],
+        "properties": {
+            "schema_version": { "type": "string" },
+            "continue_on_error": { "type": "boolean" },
+            "operations": {
+                "type": "array",
+                "minItems": 1,
+                "items": {
+                    "type": "object",
+                    "required": ["command", "args", "json"],
+                    "properties": {
+                        "command": { "type": "string" },
+                        "args": { "type": "array", "items": { "type": "string" } },
+                        "json": { "type": "boolean" }
+                    }
+                }
+            }
+        }
+    })
+}
+
+fn batch_response_schema() -> Value {
+    json!({
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$id": "schema.cli.batch_response",
+        "type": "object",
+        "required": ["schema_version", "status", "exit_code", "results"],
+        "properties": {
+            "schema_version": { "type": "string" },
+            "status": { "type": "string", "enum": ["SUCCESS", "FAIL", "UNKNOWN", "ERROR"] },
+            "exit_code": { "type": "integer", "enum": [0, 1, 2, 3] },
+            "results": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "required": ["index", "command", "args", "exit_code", "stdout", "stderr"],
+                    "properties": {
+                        "index": { "type": "integer", "minimum": 0 },
+                        "command": { "type": "string" },
+                        "args": { "type": "array", "items": { "type": "string" } },
+                        "exit_code": { "type": "integer" },
+                        "stdout": { "type": ["object", "array", "string", "number", "boolean", "null"] },
+                        "stderr": { "type": ["object", "array", "string", "number", "boolean", "null"] }
+                    }
+                }
+            }
+        }
+    })
+}

--- a/packages/valid/src/lib.rs
+++ b/packages/valid/src/lib.rs
@@ -4,6 +4,7 @@ pub mod api;
 pub mod benchmark;
 #[doc(hidden)]
 pub mod bundled_models;
+pub mod cli;
 pub mod contract;
 pub mod coverage;
 pub mod engine;

--- a/packages/valid/src/registry.rs
+++ b/packages/valid/src/registry.rs
@@ -1,4 +1,8 @@
-use std::{env, fs, process};
+use std::{
+    env, fs,
+    io::{self, Read},
+    process::{self, Command},
+};
 
 use crate::{
     benchmark::{
@@ -6,13 +10,19 @@ use crate::{
         render_benchmark_comparison_json, render_benchmark_comparison_text, render_benchmark_json,
         render_benchmark_text,
     },
+    cli::{
+        child_stream_to_json, detect_json_flag, detect_progress_json_flag, message_diagnostic,
+        parse_batch_request, render_batch_response, render_cli_error_json, render_cli_warning_json,
+        render_commands_json, render_commands_text, render_schema_json, usage_diagnostic,
+        BatchResult, ExitCode, ProgressReporter, Surface,
+    },
     contract::{
         build_lock_file, compare_snapshot, parse_lock_file, render_drift_json, render_lock_json,
         snapshot_model, write_lock_file, ContractSnapshot,
     },
     coverage::{render_coverage_json, render_coverage_text, CoverageReport},
     engine::CheckOutcome,
-    evidence::{render_diagnostics_json, render_outcome_json, render_outcome_text},
+    evidence::{render_outcome_json, render_outcome_text},
     modeling::{
         build_machine_test_vectors_for_strategy, check_machine_outcome,
         check_machine_outcome_for_property, check_machine_outcomes, check_machine_with_adapter,
@@ -36,6 +46,26 @@ use crate::api::{
     InspectTransitionUpdate, OrchestrateResponse, OrchestratedRunSummary, TestgenResponse,
 };
 
+const REGISTRY_USAGE: &str =
+    "usage: <registry-bin> <models|inspect|graph|readiness|migrate|benchmark|verify|explain|coverage|orchestrate|generate-tests|replay|contract|commands|schema|batch> [model] [--json] [--progress=json] [--format=<mermaid|dot|svg|text|json>] [--view=<overview|logic>] [--property=<id>] [--backend=<explicit|mock-bmc|sat-varisat|smt-cvc5|command>] [--solver-exec <path>] [--solver-arg <arg>] [--focus-action=<id>] [--actions=a,b,c] [--strategy=<counterexample|transition|witness|guard|boundary|path|random>] [--repeat=<n>] [--baseline[=compare|record|ignore]] [--threshold-percent=<n>] [--write[=<path>]] [--check]";
+const LIST_USAGE: &str = "usage: <registry-bin> list [--json]";
+const INSPECT_USAGE: &str = "usage: <registry-bin> inspect <model> [--json] [--progress=json]";
+const GRAPH_USAGE: &str = "usage: <registry-bin> graph <model> [--format=mermaid|dot|svg|text|json] [--view=<overview|logic>] [--json] [--progress=json]";
+const LINT_USAGE: &str = "usage: <registry-bin> lint <model> [--json] [--progress=json]";
+const BENCHMARK_USAGE: &str = "usage: <registry-bin> benchmark <model> [--json] [--progress=json] [--property=<id>] [--repeat=<n>] [--baseline[=compare|record|ignore]] [--threshold-percent=<n>] [--backend=<...>] [--solver-exec <path>] [--solver-arg <arg>]";
+const MIGRATE_USAGE: &str =
+    "usage: <registry-bin> migrate <model> [--json] [--progress=json] [--write[=<path>]] [--check]";
+const CHECK_USAGE: &str = "usage: <registry-bin> check <model> [--json] [--progress=json] [--property=<id>] [--backend=<...>] [--solver-exec <path>] [--solver-arg <arg>]";
+const EXPLAIN_USAGE: &str = "usage: <registry-bin> explain <model> [--json] [--progress=json]";
+const COVERAGE_USAGE: &str = "usage: <registry-bin> coverage <model> [--json] [--progress=json]";
+const ORCHESTRATE_USAGE: &str = "usage: <registry-bin> orchestrate <model> [--json] [--progress=json] [--backend=<...>] [--solver-exec <path>] [--solver-arg <arg>]";
+const TESTGEN_USAGE: &str = "usage: <registry-bin> testgen <model> [--json] [--progress=json] [--property=<id>] [--strategy=<...>]";
+const REPLAY_USAGE: &str = "usage: <registry-bin> replay <model> [--json] [--progress=json] [--property=<id>] [--focus-action=<id>] [--actions=a,b,c]";
+const CONTRACT_USAGE: &str =
+    "usage: <registry-bin> contract <snapshot|lock|drift|check> [lock-file] [--json] [--progress=json]";
+const SCHEMA_USAGE: &str = "usage: <registry-bin> schema <command>";
+const BATCH_USAGE: &str = "usage: <registry-bin> batch [--json] [--progress=json] < batch.json";
+
 pub struct RegisteredModel {
     pub name: &'static str,
     pub inspect: fn(&str) -> InspectResponse,
@@ -43,7 +73,7 @@ pub struct RegisteredModel {
     pub explain: fn(&str) -> Result<ExplainResponse, String>,
     pub coverage: fn() -> CoverageReport,
     pub orchestrate: fn(&str, Option<&AdapterConfig>) -> Result<OrchestrateResponse, String>,
-    pub testgen: fn(Option<&str>, &str) -> TestgenResponse,
+    pub testgen: fn(Option<&str>, &str, bool) -> TestgenResponse,
     pub replay: fn(Option<&str>, &[String], Option<&str>) -> Result<String, String>,
     pub contract_snapshot: fn() -> Result<ContractSnapshot, String>,
 }
@@ -77,9 +107,10 @@ macro_rules! valid_models {
 
 pub fn run_registry_cli(models: Vec<RegisteredModel>) {
     let models = models;
-    let mut args = env::args().skip(1);
-    let command = normalize_command(&args.next().unwrap_or_default());
-    let remaining = args.collect::<Vec<_>>();
+    let args = env::args().skip(1).collect::<Vec<_>>();
+    let json = detect_json_flag(&args) || args.iter().any(|arg| arg == "--format=json");
+    let command = normalize_command(args.first().map(String::as_str).unwrap_or_default());
+    let remaining = args.into_iter().skip(1).collect::<Vec<_>>();
 
     match command.as_str() {
         "list" => cmd_list(&models, remaining),
@@ -95,8 +126,11 @@ pub fn run_registry_cli(models: Vec<RegisteredModel>) {
         "testgen" => cmd_testgen(&models, remaining),
         "replay" => cmd_replay(&models, remaining),
         "contract" => cmd_contract(&models, remaining),
-        "help" => usage_exit(),
-        _ => usage_exit(),
+        "commands" => cmd_commands(remaining),
+        "schema" => cmd_schema(remaining),
+        "batch" => cmd_batch(remaining),
+        "help" => usage_exit("registry", json, REGISTRY_USAGE),
+        _ => usage_exit("registry", json, REGISTRY_USAGE),
     }
 }
 
@@ -114,7 +148,7 @@ fn normalize_command(command: &str) -> String {
 }
 
 fn cmd_list(models: &[RegisteredModel], args: Vec<String>) {
-    let parsed = parse_args(args);
+    let parsed = parse_args(args, "list", LIST_USAGE);
     if parsed.json {
         println!(
             "{{\"models\":[{}]}}",
@@ -132,19 +166,37 @@ fn cmd_list(models: &[RegisteredModel], args: Vec<String>) {
 }
 
 fn cmd_inspect(models: &[RegisteredModel], args: Vec<String>) {
-    let parsed = parse_args(args);
-    let model = find_model(models, parsed.model.as_deref());
+    let parsed = parse_args(args, "inspect", INSPECT_USAGE);
+    let progress = ProgressReporter::new("inspect", parsed.progress_json);
+    progress.start(None);
+    let model = find_model(
+        "inspect",
+        parsed.json,
+        INSPECT_USAGE,
+        models,
+        parsed.model.as_deref(),
+    );
     let response = (model.inspect)("registry-inspect");
     if parsed.json {
         println!("{}", render_inspect_json(&response));
     } else {
         print!("{}", render_inspect_text(&response));
     }
+    progress.finish(ExitCode::Success);
 }
 
 fn cmd_graph(models: &[RegisteredModel], args: Vec<String>) {
-    let parsed = parse_args(args);
-    let model = find_model(models, parsed.model.as_deref());
+    let parsed = parse_args(args, "graph", GRAPH_USAGE);
+    let json_output = parsed.json || matches!(parsed.format.as_deref(), Some("json"));
+    let progress = ProgressReporter::new("graph", parsed.progress_json);
+    progress.start(None);
+    let model = find_model(
+        "graph",
+        json_output,
+        GRAPH_USAGE,
+        models,
+        parsed.model.as_deref(),
+    );
     let response = (model.inspect)("registry-graph");
     let view = GraphView::parse(parsed.view.as_deref());
     match parsed.format.as_deref().unwrap_or("mermaid") {
@@ -154,11 +206,20 @@ fn cmd_graph(models: &[RegisteredModel], args: Vec<String>) {
         "svg" => println!("{}", render_model_svg_with_view(&response, view)),
         _ => println!("{}", render_model_mermaid_with_view(&response, view)),
     }
+    progress.finish(ExitCode::Success);
 }
 
 fn cmd_lint(models: &[RegisteredModel], args: Vec<String>) {
-    let parsed = parse_args(args);
-    let model = find_model(models, parsed.model.as_deref());
+    let parsed = parse_args(args, "lint", LINT_USAGE);
+    let progress = ProgressReporter::new("lint", parsed.progress_json);
+    progress.start(None);
+    let model = find_model(
+        "lint",
+        parsed.json,
+        LINT_USAGE,
+        models,
+        parsed.model.as_deref(),
+    );
     let response = lint_from_inspect(&(model.inspect)("registry-lint"));
     if parsed.json {
         println!("{}", render_lint_json(&response));
@@ -169,15 +230,29 @@ fn cmd_lint(models: &[RegisteredModel], args: Vec<String>) {
         .findings
         .iter()
         .any(|finding| matches!(finding.severity.as_str(), "warn" | "error"));
-    process::exit(if has_findings { 2 } else { 0 });
+    let exit_code = if has_findings {
+        ExitCode::Fail
+    } else {
+        ExitCode::Success
+    };
+    progress.finish(exit_code);
+    process::exit(exit_code.code());
 }
 
 fn cmd_benchmark(models: &[RegisteredModel], args: Vec<String>) {
-    let parsed = parse_args(args);
-    let model = find_model(models, parsed.model.as_deref());
+    let parsed = parse_args(args, "benchmark", BENCHMARK_USAGE);
+    let progress = ProgressReporter::new("benchmark", parsed.progress_json);
+    let repeat_total = parsed.repeat.max(1);
+    progress.start(Some(repeat_total));
+    let model = find_model(
+        "benchmark",
+        parsed.json,
+        BENCHMARK_USAGE,
+        models,
+        parsed.model.as_deref(),
+    );
     let adapter = adapter_from_parsed_args(&parsed).unwrap_or_else(|message| {
-        eprintln!("{message}");
-        process::exit(3);
+        message_exit("benchmark", parsed.json, &message, Some(BENCHMARK_USAGE))
     });
     let backend_label = parsed
         .backend
@@ -189,16 +264,23 @@ fn cmd_benchmark(models: &[RegisteredModel], args: Vec<String>) {
         &backend_label,
         parsed.property_id.as_deref(),
         parsed.repeat,
-        |_| {
-            (model.check)(
+        |iteration| {
+            progress.item_start(iteration, repeat_total, model.name);
+            let outcome = (model.check)(
                 "registry-benchmark",
                 parsed.property_id.as_deref(),
                 adapter.as_ref(),
             )
             .unwrap_or_else(|message| {
-                eprintln!("{message}");
-                process::exit(3);
-            })
+                message_exit("benchmark", parsed.json, &message, Some(BENCHMARK_USAGE))
+            });
+            progress.item_complete(
+                iteration,
+                repeat_total,
+                model.name,
+                ExitCode::from_check_outcome(&outcome).code(),
+            );
+            outcome
         },
     );
     let summary_json = render_benchmark_json(&summary);
@@ -218,6 +300,7 @@ fn cmd_benchmark(models: &[RegisteredModel], args: Vec<String>) {
             &baseline_id,
             parsed.baseline_mode.as_deref().unwrap_or("compare"),
             parsed.threshold_percent.unwrap_or(25),
+            parsed.json,
         );
     if parsed.json {
         println!(
@@ -234,29 +317,36 @@ fn cmd_benchmark(models: &[RegisteredModel], args: Vec<String>) {
     let baseline_mode = parsed.baseline_mode.as_deref().unwrap_or("compare");
     let exit_code = if baseline_mode == "ignore" {
         if summary.error_count > 0 {
-            3
-        } else if summary.fail_count > 0 {
-            2
+            ExitCode::Error
+        } else if summary.fail_count > 0 || regression_detected {
+            ExitCode::Fail
         } else if summary.unknown_count > 0 {
-            4
-        } else if regression_detected {
-            5
+            ExitCode::Unknown
         } else {
-            0
+            ExitCode::Success
         }
     } else if summary.error_count > 0 {
-        3
+        ExitCode::Error
     } else if regression_detected {
-        5
+        ExitCode::Fail
     } else {
-        0
+        ExitCode::Success
     };
-    process::exit(exit_code);
+    progress.finish(exit_code);
+    process::exit(exit_code.code());
 }
 
 fn cmd_migrate(models: &[RegisteredModel], args: Vec<String>) {
-    let parsed = parse_args(args);
-    let model = find_model(models, parsed.model.as_deref());
+    let parsed = parse_args(args, "migrate", MIGRATE_USAGE);
+    let progress = ProgressReporter::new("migrate", parsed.progress_json);
+    progress.start(None);
+    let model = find_model(
+        "migrate",
+        parsed.json,
+        MIGRATE_USAGE,
+        models,
+        parsed.model.as_deref(),
+    );
     let inspect = (model.inspect)("registry-migrate");
     let lint = lint_from_inspect(&inspect);
     let migration = migration_from_inspect(&inspect, &lint, parsed.check);
@@ -285,30 +375,41 @@ fn cmd_migrate(models: &[RegisteredModel], args: Vec<String>) {
     }
     let exit_code = if parsed.check {
         match migration.check.as_ref().map(|check| check.status.as_str()) {
-            Some("already-declarative") => 0,
-            Some("no-candidates") => 2,
-            Some("candidate-complete") | Some("partial") => 6,
-            _ => 3,
+            Some("already-declarative") => ExitCode::Success,
+            Some("no-candidates") => ExitCode::Unknown,
+            Some("candidate-complete") | Some("partial") => ExitCode::Fail,
+            _ => ExitCode::Error,
         }
     } else if migration.snippets.is_empty() {
-        2
+        ExitCode::Unknown
     } else {
-        0
+        ExitCode::Success
     };
-    process::exit(exit_code);
+    progress.finish(exit_code);
+    process::exit(exit_code.code());
 }
 
 fn cmd_check(models: &[RegisteredModel], args: Vec<String>) {
-    let parsed = parse_args(args);
-    let model = find_model(models, parsed.model.as_deref());
+    let parsed = parse_args(args, "check", CHECK_USAGE);
+    let progress = ProgressReporter::new("check", parsed.progress_json);
+    progress.start(None);
+    let model = find_model(
+        "check",
+        parsed.json,
+        CHECK_USAGE,
+        models,
+        parsed.model.as_deref(),
+    );
     let inspect = (model.inspect)("registry-check-preflight");
-    let adapter = adapter_from_parsed_args(&parsed).unwrap_or_else(|message| {
-        eprintln!("{message}");
-        process::exit(3);
-    });
+    let adapter = adapter_from_parsed_args(&parsed)
+        .unwrap_or_else(|message| message_exit("check", parsed.json, &message, Some(CHECK_USAGE)));
     if matches!(adapter, Some(AdapterConfig::Explicit) | None) {
         if let Some(warning) = explicit_analysis_warning(&inspect) {
-            eprintln!("{warning}");
+            if parsed.json || parsed.progress_json {
+                eprintln!("{}", render_cli_warning_json("check", &warning));
+            } else {
+                eprintln!("{warning}");
+            }
         }
     }
     let outcome = (model.check)(
@@ -316,28 +417,28 @@ fn cmd_check(models: &[RegisteredModel], args: Vec<String>) {
         parsed.property_id.as_deref(),
         adapter.as_ref(),
     )
-    .unwrap_or_else(|message| {
-        eprintln!("{message}");
-        process::exit(3);
-    });
+    .unwrap_or_else(|message| message_exit("check", parsed.json, &message, Some(CHECK_USAGE)));
     if parsed.json {
         println!("{}", render_outcome_json(model.name, &outcome));
     } else {
         print!("{}", render_outcome_text(&outcome));
     }
-    process::exit(match outcome {
-        CheckOutcome::Completed(result) => match result.status {
-            crate::engine::RunStatus::Pass => 0,
-            crate::engine::RunStatus::Fail => 2,
-            crate::engine::RunStatus::Unknown => 4,
-        },
-        CheckOutcome::Errored(_) => 3,
-    });
+    let exit_code = ExitCode::from_check_outcome(&outcome);
+    progress.finish(exit_code);
+    process::exit(exit_code.code());
 }
 
 fn cmd_explain(models: &[RegisteredModel], args: Vec<String>) {
-    let parsed = parse_args(args);
-    let model = find_model(models, parsed.model.as_deref());
+    let parsed = parse_args(args, "explain", EXPLAIN_USAGE);
+    let progress = ProgressReporter::new("explain", parsed.progress_json);
+    progress.start(None);
+    let model = find_model(
+        "explain",
+        parsed.json,
+        EXPLAIN_USAGE,
+        models,
+        parsed.model.as_deref(),
+    );
     match (model.explain)("registry-explain") {
         Ok(response) => {
             if parsed.json {
@@ -345,47 +446,61 @@ fn cmd_explain(models: &[RegisteredModel], args: Vec<String>) {
             } else {
                 print!("{}", render_explain_text(&response));
             }
+            progress.finish(ExitCode::Success);
         }
         Err(message) => {
-            if parsed.json {
-                println!(
-                    "{}",
-                    render_diagnostics_json(&[crate::support::diagnostics::Diagnostic::new(
-                        crate::support::diagnostics::ErrorCode::SearchError,
-                        crate::support::diagnostics::DiagnosticSegment::EngineSearch,
-                        message,
-                    )])
-                );
-            } else {
-                eprintln!("{message}");
-            }
-            process::exit(3);
+            message_exit("explain", parsed.json, &message, Some(EXPLAIN_USAGE));
         }
     }
 }
 
 fn cmd_coverage(models: &[RegisteredModel], args: Vec<String>) {
-    let parsed = parse_args(args);
-    let model = find_model(models, parsed.model.as_deref());
+    let parsed = parse_args(args, "coverage", COVERAGE_USAGE);
+    let progress = ProgressReporter::new("coverage", parsed.progress_json);
+    progress.start(None);
+    let model = find_model(
+        "coverage",
+        parsed.json,
+        COVERAGE_USAGE,
+        models,
+        parsed.model.as_deref(),
+    );
     let report = (model.coverage)();
     if parsed.json {
         println!("{}", render_coverage_json(&report));
     } else {
         println!("{}", render_coverage_text(&report));
     }
+    progress.finish(ExitCode::Success);
 }
 
 fn cmd_orchestrate(models: &[RegisteredModel], args: Vec<String>) {
-    let parsed = parse_args(args);
-    let model = find_model(models, parsed.model.as_deref());
+    let parsed = parse_args(args, "orchestrate", ORCHESTRATE_USAGE);
+    let progress = ProgressReporter::new("orchestrate", parsed.progress_json);
+    progress.start(None);
+    let model = find_model(
+        "orchestrate",
+        parsed.json,
+        ORCHESTRATE_USAGE,
+        models,
+        parsed.model.as_deref(),
+    );
     let adapter = adapter_from_parsed_args(&parsed).unwrap_or_else(|message| {
-        eprintln!("{message}");
-        process::exit(3);
+        message_exit(
+            "orchestrate",
+            parsed.json,
+            &message,
+            Some(ORCHESTRATE_USAGE),
+        )
     });
     let response =
         (model.orchestrate)("registry-orchestrate", adapter.as_ref()).unwrap_or_else(|message| {
-            eprintln!("{message}");
-            process::exit(3);
+            message_exit(
+                "orchestrate",
+                parsed.json,
+                &message,
+                Some(ORCHESTRATE_USAGE),
+            )
         });
     if parsed.json {
         let body = response
@@ -413,14 +528,24 @@ fn cmd_orchestrate(models: &[RegisteredModel], args: Vec<String>) {
             println!("property_id: {} status: {}", run.property_id, run.status);
         }
     }
+    progress.finish(ExitCode::Success);
 }
 
 fn cmd_testgen(models: &[RegisteredModel], args: Vec<String>) {
-    let parsed = parse_args(args);
-    let model = find_model(models, parsed.model.as_deref());
+    let parsed = parse_args(args, "testgen", TESTGEN_USAGE);
+    let progress = ProgressReporter::new("testgen", parsed.progress_json);
+    progress.start(None);
+    let model = find_model(
+        "testgen",
+        parsed.json,
+        TESTGEN_USAGE,
+        models,
+        parsed.model.as_deref(),
+    );
     let response = (model.testgen)(
         parsed.property_id.as_deref(),
         parsed.strategy.as_deref().unwrap_or("counterexample"),
+        parsed.json,
     );
     if parsed.json {
         println!(
@@ -460,21 +585,28 @@ fn cmd_testgen(models: &[RegisteredModel], args: Vec<String>) {
             }
         }
     }
+    progress.finish(ExitCode::Success);
 }
 
 fn cmd_replay(models: &[RegisteredModel], args: Vec<String>) {
-    let parsed = parse_args(args);
-    let model = find_model(models, parsed.model.as_deref());
+    let parsed = parse_args(args, "replay", REPLAY_USAGE);
+    let progress = ProgressReporter::new("replay", parsed.progress_json);
+    progress.start(None);
+    let model = find_model(
+        "replay",
+        parsed.json,
+        REPLAY_USAGE,
+        models,
+        parsed.model.as_deref(),
+    );
     let response = (model.replay)(
         parsed.property_id.as_deref(),
         &parsed.actions,
         parsed.focus_action_id.as_deref(),
     )
-    .unwrap_or_else(|message| {
-        eprintln!("{message}");
-        process::exit(3);
-    });
+    .unwrap_or_else(|message| message_exit("replay", parsed.json, &message, Some(REPLAY_USAGE)));
     println!("{response}");
+    progress.finish(ExitCode::Success);
 }
 
 fn inspect_machine<M: VerifiedMachine>(request_id: &str) -> InspectResponse {
@@ -712,13 +844,12 @@ fn orchestrate_machine<M: VerifiedMachine>(
 fn testgen_machine<M: VerifiedMachine>(
     property_id: Option<&str>,
     request_id: &str,
+    json: bool,
 ) -> TestgenResponse {
     let mut vectors = build_machine_test_vectors_for_strategy::<M>(property_id, request_id);
     annotate_registry_replay_targets::<M>(property_id, &mut vectors);
-    let generated_files = write_generated_test_files(&vectors).unwrap_or_else(|message| {
-        eprintln!("{message}");
-        process::exit(3);
-    });
+    let generated_files = write_generated_test_files(&vectors)
+        .unwrap_or_else(|message| message_exit("testgen", json, &message, Some(TESTGEN_USAGE)));
     TestgenResponse {
         schema_version: "1.0.0".to_string(),
         request_id: "registry-testgen".to_string(),
@@ -811,6 +942,7 @@ fn annotate_registry_replay_targets<M: VerifiedMachine>(
 #[derive(Default)]
 struct ParsedArgs {
     json: bool,
+    progress_json: bool,
     model: Option<String>,
     repeat: usize,
     baseline_mode: Option<String>,
@@ -828,13 +960,24 @@ struct ParsedArgs {
     check: bool,
 }
 
-fn parse_args(args: Vec<String>) -> ParsedArgs {
+fn parse_args(args: Vec<String>, command: &str, usage: &str) -> ParsedArgs {
     let mut parsed = ParsedArgs::default();
     parsed.repeat = 3;
+    parsed.json = detect_json_flag(&args) || args.iter().any(|arg| arg == "--format=json");
+    parsed.progress_json = detect_progress_json_flag(&args);
     let mut iter = args.into_iter();
     while let Some(arg) = iter.next() {
         if arg == "--json" {
             parsed.json = true;
+        } else if arg == "--progress=json" {
+            parsed.progress_json = true;
+        } else if arg.starts_with("--progress=") {
+            message_exit(
+                command,
+                parsed.json,
+                "unsupported progress mode",
+                Some(usage),
+            );
         } else if arg == "--check" {
             parsed.check = true;
         } else if arg == "--write" {
@@ -846,9 +989,15 @@ fn parse_args(args: Vec<String>) -> ParsedArgs {
         } else if let Some(value) = arg.strip_prefix("--baseline=") {
             parsed.baseline_mode = Some(value.to_string());
         } else if let Some(value) = arg.strip_prefix("--threshold-percent=") {
-            parsed.threshold_percent = Some(value.parse().unwrap_or_else(|_| usage_exit()));
+            parsed.threshold_percent = Some(
+                value
+                    .parse()
+                    .unwrap_or_else(|_| usage_exit(command, parsed.json, usage)),
+            );
         } else if let Some(value) = arg.strip_prefix("--repeat=") {
-            parsed.repeat = value.parse().unwrap_or_else(|_| usage_exit());
+            parsed.repeat = value
+                .parse()
+                .unwrap_or_else(|_| usage_exit(command, parsed.json, usage));
         } else if let Some(value) = arg.strip_prefix("--format=") {
             parsed.format = Some(value.to_string());
         } else if let Some(value) = arg.strip_prefix("--view=") {
@@ -860,11 +1009,15 @@ fn parse_args(args: Vec<String>) -> ParsedArgs {
         } else if let Some(value) = arg.strip_prefix("--backend=") {
             parsed.backend = Some(value.to_string());
         } else if arg == "--solver-exec" {
-            parsed.solver_executable = Some(iter.next().unwrap_or_else(|| usage_exit()));
+            parsed.solver_executable = Some(
+                iter.next()
+                    .unwrap_or_else(|| usage_exit(command, parsed.json, usage)),
+            );
         } else if arg == "--solver-arg" {
-            parsed
-                .solver_args
-                .push(iter.next().unwrap_or_else(|| usage_exit()));
+            parsed.solver_args.push(
+                iter.next()
+                    .unwrap_or_else(|| usage_exit(command, parsed.json, usage)),
+            );
         } else if let Some(value) = arg.strip_prefix("--actions=") {
             parsed.actions = value
                 .split(',')
@@ -876,7 +1029,7 @@ fn parse_args(args: Vec<String>) -> ParsedArgs {
         } else if parsed.model.is_none() {
             parsed.model = Some(arg);
         } else {
-            usage_exit();
+            usage_exit(command, parsed.json, usage);
         }
     }
     parsed
@@ -906,16 +1059,26 @@ fn adapter_from_parsed_args(parsed: &ParsedArgs) -> Result<Option<AdapterConfig>
     }
 }
 
-fn find_model<'a>(models: &'a [RegisteredModel], model_name: Option<&str>) -> &'a RegisteredModel {
+fn find_model<'a>(
+    command: &str,
+    json: bool,
+    usage: &str,
+    models: &'a [RegisteredModel],
+    model_name: Option<&str>,
+) -> &'a RegisteredModel {
     let Some(model_name) = model_name else {
-        usage_exit();
+        usage_exit(command, json, usage);
     };
     models
         .iter()
         .find(|model| model.name == model_name)
         .unwrap_or_else(|| {
-            eprintln!("unknown model `{model_name}`");
-            process::exit(3);
+            message_exit(
+                command,
+                json,
+                &format!("unknown model `{model_name}`"),
+                Some(usage),
+            )
         })
 }
 
@@ -924,6 +1087,7 @@ fn registry_benchmark_baseline_outputs(
     baseline_id: &str,
     baseline_mode: &str,
     threshold_percent: u32,
+    json: bool,
 ) -> (Option<String>, Option<String>, bool) {
     match baseline_mode {
         "ignore" => (None, None, false),
@@ -990,8 +1154,12 @@ fn registry_benchmark_baseline_outputs(
             )
         }
         other => {
-            eprintln!("unsupported benchmark baseline mode `{other}`");
-            process::exit(3);
+            message_exit(
+                "benchmark",
+                json,
+                &format!("unsupported benchmark baseline mode `{other}`"),
+                Some(BENCHMARK_USAGE),
+            );
         }
     }
 }
@@ -1009,7 +1177,11 @@ fn registry_migration_output_path(model: &str, requested: &str) -> String {
 }
 
 fn cmd_contract(models: &[RegisteredModel], args: Vec<String>) {
-    let json = args.iter().any(|a| a == "--json");
+    let json = detect_json_flag(&args);
+    reject_unsupported_progress_mode("contract", json, &args, CONTRACT_USAGE);
+    let progress = ProgressReporter::from_args("contract", &args);
+    let total = models.len();
+    progress.start(Some(total));
     let positional: Vec<&str> = args
         .iter()
         .filter(|a| !a.starts_with("--"))
@@ -1021,14 +1193,18 @@ fn cmd_contract(models: &[RegisteredModel], args: Vec<String>) {
     match sub {
         "snapshot" => {
             let mut snapshots = Vec::new();
-            for model in models {
-                match (model.contract_snapshot)() {
-                    Ok(snapshot) => snapshots.push(snapshot),
-                    Err(message) => {
-                        eprintln!("contract snapshot failed for `{}`: {message}", model.name);
-                        process::exit(3);
-                    }
-                }
+            for (index, model) in models.iter().enumerate() {
+                progress.item_start(index, total, model.name);
+                let snapshot = (model.contract_snapshot)().unwrap_or_else(|message| {
+                    message_exit(
+                        "contract",
+                        json,
+                        &format!("contract snapshot failed for `{}`: {message}", model.name),
+                        Some(CONTRACT_USAGE),
+                    )
+                });
+                progress.item_complete(index, total, model.name, ExitCode::Success.code());
+                snapshots.push(snapshot);
             }
             if json {
                 let body = snapshots
@@ -1047,50 +1223,65 @@ fn cmd_contract(models: &[RegisteredModel], args: Vec<String>) {
                     println!("{}: {}", snapshot.model_id, snapshot.contract_hash);
                 }
             }
+            progress.finish(ExitCode::Success);
         }
         "lock" => {
             let output = lock_path.unwrap_or_else(|| "valid.lock.json".to_string());
             let mut snapshots = Vec::new();
-            for model in models {
-                match (model.contract_snapshot)() {
-                    Ok(snapshot) => snapshots.push(snapshot),
-                    Err(message) => {
-                        eprintln!("contract snapshot failed for `{}`: {message}", model.name);
-                        process::exit(3);
-                    }
-                }
+            for (index, model) in models.iter().enumerate() {
+                progress.item_start(index, total, model.name);
+                let snapshot = (model.contract_snapshot)().unwrap_or_else(|message| {
+                    message_exit(
+                        "contract",
+                        json,
+                        &format!("contract snapshot failed for `{}`: {message}", model.name),
+                        Some(CONTRACT_USAGE),
+                    )
+                });
+                progress.item_complete(index, total, model.name, ExitCode::Success.code());
+                snapshots.push(snapshot);
             }
             let lock = build_lock_file(snapshots);
             write_lock_file(&output, &lock).unwrap_or_else(|err| {
-                eprintln!("{err}");
-                process::exit(3);
+                message_exit("contract", json, &err.to_string(), Some(CONTRACT_USAGE))
             });
             if json {
                 println!("{}", render_lock_json(&lock));
             } else {
                 println!("lock written: {output}");
             }
+            progress.finish(ExitCode::Success);
         }
         "drift" | "check" => {
             let lock_file = lock_path.unwrap_or_else(|| "valid.lock.json".to_string());
             let lock_body = fs::read_to_string(&lock_file).unwrap_or_else(|err| {
-                eprintln!("failed to read lock file `{lock_file}`: {err}");
-                process::exit(3);
+                message_exit(
+                    "contract",
+                    json,
+                    &format!("failed to read lock file `{lock_file}`: {err}"),
+                    Some(CONTRACT_USAGE),
+                )
             });
             let lock = parse_lock_file(&lock_body).unwrap_or_else(|err| {
-                eprintln!("failed to parse lock file: {err}");
-                process::exit(3);
+                message_exit(
+                    "contract",
+                    json,
+                    &format!("failed to parse lock file: {err}"),
+                    Some(CONTRACT_USAGE),
+                )
             });
             let mut has_drift = false;
             let mut reports = Vec::new();
-            for model in models {
-                let snapshot = match (model.contract_snapshot)() {
-                    Ok(snapshot) => snapshot,
-                    Err(message) => {
-                        eprintln!("contract snapshot failed for `{}`: {message}", model.name);
-                        process::exit(3);
-                    }
-                };
+            for (index, model) in models.iter().enumerate() {
+                progress.item_start(index, total, model.name);
+                let snapshot = (model.contract_snapshot)().unwrap_or_else(|message| {
+                    message_exit(
+                        "contract",
+                        json,
+                        &format!("contract snapshot failed for `{}`: {message}", model.name),
+                        Some(CONTRACT_USAGE),
+                    )
+                });
                 let expected = lock
                     .entries
                     .iter()
@@ -1105,12 +1296,16 @@ fn cmd_contract(models: &[RegisteredModel], args: Vec<String>) {
                     }
                     reports.push(report);
                     has_drift = true;
+                    progress.item_complete(index, total, model.name, ExitCode::Fail.code());
                     continue;
                 };
                 let drift = compare_snapshot(expected, &snapshot);
-                if drift.status != "unchanged" {
+                let item_exit = if drift.status != "unchanged" {
                     has_drift = true;
-                }
+                    ExitCode::Fail
+                } else {
+                    ExitCode::Success
+                };
                 if json {
                     reports.push(render_drift_json(&drift));
                 } else {
@@ -1119,22 +1314,168 @@ fn cmd_contract(models: &[RegisteredModel], args: Vec<String>) {
                         println!("  changed: {change}");
                     }
                 }
+                progress.item_complete(index, total, model.name, item_exit.code());
             }
             if json {
                 println!("{{\"reports\":[{}]}}", reports.join(","));
             }
-            process::exit(if has_drift { 2 } else { 0 });
+            let exit_code = if has_drift {
+                ExitCode::Fail
+            } else {
+                ExitCode::Success
+            };
+            progress.finish(exit_code);
+            process::exit(exit_code.code());
         }
         _ => {
-            eprintln!(
-                "usage: <registry-bin> contract <snapshot|lock|drift|check> [lock-file] [--json]"
-            );
-            process::exit(3);
+            usage_exit("contract", json, CONTRACT_USAGE);
         }
     }
 }
 
-fn usage_exit() -> ! {
-    eprintln!("usage: <registry-bin> <models|inspect|graph|readiness|migrate|benchmark|verify|explain|coverage|orchestrate|generate-tests|replay|contract> [model] [--json] [--format=<mermaid|dot|svg|text|json>] [--view=<overview|logic>] [--property=<id>] [--backend=<explicit|mock-bmc|sat-varisat|smt-cvc5|command>] [--solver-exec <path>] [--solver-arg <arg>] [--focus-action=<id>] [--actions=a,b,c] [--strategy=<counterexample|transition|witness|guard|boundary|path|random>] [--repeat=<n>] [--baseline[=compare|record|ignore]] [--threshold-percent=<n>] [--write[=<path>]] [--check]");
-    process::exit(3);
+fn usage_exit(command: &str, json: bool, usage: &str) -> ! {
+    if json {
+        eprintln!(
+            "{}",
+            render_cli_error_json(
+                command,
+                &[usage_diagnostic("invalid command arguments", usage)],
+                Some(usage),
+            )
+        );
+    } else {
+        eprintln!("{usage}");
+    }
+    process::exit(ExitCode::Error.code());
+}
+
+fn reject_unsupported_progress_mode(command: &str, json: bool, args: &[String], usage: &str) {
+    if args
+        .iter()
+        .any(|arg| arg.starts_with("--progress=") && arg != "--progress=json")
+    {
+        message_exit(command, json, "unsupported progress mode", Some(usage));
+    }
+}
+
+fn message_exit(command: &str, json: bool, message: &str, usage: Option<&str>) -> ! {
+    if json {
+        eprintln!(
+            "{}",
+            render_cli_error_json(command, &[message_diagnostic(message)], usage)
+        );
+    } else {
+        if let Some(usage) = usage {
+            eprintln!("{usage}");
+        }
+        eprintln!("{message}");
+    }
+    process::exit(ExitCode::Error.code());
+}
+
+fn cmd_commands(args: Vec<String>) {
+    let json = detect_json_flag(&args);
+    reject_unsupported_progress_mode("commands", json, &args, REGISTRY_USAGE);
+    if detect_json_flag(&args) {
+        println!("{}", render_commands_json(Surface::Registry));
+    } else {
+        println!("{}", render_commands_text(Surface::Registry));
+    }
+}
+
+fn cmd_schema(args: Vec<String>) {
+    let json = detect_json_flag(&args);
+    reject_unsupported_progress_mode("schema", json, &args, SCHEMA_USAGE);
+    let command = args
+        .iter()
+        .find(|arg| !arg.starts_with("--"))
+        .cloned()
+        .unwrap_or_else(|| usage_exit("schema", true, SCHEMA_USAGE));
+    match render_schema_json(Surface::Registry, &normalize_command(&command)) {
+        Ok(body) => println!("{body}"),
+        Err(message) => message_exit("schema", true, &message, Some(SCHEMA_USAGE)),
+    }
+}
+
+fn cmd_batch(args: Vec<String>) {
+    let json = detect_json_flag(&args);
+    reject_unsupported_progress_mode("batch", json, &args, BATCH_USAGE);
+    let progress = ProgressReporter::from_args("batch", &args);
+    let mut stdin = String::new();
+    io::stdin()
+        .read_to_string(&mut stdin)
+        .unwrap_or_else(|err| {
+            message_exit(
+                "batch",
+                json,
+                &format!("failed to read stdin: {err}"),
+                Some(BATCH_USAGE),
+            )
+        });
+    let request = parse_batch_request(&stdin)
+        .unwrap_or_else(|message| message_exit("batch", true, &message, Some(BATCH_USAGE)));
+    let total = request.operations.len();
+    progress.start(Some(total));
+    let current_exe = env::current_exe().unwrap_or_else(|err| {
+        message_exit(
+            "batch",
+            json,
+            &format!("failed to resolve current executable: {err}"),
+            Some(BATCH_USAGE),
+        )
+    });
+    let mut aggregate = ExitCode::Success;
+    let mut results = Vec::new();
+    for (index, operation) in request.operations.into_iter().enumerate() {
+        progress.item_start(index, total, &operation.command);
+        let mut child_args = vec![operation.command.clone()];
+        child_args.extend(operation.args.clone());
+        if operation.json
+            && !child_args
+                .iter()
+                .any(|arg| arg == "--json" || arg.starts_with("--format="))
+        {
+            if normalize_command(&operation.command) == "graph" {
+                child_args.push("--format=json".to_string());
+            } else {
+                child_args.push("--json".to_string());
+            }
+        }
+        let output = Command::new(&current_exe)
+            .args(&child_args)
+            .output()
+            .unwrap_or_else(|err| {
+                message_exit(
+                    "batch",
+                    true,
+                    &format!(
+                        "failed to execute batch operation `{}`: {err}",
+                        operation.command
+                    ),
+                    Some(BATCH_USAGE),
+                )
+            });
+        let exit_code = output.status.code().unwrap_or(ExitCode::Error.code());
+        aggregate = aggregate.aggregate(match exit_code {
+            0 => ExitCode::Success,
+            1 => ExitCode::Fail,
+            2 => ExitCode::Unknown,
+            _ => ExitCode::Error,
+        });
+        results.push(BatchResult {
+            index,
+            command: operation.command.clone(),
+            args: child_args.into_iter().skip(1).collect(),
+            exit_code,
+            stdout: child_stream_to_json(&output.stdout),
+            stderr: child_stream_to_json(&output.stderr),
+        });
+        progress.item_complete(index, total, &operation.command, exit_code);
+        if exit_code != 0 && !request.continue_on_error {
+            break;
+        }
+    }
+    progress.finish(aggregate);
+    println!("{}", render_batch_response(aggregate, results));
+    process::exit(aggregate.code());
 }

--- a/tests/e2e_cargo_valid.rs
+++ b/tests/e2e_cargo_valid.rs
@@ -1,6 +1,7 @@
 use std::fs;
+use std::io::Write;
 use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::process::{Command, Stdio};
 use std::sync::{Mutex, OnceLock};
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -273,7 +274,7 @@ fn cargo_valid_verifies_relation_map_regression() {
         .arg("--json")
         .output()
         .expect("cargo-valid verify tenant relation regression should run");
-    assert!(output.status.code() == Some(2));
+    assert!(output.status.code() == Some(1));
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(stdout.contains("\"status\":\"FAIL\""));
     assert!(stdout.contains("\"property_id\":\"P_NO_CROSS_TENANT_ACCESS\""));
@@ -311,7 +312,7 @@ fn cargo_valid_readiness_reports_password_solver_limitations() {
         .arg("--json")
         .output()
         .expect("cargo-valid readiness password policy should run");
-    assert_eq!(output.status.code(), Some(2));
+    assert_eq!(output.status.code(), Some(1));
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(stdout.contains("\"code\":\"string_fields_require_explicit_backend\""));
     assert!(stdout.contains("\"code\":\"regex_match_requires_explicit_backend\""));
@@ -343,7 +344,7 @@ fn cargo_valid_verifies_password_policy_models() {
         .arg("--json")
         .output()
         .expect("cargo-valid verify regression password model should run");
-    assert_eq!(regression_output.status.code(), Some(2));
+    assert_eq!(regression_output.status.code(), Some(1));
     let regression_stdout = String::from_utf8_lossy(&regression_output.stdout);
     assert!(regression_stdout.contains("\"status\":\"FAIL\""));
     assert!(regression_stdout.contains("\"property_id\":\"P_PASSWORD_POLICY_MATCHES_FLAG\""));
@@ -444,7 +445,7 @@ fn cargo_valid_checks_registered_model() {
         .arg("--json")
         .output()
         .expect("cargo-valid check should run");
-    assert_eq!(output.status.code(), Some(2));
+    assert_eq!(output.status.code(), Some(1));
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(stdout.contains("\"property_id\":\"P_FAIL\""));
     assert!(stdout.contains("\"ci\":{\"exit_code\":2"));
@@ -482,7 +483,7 @@ fn cargo_valid_verifies_grouped_saas_regression() {
         .arg("--json")
         .output()
         .expect("cargo-valid verify saas regression should run");
-    assert_eq!(output.status.code(), Some(2));
+    assert_eq!(output.status.code(), Some(1));
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(stdout.contains("\"status\":\"FAIL\""));
     assert!(stdout.contains("\"property_id\":\"P_NO_CROSS_TENANT_ACCESS\""));
@@ -539,7 +540,7 @@ fn cargo_valid_lints_registered_model_with_migration_hints() {
         .arg("--json")
         .output()
         .expect("cargo-valid lint should run");
-    assert_eq!(output.status.code(), Some(2));
+    assert_eq!(output.status.code(), Some(1));
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(stdout.contains("\"code\":\"opaque_step_closure\""));
     assert!(stdout.contains("\"code\":\"missing_declarative_transitions\""));
@@ -603,7 +604,7 @@ fn cargo_valid_migrate_check_marks_step_models_for_manual_review() {
         .arg("--json")
         .output()
         .expect("cargo-valid migrate check should run");
-    assert_eq!(output.status.code(), Some(6));
+    assert_eq!(output.status.code(), Some(1));
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(stdout.contains("\"check\":{"));
     assert!(stdout.contains("\"status\":\"candidate-complete\""));
@@ -681,7 +682,7 @@ fn cargo_valid_checks_example_model() {
         .arg("--json")
         .output()
         .expect("cargo-valid check for example registry should run");
-    assert_eq!(output.status.code(), Some(2));
+    assert_eq!(output.status.code(), Some(1));
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(stdout.contains("\"property_id\":\"P_FAIL\""));
 }
@@ -716,7 +717,7 @@ fn cargo_valid_checks_all_example_models_from_file() {
         .arg("--json")
         .output()
         .expect("cargo-valid all for file-backed example registry should run");
-    assert_eq!(output.status.code(), Some(2));
+    assert_eq!(output.status.code(), Some(1));
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(stdout.contains("\"runs\":["));
     assert!(stdout.contains("\"model_id\":\"counter\""));
@@ -840,7 +841,7 @@ fn cargo_valid_check_can_target_specific_property() {
         .arg("--json")
         .output()
         .expect("cargo-valid property-specific check should run");
-    assert_eq!(output.status.code(), Some(2));
+    assert_eq!(output.status.code(), Some(1));
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(stdout.contains("\"property_id\":\"P_FAIL\""));
 }
@@ -866,7 +867,7 @@ fn cargo_valid_external_registry_can_use_command_backend() {
         .arg("--json")
         .output()
         .expect("cargo-valid command backend check should run");
-    assert_eq!(output.status.code(), Some(2));
+    assert_eq!(output.status.code(), Some(1));
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(stdout.contains("\"property_id\":\"P_BILLING_READ_REQUIRES_SESSION\""));
     assert!(stdout.contains("\"status\":\"FAIL\""));
@@ -1193,7 +1194,7 @@ fn cargo_valid_bundled_declarative_model_can_use_command_backend() {
         .arg("--json")
         .output()
         .expect("cargo-valid bundled declarative command backend check should run");
-    assert_eq!(output.status.code(), Some(2));
+    assert_eq!(output.status.code(), Some(1));
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(stdout.contains("\"property_id\":\"P_BILLING_READ_REQUIRES_SESSION\""));
     assert!(stdout.contains("\"status\":\"FAIL\""));
@@ -1227,7 +1228,7 @@ fn cargo_valid_bundled_declarative_model_can_use_mock_cvc5_backend() {
         .arg("--json")
         .output()
         .expect("cargo-valid bundled mock cvc5 check should run");
-    assert_eq!(output.status.code(), Some(2));
+    assert_eq!(output.status.code(), Some(1));
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(stdout.contains("\"backend_name\":\"smt-cvc5\""));
     assert!(stdout.contains("\"property_id\":\"P_BILLING_READ_REQUIRES_SESSION\""));
@@ -1263,7 +1264,7 @@ fn cargo_valid_external_registry_can_use_mock_cvc5_backend() {
         .arg("--json")
         .output()
         .expect("cargo-valid external mock cvc5 check should run");
-    assert_eq!(output.status.code(), Some(2));
+    assert_eq!(output.status.code(), Some(1));
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(stdout.contains("\"backend_name\":\"smt-cvc5\""));
     assert!(stdout.contains("\"property_id\":\"P_BILLING_READ_REQUIRES_SESSION\""));
@@ -1302,4 +1303,77 @@ fn cargo_valid_bundled_declarative_testgen_can_use_command_backend() {
         assert!(body.contains("assert_replay_output_json"));
     }
     cleanup_generated_files(&stdout);
+}
+
+#[test]
+fn cargo_valid_commands_and_schema_are_machine_readable() {
+    let _guard = cargo_guard();
+    let commands = Command::new(cargo_valid_path())
+        .arg("commands")
+        .arg("--json")
+        .output()
+        .expect("commands should run");
+    assert!(commands.status.success());
+    let commands_stdout = String::from_utf8_lossy(&commands.stdout);
+    assert!(commands_stdout.contains("\"surface\":\"cargo-valid\""));
+    assert!(commands_stdout.contains("\"name\":\"batch\""));
+    assert!(commands_stdout.contains("\"response\":\"schema.cli.batch_response\""));
+
+    let schema = Command::new(cargo_valid_path())
+        .arg("schema")
+        .arg("verify")
+        .output()
+        .expect("schema should run");
+    assert!(schema.status.success());
+    let schema_stdout = String::from_utf8_lossy(&schema.stdout);
+    assert!(schema_stdout.contains("\"command\":\"check\""));
+    assert!(schema_stdout
+        .contains("\"parameter_schema_id\":\"schema.cli.cargo-valid.check.parameters\""));
+    assert!(schema_stdout.contains("\"response_schema_id\":\"schema.run_result\""));
+}
+
+#[test]
+fn cargo_valid_json_errors_go_to_stderr() {
+    let _guard = cargo_guard();
+    let output = Command::new(cargo_valid_path())
+        .arg("--registry")
+        .arg(example_registry_file())
+        .arg("inspect")
+        .arg("missing-model")
+        .arg("--json")
+        .output()
+        .expect("json error case should run");
+    assert_eq!(output.status.code(), Some(3));
+    assert!(String::from_utf8_lossy(&output.stdout).trim().is_empty());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("\"kind\":\"cli_error\""));
+    assert!(stderr.contains("\"unknown model `missing-model`\""));
+}
+
+#[test]
+fn cargo_valid_batch_runs_multiple_operations() {
+    let _guard = cargo_guard();
+    let request = "{\"schema_version\":\"1.0.0\",\"continue_on_error\":true,\"operations\":[{\"command\":\"inspect\",\"args\":[\"counter\",\"--registry\",\"examples/valid_models.rs\"],\"json\":true},{\"command\":\"verify\",\"args\":[\"failing-counter\",\"--registry\",\"examples/valid_models.rs\"],\"json\":true}]}";
+    let mut child = Command::new(cargo_valid_path())
+        .arg("batch")
+        .arg("--json")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("batch should spawn");
+    child
+        .stdin
+        .as_mut()
+        .expect("stdin")
+        .write_all(request.as_bytes())
+        .expect("write batch request");
+    let output = child.wait_with_output().expect("batch should complete");
+    assert_eq!(output.status.code(), Some(1));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("\"status\":\"FAIL\""));
+    assert!(stdout.contains("\"command\":\"inspect\""));
+    assert!(stdout.contains("\"command\":\"verify\""));
+    assert!(stdout.contains("\"exit_code\":0"));
+    assert!(stdout.contains("\"exit_code\":1"));
 }

--- a/tests/e2e_cli.rs
+++ b/tests/e2e_cli.rs
@@ -1,7 +1,8 @@
 use std::{
     fs,
+    io::Write,
     path::{Path, PathBuf},
-    process::Command,
+    process::{Command, Stdio},
     time::{SystemTime, UNIX_EPOCH},
 };
 
@@ -267,7 +268,7 @@ fn cli_check_and_orchestrate_work_against_repo_examples() {
         .arg("--json")
         .output()
         .expect("fail check should run");
-    assert_eq!(fail_output.status.code(), Some(2));
+    assert_eq!(fail_output.status.code(), Some(1));
 
     let orchestrate = Command::new(binary_path())
         .arg("orchestrate")
@@ -331,7 +332,7 @@ fn cli_command_backend_demo_script_normalizes_failures() {
         .arg(solver)
         .output()
         .expect("command backend should run");
-    assert_eq!(output.status.code(), Some(2));
+    assert_eq!(output.status.code(), Some(1));
 
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(stdout.contains("MOCK_SOLVER_COUNTEREXAMPLE"));
@@ -354,7 +355,7 @@ fn cli_cvc5_backend_demo_script_normalizes_failures() {
         .arg(solver)
         .output()
         .expect("cvc5 backend should run");
-    assert_eq!(output.status.code(), Some(2));
+    assert_eq!(output.status.code(), Some(1));
 
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(stdout.contains("CVC5_COUNTEREXAMPLE"));
@@ -404,7 +405,7 @@ fn bundled_rust_models_run_via_main_cli_path() {
         .arg("--json")
         .output()
         .expect("check should run");
-    assert_eq!(check.status.code(), Some(2));
+    assert_eq!(check.status.code(), Some(1));
     assert!(String::from_utf8_lossy(&check.stdout).contains("\"property_id\":\"P_FAIL\""));
 
     let coverage = Command::new(binary_path())
@@ -427,7 +428,81 @@ fn main_cli_lints_bundled_step_model() {
         .arg("--json")
         .output()
         .expect("lint should run");
-    assert_eq!(lint.status.code(), Some(2));
+    assert_eq!(lint.status.code(), Some(1));
     let stdout = String::from_utf8_lossy(&lint.stdout);
     assert!(stdout.contains("\"opaque_step_closure\""));
+}
+
+#[test]
+fn cli_commands_and_schema_are_machine_readable() {
+    let commands = Command::new(binary_path())
+        .arg("commands")
+        .arg("--json")
+        .output()
+        .expect("commands should run");
+    assert!(commands.status.success());
+    let commands_stdout = String::from_utf8_lossy(&commands.stdout);
+    assert!(commands_stdout.contains("\"surface\":\"valid\""));
+    assert!(commands_stdout.contains("\"name\":\"check\""));
+    assert!(commands_stdout.contains("\"response\":\"schema.run_result\""));
+
+    let schema = Command::new(binary_path())
+        .arg("schema")
+        .arg("check")
+        .output()
+        .expect("schema should run");
+    assert!(schema.status.success());
+    let schema_stdout = String::from_utf8_lossy(&schema.stdout);
+    assert!(schema_stdout.contains("\"command\":\"check\""));
+    assert!(schema_stdout.contains("\"parameter_schema_id\":\"schema.cli.valid.check.parameters\""));
+    assert!(schema_stdout.contains("\"response_schema_id\":\"schema.run_result\""));
+}
+
+#[test]
+fn cli_json_errors_go_to_stderr() {
+    let missing = repo_path("tests/fixtures/models/does-not-exist.valid");
+    let output = Command::new(binary_path())
+        .arg("check")
+        .arg(&missing)
+        .arg("--json")
+        .output()
+        .expect("json error case should run");
+    assert_eq!(output.status.code(), Some(3));
+    assert!(String::from_utf8_lossy(&output.stdout).trim().is_empty());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("\"kind\":\"cli_error\""));
+    assert!(stderr.contains("\"command\":\"check\""));
+    assert!(stderr.contains("failed to read"));
+}
+
+#[test]
+fn cli_batch_runs_multiple_operations() {
+    let safe = repo_path("tests/fixtures/models/safe_counter.valid");
+    let fail = repo_path("tests/fixtures/models/failing_counter.valid");
+    let request = format!(
+        "{{\"schema_version\":\"1.0.0\",\"continue_on_error\":true,\"operations\":[{{\"command\":\"check\",\"args\":[\"{}\"],\"json\":true}},{{\"command\":\"check\",\"args\":[\"{}\"],\"json\":true}}]}}",
+        safe.display(),
+        fail.display()
+    );
+    let mut child = Command::new(binary_path())
+        .arg("batch")
+        .arg("--json")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("batch should spawn");
+    child
+        .stdin
+        .as_mut()
+        .expect("stdin")
+        .write_all(request.as_bytes())
+        .expect("write batch request");
+    let output = child.wait_with_output().expect("batch should complete");
+    assert_eq!(output.status.code(), Some(1));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("\"status\":\"FAIL\""));
+    assert!(stdout.contains("\"command\":\"check\""));
+    assert!(stdout.contains("\"exit_code\":0"));
+    assert!(stdout.contains("\"exit_code\":1"));
 }

--- a/tests/e2e_enterprise_scale.rs
+++ b/tests/e2e_enterprise_scale.rs
@@ -103,7 +103,7 @@ fn enterprise_scale_regression_fails_with_review_summary() {
         .arg("--json")
         .output()
         .expect("cargo-valid verify should run");
-    assert_eq!(output.status.code(), Some(2));
+    assert_eq!(output.status.code(), Some(1));
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(stdout.contains("\"status\":\"FAIL\""));
     assert!(stdout.contains("\"ci\":{\"exit_code\":2"));

--- a/tests/e2e_practical_suite.rs
+++ b/tests/e2e_practical_suite.rs
@@ -126,7 +126,7 @@ fn practical_suite_regression_model_fails_with_explainable_path() {
         .arg("--json")
         .output()
         .expect("check should run for regression model");
-    assert_eq!(check.status.code(), Some(2));
+    assert_eq!(check.status.code(), Some(1));
     let check_stdout = String::from_utf8_lossy(&check.stdout);
     assert!(check_stdout.contains("\"status\":\"FAIL\""));
     assert!(check_stdout.contains("\"property_id\":\"P_ACCESS_REQUIRES_INCIDENT\""));

--- a/tests/e2e_real_solver.rs
+++ b/tests/e2e_real_solver.rs
@@ -51,7 +51,7 @@ fn real_cvc5_backend_finds_counterexample_when_available() {
 
     assert_eq!(
         output.status.code(),
-        Some(2),
+        Some(1),
         "stdout: {}\nstderr: {}",
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr)


### PR DESCRIPTION
## 概要
- valid / cargo-valid / registry で共有する CLI ヘルパーを追加し、commands/schema/batch と JSON 向けエラー整形を共通化
- --json 時の stderr エラーを構造化し、exit code を 0=success / 1=fail / 2=unknown / 3=error に正規化
- --progress=json、batch 実行、機械可読なコマンド一覧と JSON schema 取得を追加し、E2E で検証

## テスト
- cargo test -q

Closes #21