### PR TITLE
CI: contract/coverage ゲートの追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,3 +59,43 @@ jobs:
         with:
           name: benchmark-reports
           path: artifacts/benchmarks
+  contract:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+      - name: Run contract check when lock file exists
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p artifacts/ci
+          if [[ -f valid.lock.json ]]; then
+            cargo run --quiet --bin cargo-valid -- contract check valid.lock.json --json | tee artifacts/ci/contract-check.json
+          else
+            echo "No valid.lock.json found; skipping contract check."
+          fi
+      - name: Upload contract artifact
+        if: always() && hashFiles('artifacts/ci/contract-check.json') != ''
+        uses: actions/upload-artifact@v4
+        with:
+          name: ci-contract
+          path: artifacts/ci/contract-check.json
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+      - name: Evaluate coverage gate
+        run: python3 scripts/ci/coverage_gate.py
+      - name: Upload coverage artifacts
+        if: always() && hashFiles('artifacts/ci/coverage/*.json') != ''
+        uses: actions/upload-artifact@v4
+        with:
+          name: ci-coverage
+          path: artifacts/ci/coverage/

--- a/packages/valid/src/bin/cargo-valid.rs
+++ b/packages/valid/src/bin/cargo-valid.rs
@@ -59,6 +59,14 @@ fn main() {
     if parsed.command == "clean" {
         cmd_clean(&parsed);
     }
+    if parsed.manifest_path.is_none()
+        && parsed.example.is_none()
+        && parsed.bin.is_none()
+        && parsed.file.is_none()
+        && !parsed.extra_positionals.is_empty()
+    {
+        usage_exit(&primary_usage());
+    }
     if parsed.manifest_path.is_some()
         || parsed.example.is_some()
         || parsed.bin.is_some()
@@ -116,7 +124,7 @@ fn main() {
 }
 
 fn primary_usage() -> String {
-    "usage: cargo valid [--manifest-path <path>] [--registry <path>|--file <path>|--example <name>|--bin <name>] <init|models|inspect|graph|readiness|migrate|benchmark|verify|suite|explain|coverage|orchestrate|generate-tests|replay|clean|commands|schema|batch> [model] [--json] [--progress=json] [--format=<mermaid|dot|svg|text|json>] [--view=<overview|logic>] [--property=<id>] [--backend=<explicit|mock-bmc|sat-varisat|smt-cvc5|command>] [--solver-exec <path>] [--solver-arg <arg>] [--focus-action=<id>] [--actions=a,b,c] [--strategy=<counterexample|transition|witness|guard|boundary|path|random>] [--repeat=<n>] [--baseline[=compare|record|ignore]] [--threshold-percent=<n>] [--write[=<path>]] [--check]".to_string()
+    "usage: cargo valid [--manifest-path <path>] [--registry <path>|--file <path>|--example <name>|--bin <name>] <init|models|inspect|graph|readiness|migrate|benchmark|verify|suite|explain|coverage|orchestrate|generate-tests|replay|contract|clean|commands|schema|batch> [extra args] [model] [--json] [--progress=json] [--format=<mermaid|dot|svg|text|json>] [--view=<overview|logic>] [--property=<id>] [--backend=<explicit|mock-bmc|sat-varisat|smt-cvc5|command>] [--solver-exec <path>] [--solver-arg <arg>] [--focus-action=<id>] [--actions=a,b,c] [--strategy=<counterexample|transition|witness|guard|boundary|path|random>] [--repeat=<n>] [--baseline[=compare|record|ignore]] [--threshold-percent=<n>] [--write[=<path>]] [--check]".to_string()
 }
 
 fn internal_bundled_mode_enabled() -> bool {
@@ -190,6 +198,7 @@ fn run_external_benchmark(parsed: CliArgs) -> ! {
             benchmark_models: Vec::new(),
             write_path: None,
             check: false,
+            extra_positionals: Vec::new(),
         })
         .output()
         .unwrap_or_else(|err| {
@@ -269,6 +278,7 @@ fn run_external_all(parsed: CliArgs) -> ! {
             benchmark_models: Vec::new(),
             write_path: None,
             check: false,
+            extra_positionals: Vec::new(),
         });
         let output = command.output().unwrap_or_else(|err| {
             message_exit(
@@ -327,6 +337,9 @@ fn build_external_command(parsed: &CliArgs) -> Command {
     command.arg(&parsed.command);
     if let Some(model) = &parsed.model {
         command.arg(model);
+    }
+    for extra in &parsed.extra_positionals {
+        command.arg(extra);
     }
     if parsed.command == "benchmark" && parsed.repeat > 0 {
         command.arg(format!("--repeat={}", parsed.repeat));
@@ -411,6 +424,7 @@ fn fetch_external_models(parsed: &CliArgs) -> Vec<String> {
         benchmark_models: Vec::new(),
         write_path: None,
         check: false,
+        extra_positionals: Vec::new(),
     })
     .output()
     .unwrap_or_else(|err| {
@@ -1019,6 +1033,7 @@ struct CliArgs {
     file: Option<String>,
     command: String,
     model: Option<String>,
+    extra_positionals: Vec<String>,
     repeat: usize,
     baseline_mode: Option<String>,
     threshold_percent: Option<u32>,
@@ -1117,7 +1132,7 @@ fn parse_cli(args: Vec<String>) -> CliArgs {
             }
             _ if parsed.command.is_empty() => parsed.command = normalize_command(&arg),
             _ if parsed.model.is_none() => parsed.model = Some(arg),
-            _ => usage_exit(&primary_usage()),
+            _ => parsed.extra_positionals.push(arg),
         }
     }
     if parsed.command.is_empty() {
@@ -1823,5 +1838,50 @@ fn apply_project_runtime_config(config: &ProjectConfig) {
     }
     if let Some(default_graph_format) = &config.default_graph_format {
         env::set_var("VALID_DEFAULT_GRAPH_FORMAT", default_graph_format);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_cli_keeps_extra_positionals_for_external_commands() {
+        let parsed = parse_cli(vec![
+            "contract".to_string(),
+            "check".to_string(),
+            "valid.lock.json".to_string(),
+            "--json".to_string(),
+        ]);
+
+        assert_eq!(parsed.command, "contract");
+        assert_eq!(parsed.model.as_deref(), Some("check"));
+        assert_eq!(parsed.extra_positionals, vec!["valid.lock.json"]);
+        assert!(parsed.json);
+    }
+
+    #[test]
+    fn build_external_command_appends_extra_positionals_after_model() {
+        let command = build_external_command(&CliArgs {
+            manifest_path: Some("Cargo.toml".to_string()),
+            file: Some("examples/valid_models.rs".to_string()),
+            command: "contract".to_string(),
+            model: Some("check".to_string()),
+            extra_positionals: vec!["valid.lock.json".to_string()],
+            json: true,
+            ..CliArgs::default()
+        });
+        let args = command
+            .get_args()
+            .map(|arg| arg.to_string_lossy().into_owned())
+            .collect::<Vec<_>>();
+
+        assert!(args.ends_with(&[
+            "--".to_string(),
+            "contract".to_string(),
+            "check".to_string(),
+            "valid.lock.json".to_string(),
+            "--json".to_string(),
+        ]));
     }
 }

--- a/scripts/ci/coverage_gate.py
+++ b/scripts/ci/coverage_gate.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+ARTIFACT_DIR = ROOT / "artifacts" / "ci" / "coverage"
+
+
+def escape_workflow_command(value: str) -> str:
+    return value.replace("%", "%25").replace("\r", "%0D").replace("\n", "%0A")
+
+
+def run_command(args: list[str]) -> str:
+    completed = subprocess.run(
+        args,
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+    )
+    if completed.returncode != 0:
+        if completed.stdout:
+            print(completed.stdout, file=sys.stderr, end="")
+        if completed.stderr:
+            print(completed.stderr, file=sys.stderr, end="")
+        raise SystemExit(completed.returncode)
+    return completed.stdout
+
+
+def load_models() -> list[str]:
+    config_path = ROOT / "valid.toml"
+    if config_path.exists():
+        config_body = config_path.read_text(encoding="utf-8")
+        match = re.search(r"^suite_models\s*=\s*\[(.*?)\]", config_body, re.MULTILINE | re.DOTALL)
+        suite_models = []
+        if match:
+            for raw_item in match.group(1).split(","):
+                model = raw_item.strip().strip('"').strip("'")
+                if model:
+                    suite_models.append(model)
+        if suite_models:
+            return suite_models
+
+    stdout = run_command(
+        ["cargo", "run", "--quiet", "--bin", "cargo-valid", "--", "models", "--json"]
+    )
+    payload = json.loads(stdout)
+    models = payload.get("models", [])
+    if not isinstance(models, list) or not models:
+        raise SystemExit("coverage gate requires at least one model")
+    return [str(model) for model in models]
+
+
+def main() -> int:
+    ARTIFACT_DIR.mkdir(parents=True, exist_ok=True)
+    models = load_models()
+
+    for model in models:
+        stdout = run_command(
+            [
+                "cargo",
+                "run",
+                "--quiet",
+                "--bin",
+                "cargo-valid",
+                "--",
+                "coverage",
+                model,
+                "--json",
+            ]
+        )
+        report = json.loads(stdout)
+        artifact_path = ARTIFACT_DIR / f"{model}.json"
+        artifact_path.write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")
+
+        summary = report.get("summary", {})
+        gate = report.get("gate", {})
+        status = str(gate.get("status", "unknown"))
+        transition = summary.get("transition_coverage_percent", "n/a")
+        guard = summary.get("guard_full_coverage_percent", "n/a")
+        reasons = gate.get("reasons") or []
+
+        print(
+            f"coverage[{model}] status={status} "
+            f"transition={transition}% guard_full={guard}%"
+        )
+        if status != "pass":
+            reason_text = ", ".join(str(reason) for reason in reasons) or "threshold not met"
+            message = (
+                f"model={model} transition={transition}% "
+                f"guard_full={guard}% reasons={reason_text}"
+            )
+            print(f"::warning title=Coverage gate::{escape_workflow_command(message)}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## 概要
- CI に contract check job を追加し、`valid.lock.json` がある場合に `contract check` を実行するようにした
- coverage gate を CI で評価し、閾値未達は warning annotation と artifact 出力にして非ブロッキング化した
- project-first な `cargo-valid` から `contract check <lock-file>` を通せるように extra positional passthrough を追加した

## 変更内容
- `.github/workflows/ci.yml`
  - `contract` job を追加
  - `coverage` job を追加
  - contract / coverage の JSON artifact を upload
- `packages/valid/src/bin/cargo-valid.rs`
  - external registry command への extra positional passthrough を追加
  - `contract` usage を明示
  - passthrough の unit test を追加
- `scripts/ci/coverage_gate.py`
  - `suite_models` 優先で coverage を評価
  - `gate.status != pass` の場合は `::warning` を出しつつ job は成功
  - coverage report を `artifacts/ci/coverage/*.json` に保存

## 確認
- `cargo test -q`
- `python3 scripts/ci/coverage_gate.py`
- `cargo run --quiet --bin cargo-valid -- --registry examples/fizzbuzz.rs contract lock <tmp> --json`
- `cargo run --quiet --bin cargo-valid -- --registry examples/fizzbuzz.rs contract check <tmp> --json`

## 備考
- `doc --check` は現時点でこの repo に CLI 実装がないため、今回の issue スコープでは追加していません

Closes #18


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Command-line interface now accepts and forwards additional positional arguments to external subcommands.

* **Chores**
  * Added automated contract validation checks to CI/CD pipeline.
  * Added per-model coverage evaluation and reporting to CI/CD pipeline.
  * Configured coverage validation with threshold monitoring and automated workflow notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->