### PR TITLE
Add project organization guide for valid models

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ especially [docs/dsl/README.md](./docs/dsl/README.md),
 [docs/dsl/language-spec.md](./docs/dsl/language-spec.md), and
 [docs/dsl/language-evolution.md](./docs/dsl/language-evolution.md). AI-assisted
 authoring should start with [docs/ai/authoring-guide.md](./docs/ai/authoring-guide.md).
+Project layout and file-splitting guidance lives in
+[docs/project-organization.md](./docs/project-organization.md).
 Installation and packaging guidance lives in
 [docs/install.md](./docs/install.md), and the clean-architecture overview lives
 in [docs/architecture.md](./docs/architecture.md).
@@ -99,6 +101,10 @@ benchmark_baseline_dir = "benchmarks/baselines"
 benchmark_regression_threshold_percent = 25
 default_graph_format = "mermaid"
 ```
+
+Keep the registry file thin and move real model logic into `src/models/` or
+another explicit module tree. The recommended project layout is documented in
+[docs/project-organization.md](./docs/project-organization.md).
 
 This repository already includes a `valid.toml`, so from the repo root the
 default `cargo valid` workflow points at the smallest step-first example:

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,6 +4,9 @@
   Installation modes, binary vs Cargo usage, Docker, and backend selection.
 - [AI Authoring Guide](./ai/authoring-guide.md)
   Short canonical entrypoint for LLM agents and AI-assisted authoring flows.
+- [Project Organization Guide](./project-organization.md)
+  Recommended layout for model files, registries, shared types, integration
+  models, and generated artifacts.
 - [Architecture](./architecture.md)
   Clean-architecture view of the repository, package roles, DTO boundary, and
   solver-neutral layering.
@@ -24,6 +27,8 @@
 If you want to install or distribute the tool, start with the install guide.
 If you want to wire an LLM or MCP client into `valid`, start with the AI
 authoring guide.
+If you want to keep a `valid` project maintainable as it grows, read the
+project organization guide next.
 If you want to model and verify a system, start with the Rust DSL guide.
 If you want to understand the repository's design and scope, read the
 architecture note and the RDD.

--- a/docs/ai/authoring-guide.md
+++ b/docs/ai/authoring-guide.md
@@ -11,6 +11,7 @@ Related documents:
 - [Modeling Checklist](./modeling-checklist.md)
 - [Common Pitfalls](./common-pitfalls.md)
 - [Examples Curriculum](./examples-curriculum.md)
+- [Project Organization Guide](../project-organization.md)
 - [Rust DSL Guide](../dsl/README.md)
 - [DSL Language Spec](../dsl/language-spec.md)
 
@@ -179,6 +180,9 @@ For MCP-driven authoring:
 - Keep project-level `critical_properties` and `property_suites` small and
   reviewable. Treat them as CI targeting contracts, not a dump of every
   property in the model.
+- Keep registry files thin. Prefer one model per file and move shared enums or
+  reusable domain vocabulary into a dedicated shared module instead of copying
+  them across models.
 - Use `..state` only as explicit frame-condition sugar.
 - Keep domains finite and obvious.
 - Choose declarative transitions unless you are intentionally staying
@@ -199,4 +203,5 @@ For MCP-driven authoring:
 - If you need a generation checklist: [Modeling Checklist](./modeling-checklist.md)
 - If you need anti-patterns: [Common Pitfalls](./common-pitfalls.md)
 - If you need examples in learning order: [Examples Curriculum](./examples-curriculum.md)
+- If you need project layout guidance: [Project Organization Guide](../project-organization.md)
 - If you need the full supported surface: [DSL Language Spec](../dsl/language-spec.md)

--- a/docs/dsl/README.md
+++ b/docs/dsl/README.md
@@ -9,6 +9,7 @@ This is not the design spec. For requirements and architecture, see the RDD.
 Related documents:
 
 - [AI Authoring Guide](../ai/authoring-guide.md)
+- [Project Organization Guide](../project-organization.md)
 - [Current Language Spec](./language-spec.md)
 - [Language Evolution Notes](./language-evolution.md)
 - [ADR-0001: `valid_model!` Frontend Decision](../adr/0001-valid-model-frontend.md)
@@ -437,6 +438,12 @@ fn main() {
 ```
 
 In a project, `valid.toml` points `cargo valid` at the registry file.
+
+For long-lived projects, keep the registry file thin and put real model logic
+under a dedicated module tree such as `src/models/`. See the
+[Project Organization Guide](../project-organization.md) for recommended
+layouts for standalone models, integration models, shared types, and generated
+artifacts.
 
 Project-level verification targeting can also live in `valid.toml`:
 

--- a/docs/project-organization.md
+++ b/docs/project-organization.md
@@ -1,0 +1,270 @@
+# Project Organization Guide
+
+This guide explains how to structure `valid` projects so models stay readable
+as they grow from a single example into a real verification suite.
+
+The goal is not to impose one mandatory layout. The goal is to keep model
+intent, shared domain vocabulary, registries, and generated artifacts from
+colliding in one place.
+
+Related documents:
+
+- [AI Authoring Guide](./ai/authoring-guide.md)
+- [Rust DSL Guide](./dsl/README.md)
+- [Examples](../examples/README.md)
+
+## Default Rules
+
+Use these as the default unless you have a clear reason to deviate:
+
+- keep one model per file
+- keep registry files thin
+- keep shared enums, state helpers, and domain vocabulary in separate modules
+- keep examples small and user-facing
+- keep generated artifacts out of hand-written source trees
+- add one short comment block at the top of every model file explaining scope
+
+`valid` works best when a reviewer can answer these questions quickly:
+
+- where is the source of truth for this model
+- which file exports it to `cargo valid`
+- which shared types are local to one model vs shared across a subdomain
+- where integration models live
+- where generated tests and artifacts go
+
+## Recommended Layouts
+
+### Small Project
+
+Use this when you have one or two models and only a small amount of shared
+domain vocabulary.
+
+```text
+my-app/
+├── Cargo.toml
+├── valid.toml
+├── examples/
+│   └── valid_models.rs
+├── src/
+│   ├── models/
+│   │   ├── approval.rs
+│   │   └── tenant_access.rs
+│   └── domain/
+│       └── mod.rs
+├── generated-tests/
+└── artifacts/
+```
+
+Recommended conventions:
+
+- `valid.toml` points at `examples/valid_models.rs`
+- `examples/valid_models.rs` only wires models into `valid_models![...]`
+- `src/models/*.rs` owns the actual `valid_model!` definitions
+- `src/domain/` holds shared enums and reusable helpers
+
+### Medium Project
+
+Use this when you have multiple subdomains, more than one registry consumer, or
+explicit integration models.
+
+```text
+my-app/
+├── Cargo.toml
+├── valid.toml
+├── examples/
+│   ├── valid_models.rs
+│   └── integration_models.rs
+├── src/
+│   ├── domain/
+│   │   ├── authz.rs
+│   │   ├── billing.rs
+│   │   └── shared.rs
+│   ├── models/
+│   │   ├── authz/
+│   │   │   ├── role_assignment.rs
+│   │   │   └── access_review.rs
+│   │   ├── billing/
+│   │   │   ├── quota_guardrail.rs
+│   │   │   └── invoice_state.rs
+│   │   └── integration/
+│   │       └── tenant_lifecycle.rs
+│   └── lib.rs
+├── docs/
+│   └── verification/
+├── generated-tests/
+└── artifacts/
+```
+
+Recommended conventions:
+
+- split by subdomain before files become large
+- keep integration models under a clearly named `integration/` subtree
+- keep shared domain vocabulary in `src/domain/`, not copied across model files
+- keep registries as export surfaces, not as places where model logic accumulates
+
+## File Responsibilities
+
+### `valid.toml`
+
+Treat `valid.toml` as project policy, not as a dumping ground.
+
+Good contents:
+
+- active registry path
+- default backend preferences
+- `critical_properties`
+- `property_suites`
+- artifact directories
+
+Do not put model logic here.
+
+### Registry files
+
+A registry file should stay thin. Its main job is to export models through
+`valid_models![...]` and start the CLI with `run_registry_cli(...)`.
+
+Prefer this:
+
+```rust
+use valid::{registry::run_registry_cli, valid_models};
+
+use crate::models::approval::ApprovalModel;
+use crate::models::integration::tenant_lifecycle::TenantLifecycleModel;
+
+fn main() {
+    run_registry_cli(valid_models![
+        "approval" => ApprovalModel,
+        "tenant-lifecycle" => TenantLifecycleModel,
+    ]);
+}
+```
+
+Avoid putting large blocks of model logic directly in registry files unless the
+project is intentionally tiny.
+
+### Model files
+
+By default, keep one model per file. Split sooner when:
+
+- the file mixes unrelated actions and properties
+- the file needs many repeated helper conditions
+- the model is primarily about a different subdomain than its neighbors
+- one review regularly changes without touching the others
+
+Each model file should explain:
+
+- what workflow or rule family it covers
+- what is explicitly out of scope
+- whether it is standalone or integration-focused
+- which properties are treated as critical
+
+### Shared domain types
+
+Put shared enums, finite-key types, and reusable domain helpers under a
+dedicated domain module instead of duplicating them inside multiple model
+files.
+
+Good candidates for `src/domain/`:
+
+- tenant, plan, role, region, or entitlement enums
+- reusable finite relation/map key types
+- small helper constructors used by more than one model
+
+Keep model-specific predicates and transition logic in the model file itself.
+
+### Integration models
+
+Use integration models when you need to check the interaction between otherwise
+separate subdomains.
+
+Keep them separate from standalone models when possible:
+
+- standalone models stay focused and easier to review
+- integration models can state shared assumptions explicitly
+- CI and AI workflows can decide whether to run a small focused model or a
+  broader combined one
+
+If an integration model starts owning all the business logic, it is usually a
+sign that the underlying standalone models are too weak or too fragmented.
+
+## What Goes Where
+
+Use these repository areas intentionally:
+
+- `examples/`
+  small user-facing registries that demonstrate one idea clearly
+- `benchmarks/registries/`
+  larger or stress-oriented registries for scale/performance work
+- `tests/fixtures/models/`
+  `.valid` compatibility fixtures and frontend parsing fixtures
+- `tests/fixtures/domain/`
+  shared domain helpers for test-only model scenarios
+- `generated-tests/`
+  generated outputs from `generate-tests`
+- `artifacts/`
+  graph, report, benchmark, and verification outputs
+- `docs/`
+  long-lived explanation and workflow guidance
+
+Do not mix generated output back into `src/`, `examples/`, or `tests/`.
+
+## When To Split A Model
+
+Stay with one file when:
+
+- the action set is small
+- one bounded domain tells one coherent story
+- review discussions happen in one place
+
+Split by subdomain when:
+
+- one file is trying to cover multiple workflows
+- properties naturally cluster into separate rule families
+- action metadata becomes noisy or duplicated
+- comments start explaining several different mental models
+
+Split into an integration model when:
+
+- correctness depends on shared state slices across multiple models
+- one user journey crosses multiple bounded contexts
+- the standalone models are each useful, but a cross-model invariant also
+  matters
+
+## Templates and Examples
+
+The current repo reflects this guidance in a few ways:
+
+- `cargo valid init` scaffolds a thin project-first registry at
+  `examples/valid_models.rs`
+- [`examples/README.md`](../examples/README.md) keeps the user-facing examples
+  small and names where heavy fixtures belong instead
+- the AI authoring docs assume registry mode and project-level organization
+  instead of one giant model file
+
+When you add a new example, prefer a small purpose-built registry under
+`examples/` and keep benchmark-like or fixture-like inputs out of that path.
+
+## AI Workflow Guidance
+
+When an AI assistant works in a `valid` project, it should:
+
+1. locate `valid.toml`
+2. identify the active registry
+3. find the model file behind the registry entry
+4. check whether shared types live in a domain module
+5. decide whether the change belongs in a standalone model, integration model,
+   registry wiring, or project policy
+
+This keeps the assistant from editing registries as if they were the source of
+truth for the model logic.
+
+## Review Checklist
+
+Before merging a new model or layout change, verify:
+
+- model logic is not hidden inside the registry file
+- shared types are not duplicated across multiple models
+- integration models are clearly separated from standalone ones
+- generated artifacts stay in `generated-tests/` or `artifacts/`
+- the top of each model file explains scope and intent
+- examples stay small and human-readable

--- a/examples/README.md
+++ b/examples/README.md
@@ -3,6 +3,9 @@
 `examples/` is intentionally small. It only contains user-facing Rust DSL
 registries that are easy to read and debug.
 
+For broader project layout guidance, see
+[`docs/project-organization.md`](../docs/project-organization.md).
+
 Every example should start with a `/* ... */` block comment that explains:
 
 - what business rule or finite-state contract is being modeled
@@ -35,6 +38,9 @@ Heavy or fixture-like inputs live elsewhere:
   Mock solver scripts used by CLI and solver integration tests.
 - `tests/fixtures/domain/`
   Shared domain helpers used only by integration tests.
+- `src/models/` or another explicit module tree in real projects
+  The actual model logic should usually live here, while `examples/` or other
+  registry files stay thin and export-focused.
 
 Typical commands:
 
@@ -59,3 +65,5 @@ cargo valid verify failing-counter
 ```
 
 Generated tests are written under `generated-tests/`, not under `tests/`.
+Registry files should stay small enough that a reviewer can tell which models
+they export without reading pages of transition logic.


### PR DESCRIPTION
## Summary
- add a dedicated project organization guide for valid model layouts
- link the new guidance from the main README, docs index, DSL guide, AI guide, and examples guide

## Testing
- cargo test -q --test e2e_cli cli_commands_and_schema_are_machine_readable -- --exact

## Issue
- Closes #86