### PR TITLE
Add failure-centric graph slicing

### DIFF
--- a/packages/valid/src/bin/cargo-valid.rs
+++ b/packages/valid/src/bin/cargo-valid.rs
@@ -41,8 +41,9 @@ use valid::{
     },
     project::{render_project_config_template, render_registry_source_template, ProjectConfig},
     reporter::{
-        render_model_dot_with_view, render_model_mermaid_with_view, render_model_svg_with_view,
-        GraphView,
+        build_failure_graph_slice, render_model_dot_failure, render_model_dot_with_view,
+        render_model_mermaid_failure, render_model_mermaid_with_view, render_model_svg_failure,
+        render_model_svg_with_view, render_model_text_failure, GraphView,
     },
     support::{
         artifact::{benchmark_baseline_path, benchmark_report_path},
@@ -160,7 +161,7 @@ fn main() {
 }
 
 fn primary_usage() -> String {
-    "usage: cargo valid [--manifest-path <path>] [--registry <path>|--file <path>|--example <name>|--bin <name>] <init|models|inspect|graph|doc|readiness|migrate|benchmark|verify|suite|explain|coverage|orchestrate|generate-tests|replay|contract|clean|commands|schema|batch> [extra args] [model] [--json] [--progress=json] [--format=<mermaid|dot|svg|text|json>] [--view=<overview|logic>] [--property=<id>] [--critical] [--suite=<name>] [--seed=<u64>] [--backend=<explicit|mock-bmc|sat-varisat|smt-cvc5|command>] [--solver-exec <path>] [--solver-arg <arg>] [--focus-action=<id>] [--actions=a,b,c] [--strategy=<counterexample|transition|witness|guard|boundary|path|random>] [--repeat=<n>] [--baseline[=compare|record|ignore]] [--threshold-percent=<n>] [--write[=<path>]] [--check]".to_string()
+    "usage: cargo valid [--manifest-path <path>] [--registry <path>|--file <path>|--example <name>|--bin <name>] <init|models|inspect|graph|doc|readiness|migrate|benchmark|verify|suite|explain|coverage|orchestrate|generate-tests|replay|contract|clean|commands|schema|batch> [extra args] [model] [--json] [--progress=json] [--format=<mermaid|dot|svg|text|json>] [--view=<overview|logic|failure>] [--property=<id>] [--critical] [--suite=<name>] [--seed=<u64>] [--backend=<explicit|mock-bmc|sat-varisat|smt-cvc5|command>] [--solver-exec <path>] [--solver-arg <arg>] [--focus-action=<id>] [--actions=a,b,c] [--strategy=<counterexample|transition|witness|guard|boundary|path|random>] [--repeat=<n>] [--baseline[=compare|record|ignore]] [--threshold-percent=<n>] [--write[=<path>]] [--check]".to_string()
 }
 
 fn internal_bundled_mode_enabled() -> bool {
@@ -501,7 +502,15 @@ fn command_supports_solver(command: &str) -> bool {
 fn command_supports_property(command: &str) -> bool {
     matches!(
         command,
-        "check" | "verify" | "benchmark" | "testgen" | "trace" | "coverage" | "replay" | "all"
+        "check"
+            | "verify"
+            | "benchmark"
+            | "graph"
+            | "testgen"
+            | "trace"
+            | "coverage"
+            | "replay"
+            | "all"
     )
 }
 
@@ -969,9 +978,9 @@ fn cmd_inspect(parsed: ParsedArgs) {
 fn cmd_graph(parsed: ParsedArgs) {
     let progress = ProgressReporter::new("graph", parsed.progress_json);
     progress.start(None);
-    let model = parsed.model.unwrap_or_else(|| {
+    let model = parsed.model.clone().unwrap_or_else(|| {
         usage_exit(
-            "usage: cargo valid graph <model> [--format=mermaid|dot|svg|text|json] [--view=overview|logic]",
+            "usage: cargo valid graph <model> [--format=mermaid|dot|svg|text|json] [--view=overview|logic|failure] [--property=<id>]",
         )
     });
     let request = InspectRequest {
@@ -988,16 +997,91 @@ fn cmd_graph(parsed: ParsedArgs) {
     let json_output = parsed.json || default_format == "json";
     let view = GraphView::parse(parsed.view.as_deref());
     match inspect_source(&request) {
-        Ok(response) => match default_format {
-            "json" => println!("{}", render_inspect_json(&response)),
-            "text" => print!("{}", render_inspect_text(&response)),
-            "dot" => println!("{}", render_model_dot_with_view(&response, view)),
-            "svg" => println!("{}", render_model_svg_with_view(&response, view)),
-            _ => println!("{}", render_model_mermaid_with_view(&response, view)),
-        },
+        Ok(response) => {
+            match render_cargo_graph_output(&response, &request, &parsed, default_format, view) {
+                Ok(body) => print!("{body}"),
+                Err(message) => message_exit("cargo-valid", json_output, &message, None),
+            }
+        }
         Err(diagnostics) => diagnostics_exit("graph", json_output, &diagnostics),
     }
     progress.finish(ExitCode::Success);
+}
+
+fn render_cargo_graph_output(
+    response: &valid::api::InspectResponse,
+    request: &InspectRequest,
+    parsed: &ParsedArgs,
+    render_format: &str,
+    view: GraphView,
+) -> Result<String, String> {
+    if view != GraphView::Failure {
+        return Ok(match render_format {
+            "json" => format!("{}\n", render_inspect_json(response)),
+            "text" => render_inspect_text(response),
+            "dot" => format!("{}\n", render_model_dot_with_view(response, view)),
+            "svg" => format!("{}\n", render_model_svg_with_view(response, view)),
+            _ => format!("{}\n", render_model_mermaid_with_view(response, view)),
+        });
+    }
+
+    let property_id = parsed
+        .property_id
+        .as_ref()
+        .ok_or_else(|| "failure graph view requires --property=<id>".to_string())?;
+    let outcome = check_source(&CheckRequest {
+        request_id: "cargo-valid-graph-failure".to_string(),
+        source_name: request.source_name.clone(),
+        source: request.source.clone(),
+        property_id: Some(property_id.clone()),
+        scenario_id: None,
+        seed: parsed.seed,
+        backend: parsed.backend.clone(),
+        solver_executable: parsed.solver_executable.clone(),
+        solver_args: parsed.solver_args.clone(),
+    });
+    let result = match outcome {
+        valid::engine::CheckOutcome::Completed(result) => result,
+        valid::engine::CheckOutcome::Errored(error) => {
+            return Err(error
+                .diagnostics
+                .first()
+                .map(|diagnostic| diagnostic.message.clone())
+                .unwrap_or_else(|| "failure graph check failed".to_string()))
+        }
+    };
+    let trace = result
+        .trace
+        .as_ref()
+        .ok_or_else(|| format!("property `{property_id}` did not produce evidence trace"))?;
+    let slice = build_failure_graph_slice(response, trace, property_id)?;
+
+    Ok(match render_format {
+        "json" => {
+            let mut body: Value = serde_json::from_str(&render_inspect_json(response))
+                .map_err(|err| format!("failed to prepare graph json: {err}"))?;
+            body["graph_view"] = Value::String("failure".to_string());
+            body["graph_slice"] = json!({
+                "property_id": slice.property_id,
+                "failing_action_id": slice.failing_action_id,
+                "failing_step_index": slice.failing_step_index,
+                "focused_fields": slice.focused_fields,
+                "focused_reads": slice.focused_reads,
+                "focused_writes": slice.focused_writes,
+                "focused_path_tags": slice.focused_path_tags,
+                "focused_transition_indexes": slice.focused_transition_indexes,
+                "summary": slice.summary,
+            });
+            format!(
+                "{}\n",
+                serde_json::to_string(&body).map_err(|err| err.to_string())?
+            )
+        }
+        "text" => render_model_text_failure(response, &slice),
+        "dot" => format!("{}\n", render_model_dot_failure(response, &slice)),
+        "svg" => format!("{}\n", render_model_svg_failure(response, &slice)),
+        _ => format!("{}\n", render_model_mermaid_failure(response, &slice)),
+    })
 }
 
 fn cmd_doc(parsed: ParsedArgs) {

--- a/packages/valid/src/bin/valid.rs
+++ b/packages/valid/src/bin/valid.rs
@@ -6,6 +6,7 @@ use std::{
 };
 
 use clap::{ArgAction, Args, Parser, Subcommand};
+use serde_json::Value;
 use valid::{
     api::{
         capabilities_response, check_source, explain_source, inspect_source, lint_source,
@@ -45,8 +46,10 @@ use valid::{
     mcp::{serve_stdio, ServerConfig},
     project::{load_project_config, rerun_recommendations},
     reporter::{
-        render_model_dot_with_view, render_model_mermaid_with_view, render_model_svg_with_view,
-        render_trace_mermaid, render_trace_sequence_mermaid, GraphView,
+        build_failure_graph_slice, render_model_dot_failure, render_model_dot_with_view,
+        render_model_mermaid_failure, render_model_mermaid_with_view, render_model_svg_failure,
+        render_model_svg_with_view, render_model_text_failure, render_trace_mermaid,
+        render_trace_sequence_mermaid, GraphView,
     },
     selfcheck::{run_smoke_selfcheck, write_selfcheck_artifact},
     testgen::{render_replay_json, replay_path_for_model},
@@ -135,6 +138,8 @@ struct GraphArgs {
     format: Option<String>,
     #[arg(long)]
     view: Option<String>,
+    #[arg(long)]
+    property: Option<String>,
     #[command(flatten)]
     json_progress: JsonProgressArgs,
 }
@@ -366,6 +371,7 @@ fn graph_to_parsed(args: GraphArgs) -> ParsedArgs {
         path: args.path,
         format: args.format,
         view: args.view,
+        property_id: args.property,
         ..ParsedArgs::default()
     }
 }
@@ -916,7 +922,7 @@ fn cmd_inspect(args: Vec<String>) {
 fn cmd_graph(args: Vec<String>) {
     let parsed = parse_common_args_with(
         args,
-        "usage: valid graph <model-file> [--format=mermaid|dot|svg|text|json] [--view=overview|logic] [--json] [--progress=json]",
+        "usage: valid graph <model-file> [--format=mermaid|dot|svg|text|json] [--view=overview|logic|failure] [--property=<id>] [--json] [--progress=json]",
         |_arg, _parsed| false,
     );
     let json_output = parsed.json || matches!(parsed.format.as_deref(), Some("json"));
@@ -940,16 +946,93 @@ fn cmd_graph(args: Vec<String>) {
         .unwrap_or("mermaid");
     let view = GraphView::parse(parsed.view.as_deref());
     match inspect_source(&request) {
-        Ok(response) => match render_format {
-            "json" => println!("{}", render_inspect_json(&response)),
-            "text" => print!("{}", render_inspect_text(&response)),
-            "dot" => println!("{}", render_model_dot_with_view(&response, view)),
-            "svg" => println!("{}", render_model_svg_with_view(&response, view)),
-            _ => println!("{}", render_model_mermaid_with_view(&response, view)),
-        },
+        Ok(response) => {
+            match render_graph_output(&response, &request, &parsed, render_format, view, "graph") {
+                Ok(body) => print!("{body}"),
+                Err(message) => message_exit("graph", json_output, &message, None),
+            }
+        }
         Err(diagnostics) => diagnostics_exit("graph", json_output, &diagnostics, None),
     }
     progress.finish(ExitCode::Success);
+}
+
+fn render_graph_output(
+    response: &valid::api::InspectResponse,
+    request: &InspectRequest,
+    parsed: &ParsedArgs,
+    render_format: &str,
+    view: GraphView,
+    command: &str,
+) -> Result<String, String> {
+    if view != GraphView::Failure {
+        return Ok(match render_format {
+            "json" => format!("{}\n", render_inspect_json(response)),
+            "text" => render_inspect_text(response),
+            "dot" => format!("{}\n", render_model_dot_with_view(response, view)),
+            "svg" => format!("{}\n", render_model_svg_with_view(response, view)),
+            _ => format!("{}\n", render_model_mermaid_with_view(response, view)),
+        });
+    }
+
+    let property_id = parsed
+        .property_id
+        .as_ref()
+        .ok_or_else(|| "failure graph view requires --property=<id>".to_string())?;
+    let outcome = check_source(&CheckRequest {
+        request_id: format!("req-{command}-failure"),
+        source_name: request.source_name.clone(),
+        source: request.source.clone(),
+        property_id: Some(property_id.clone()),
+        scenario_id: parsed.scenario_id.clone(),
+        seed: parsed.seed,
+        backend: parsed.backend.clone(),
+        solver_executable: parsed.solver_executable.clone(),
+        solver_args: parsed.solver_args.clone(),
+    });
+    let result = match outcome {
+        CheckOutcome::Completed(result) => result,
+        CheckOutcome::Errored(error) => {
+            return Err(error
+                .diagnostics
+                .first()
+                .map(|diagnostic| diagnostic.message.clone())
+                .unwrap_or_else(|| "failure graph check failed".to_string()))
+        }
+    };
+    let trace = result
+        .trace
+        .as_ref()
+        .ok_or_else(|| format!("property `{property_id}` did not produce evidence trace"))?;
+    let slice = build_failure_graph_slice(response, trace, property_id)?;
+
+    Ok(match render_format {
+        "json" => {
+            let mut body: Value = serde_json::from_str(&render_inspect_json(response))
+                .map_err(|err| format!("failed to prepare graph json: {err}"))?;
+            body["graph_view"] = Value::String("failure".to_string());
+            body["graph_slice"] = serde_json::json!({
+                "property_id": slice.property_id,
+                "failing_action_id": slice.failing_action_id,
+                "failing_step_index": slice.failing_step_index,
+                "focused_fields": slice.focused_fields,
+                "focused_reads": slice.focused_reads,
+                "focused_writes": slice.focused_writes,
+                "focused_path_tags": slice.focused_path_tags,
+                "focused_transition_indexes": slice.focused_transition_indexes,
+                "summary": slice.summary,
+            });
+            format!(
+                "{}\n",
+                serde_json::to_string(&body)
+                    .map_err(|err| format!("failed to render graph json: {err}"))?
+            )
+        }
+        "text" => render_model_text_failure(response, &slice),
+        "dot" => format!("{}\n", render_model_dot_failure(response, &slice)),
+        "svg" => format!("{}\n", render_model_svg_failure(response, &slice)),
+        _ => format!("{}\n", render_model_mermaid_failure(response, &slice)),
+    })
 }
 
 fn cmd_doc(args: Vec<String>) {

--- a/packages/valid/src/cli.rs
+++ b/packages/valid/src/cli.rs
@@ -395,13 +395,13 @@ const TRACE_FORMAT_ARG: ArgSpec = ArgSpec {
 };
 const VIEW_ARG: ArgSpec = ArgSpec {
     name: "view",
-    syntax: "--view=<overview|logic>",
+    syntax: "--view=<overview|logic|failure>",
     value_type: "string",
     required: false,
     multiple: false,
     positional: false,
     description: "Graph view to render.",
-    values: &["overview", "logic"],
+    values: &["overview", "logic", "failure"],
 };
 const STRATEGY_ARG: ArgSpec = ArgSpec {
     name: "strategy",
@@ -660,7 +660,7 @@ const CHECK_OPTIONS: &[ArgSpec] = &[
     SOLVER_EXEC_ARG,
     SOLVER_ARG_ARG,
 ];
-const GRAPH_OPTIONS: &[ArgSpec] = &[FORMAT_ARG, VIEW_ARG, JSON_ARG, PROGRESS_ARG];
+const GRAPH_OPTIONS: &[ArgSpec] = &[FORMAT_ARG, VIEW_ARG, PROPERTY_ARG, JSON_ARG, PROGRESS_ARG];
 const LINT_OPTIONS: &[ArgSpec] = &[JSON_ARG, PROGRESS_ARG];
 const CAPABILITY_OPTIONS: &[ArgSpec] = &[
     JSON_ARG,
@@ -784,7 +784,7 @@ const VALID_COMMANDS: &[CommandSpec] = &[
         name: "graph",
         aliases: &["diagram"],
         description: "Render the model graph.",
-        usage: "valid graph <model-file> [--format=mermaid|dot|svg|text|json] [--view=overview|logic] [--json] [--progress=json]",
+        usage: "valid graph <model-file> [--format=mermaid|dot|svg|text|json] [--view=overview|logic|failure] [--property=<id>] [--json] [--progress=json]",
         positional: &[MODEL_FILE_ARG],
         options: GRAPH_OPTIONS,
         request_schema: Some(SchemaRef { id: "schema.ai.inspect_request", builder: inspect_request_schema }),
@@ -1027,7 +1027,7 @@ const REGISTRY_COMMANDS: &[CommandSpec] = &[
         name: "graph",
         aliases: &["diagram"],
         description: "Render a registered model graph.",
-        usage: "<registry-bin> graph <model> [--format=mermaid|dot|svg|text|json] [--view=<overview|logic>] [--json] [--progress=json]",
+        usage: "<registry-bin> graph <model> [--format=mermaid|dot|svg|text|json] [--view=<overview|logic|failure>] [--property=<id>] [--json] [--progress=json]",
         positional: &[MODEL_ARG],
         options: GRAPH_OPTIONS,
         request_schema: Some(SchemaRef { id: "schema.ai.inspect_request", builder: inspect_request_schema }),
@@ -1258,9 +1258,9 @@ const CARGO_VALID_COMMANDS: &[CommandSpec] = &[
         name: "graph",
         aliases: &["diagram"],
         description: "Render a model graph.",
-        usage: "cargo valid graph <model> [--format=mermaid|dot|svg|text|json] [--view=<overview|logic>] [--json] [--progress=json]",
+        usage: "cargo valid graph <model> [--format=mermaid|dot|svg|text|json] [--view=<overview|logic|failure>] [--property=<id>] [--json] [--progress=json]",
         positional: &[MODEL_ARG],
-        options: &[FORMAT_ARG, VIEW_ARG, JSON_ARG, PROGRESS_ARG, MANIFEST_ARG, REGISTRY_ARG, FILE_ARG, EXAMPLE_ARG, BIN_ARG],
+        options: &[FORMAT_ARG, VIEW_ARG, PROPERTY_ARG, JSON_ARG, PROGRESS_ARG, MANIFEST_ARG, REGISTRY_ARG, FILE_ARG, EXAMPLE_ARG, BIN_ARG],
         request_schema: Some(SchemaRef { id: "schema.ai.inspect_request", builder: inspect_request_schema }),
         response_schema: Some(SchemaRef { id: "schema.ai.inspect_response", builder: inspect_response_schema }),
         supports_json: true,

--- a/packages/valid/src/mcp/mod.rs
+++ b/packages/valid/src/mcp/mod.rs
@@ -28,8 +28,9 @@ use crate::{
     kernel::{eval::eval_expr, replay::replay_actions, transition::apply_action},
     project::{rerun_recommendations, ProjectConfig},
     reporter::{
-        render_model_dot_with_view, render_model_mermaid_with_view, render_model_svg_with_view,
-        GraphView,
+        build_failure_graph_slice, render_model_dot_failure, render_model_dot_with_view,
+        render_model_mermaid_failure, render_model_mermaid_with_view, render_model_svg_failure,
+        render_model_svg_with_view, render_model_text_failure, GraphView,
     },
     testgen::render_replay_json,
 };
@@ -909,9 +910,10 @@ fn input_schema_with_graph() -> Value {
         "view".to_string(),
         json!({
             "type": "string",
-            "enum": ["overview", "logic"]
+            "enum": ["overview", "logic", "failure"]
         }),
     );
+    properties.insert("property_id".to_string(), json!({ "type": "string" }));
     json!({
         "type": "object",
         "properties": properties,
@@ -1199,6 +1201,7 @@ struct GraphArgs {
     target: TargetArgs,
     format: Option<String>,
     view: Option<String>,
+    property_id: Option<String>,
 }
 
 enum ResolvedTarget {
@@ -2619,41 +2622,7 @@ fn graph_tool(config: &ServerConfig, args: &GraphArgs) -> Result<ToolResult, Str
                 source,
             };
             match inspect_source(&request) {
-                Ok(response) => match format {
-                    "json" => Ok(ToolResult::success(parse_embedded_json(
-                        "inspect response",
-                        &render_inspect_json(&response),
-                    )?)),
-                    "text" => Ok(ToolResult::success_with_text(
-                        json!({
-                            "format": "text",
-                            "view": view_name(view),
-                            "graph": crate::api::render_inspect_text(&response)
-                        }),
-                        crate::api::render_inspect_text(&response),
-                    )),
-                    "dot" => {
-                        let graph = render_model_dot_with_view(&response, view);
-                        Ok(ToolResult::success_with_text(
-                            json!({ "format": "dot", "view": view_name(view), "graph": graph }),
-                            render_model_dot_with_view(&response, view),
-                        ))
-                    }
-                    "svg" => {
-                        let graph = render_model_svg_with_view(&response, view);
-                        Ok(ToolResult::success_with_text(
-                            json!({ "format": "svg", "view": view_name(view), "graph": graph }),
-                            render_model_svg_with_view(&response, view),
-                        ))
-                    }
-                    _ => {
-                        let graph = render_model_mermaid_with_view(&response, view);
-                        Ok(ToolResult::success_with_text(
-                            json!({ "format": "mermaid", "view": view_name(view), "graph": graph }),
-                            render_model_mermaid_with_view(&response, view),
-                        ))
-                    }
-                },
+                Ok(response) => graph_tool_result_for_dsl(&response, &request, args, format, view),
                 Err(diagnostics) => Ok(ToolResult::error(parse_embedded_json(
                     "diagnostics",
                     &render_diagnostics_json(&diagnostics),
@@ -2665,16 +2634,17 @@ fn graph_tool(config: &ServerConfig, args: &GraphArgs) -> Result<ToolResult, Str
             model_name,
         } => {
             if format == "json" {
+                let mut command_args = vec![
+                    "graph".to_string(),
+                    model_name.clone(),
+                    "--format=json".to_string(),
+                    format!("--view={}", view_name(view)),
+                ];
+                if let Some(property_id) = &args.property_id {
+                    command_args.push(format!("--property={property_id}"));
+                }
                 return Ok(registry_tool_result(
-                    run_registry_json(
-                        &registry_binary,
-                        &[
-                            "graph",
-                            &model_name,
-                            "--format=json",
-                            &format!("--view={}", view_name(view)),
-                        ],
-                    ),
+                    run_registry_json(&registry_binary, &command_args),
                     &[0],
                 ));
             }
@@ -2684,6 +2654,9 @@ fn graph_tool(config: &ServerConfig, args: &GraphArgs) -> Result<ToolResult, Str
                 .arg(&model_name)
                 .arg(format!("--format={format}"))
                 .arg(format!("--view={}", view_name(view)));
+            if let Some(property_id) = &args.property_id {
+                command.arg(format!("--property={property_id}"));
+            }
             let output = match command.output() {
                 Ok(output) => output,
                 Err(err) => {
@@ -2712,6 +2685,126 @@ fn graph_tool(config: &ServerConfig, args: &GraphArgs) -> Result<ToolResult, Str
             }
         }
     }
+}
+
+fn graph_tool_result_for_dsl(
+    response: &crate::api::InspectResponse,
+    request: &InspectRequest,
+    args: &GraphArgs,
+    format: &str,
+    view: GraphView,
+) -> Result<ToolResult, String> {
+    if view != GraphView::Failure {
+        return Ok(match format {
+            "json" => ToolResult::success(parse_embedded_json(
+                "inspect response",
+                &render_inspect_json(response),
+            )?),
+            "text" => ToolResult::success_with_text(
+                json!({
+                    "format": "text",
+                    "view": view_name(view),
+                    "graph": crate::api::render_inspect_text(response)
+                }),
+                crate::api::render_inspect_text(response),
+            ),
+            "dot" => {
+                let graph = render_model_dot_with_view(response, view);
+                ToolResult::success_with_text(
+                    json!({ "format": "dot", "view": view_name(view), "graph": graph }),
+                    render_model_dot_with_view(response, view),
+                )
+            }
+            "svg" => {
+                let graph = render_model_svg_with_view(response, view);
+                ToolResult::success_with_text(
+                    json!({ "format": "svg", "view": view_name(view), "graph": graph }),
+                    render_model_svg_with_view(response, view),
+                )
+            }
+            _ => {
+                let graph = render_model_mermaid_with_view(response, view);
+                ToolResult::success_with_text(
+                    json!({ "format": "mermaid", "view": view_name(view), "graph": graph }),
+                    render_model_mermaid_with_view(response, view),
+                )
+            }
+        });
+    }
+
+    let property_id = args
+        .property_id
+        .as_ref()
+        .ok_or_else(|| "failure graph view requires property_id".to_string())?;
+    let outcome = check_source(&CheckRequest {
+        request_id: "mcp-graph-failure".to_string(),
+        source_name: request.source_name.clone(),
+        source: request.source.clone(),
+        property_id: Some(property_id.clone()),
+        scenario_id: None,
+        seed: None,
+        backend: None,
+        solver_executable: None,
+        solver_args: Vec::new(),
+    });
+    let result = match outcome {
+        CheckOutcome::Completed(result) => result,
+        CheckOutcome::Errored(error) => {
+            return Ok(ToolResult::error(parse_embedded_json(
+                "diagnostics",
+                &render_diagnostics_json(&error.diagnostics),
+            )?))
+        }
+    };
+    let trace = result
+        .trace
+        .as_ref()
+        .ok_or_else(|| format!("property `{property_id}` did not produce evidence trace"))?;
+    let slice = build_failure_graph_slice(response, trace, property_id)?;
+
+    Ok(match format {
+        "json" => {
+            let mut body = parse_embedded_json("inspect response", &render_inspect_json(response))?;
+            body["graph_view"] = Value::String("failure".to_string());
+            body["graph_slice"] = json!({
+                "property_id": slice.property_id,
+                "failing_action_id": slice.failing_action_id,
+                "failing_step_index": slice.failing_step_index,
+                "focused_fields": slice.focused_fields,
+                "focused_reads": slice.focused_reads,
+                "focused_writes": slice.focused_writes,
+                "focused_path_tags": slice.focused_path_tags,
+                "focused_transition_indexes": slice.focused_transition_indexes,
+                "summary": slice.summary,
+            });
+            ToolResult::success(body)
+        }
+        "text" => ToolResult::success_with_text(
+            json!({"format":"text","view":"failure","graph": render_model_text_failure(response, &slice)}),
+            render_model_text_failure(response, &slice),
+        ),
+        "dot" => {
+            let graph = render_model_dot_failure(response, &slice);
+            ToolResult::success_with_text(
+                json!({"format":"dot","view":"failure","graph": graph}),
+                render_model_dot_failure(response, &slice),
+            )
+        }
+        "svg" => {
+            let graph = render_model_svg_failure(response, &slice);
+            ToolResult::success_with_text(
+                json!({"format":"svg","view":"failure","graph": graph}),
+                render_model_svg_failure(response, &slice),
+            )
+        }
+        _ => {
+            let graph = render_model_mermaid_failure(response, &slice);
+            ToolResult::success_with_text(
+                json!({"format":"mermaid","view":"failure","graph": graph}),
+                render_model_mermaid_failure(response, &slice),
+            )
+        }
+    })
 }
 
 fn lint_tool(config: &ServerConfig, args: &BasicArgs) -> Result<ToolResult, String> {
@@ -2875,5 +2968,6 @@ fn view_name(view: GraphView) -> &'static str {
     match view {
         GraphView::Overview => "overview",
         GraphView::Logic => "logic",
+        GraphView::Failure => "failure",
     }
 }

--- a/packages/valid/src/registry.rs
+++ b/packages/valid/src/registry.rs
@@ -5,6 +5,7 @@ use std::{
 };
 
 use clap::Parser;
+use serde_json::Value;
 
 use crate::{
     benchmark::{
@@ -37,8 +38,9 @@ use crate::{
     },
     project::{load_project_config, rerun_recommendations},
     reporter::{
-        render_model_dot_with_view, render_model_mermaid_with_view, render_model_svg_with_view,
-        GraphView,
+        build_failure_graph_slice, render_model_dot_failure, render_model_dot_with_view,
+        render_model_mermaid_failure, render_model_mermaid_with_view, render_model_svg_failure,
+        render_model_svg_with_view, render_model_text_failure, GraphView,
     },
     solver::AdapterConfig,
     support::{artifact::benchmark_baseline_path, hash::stable_hash_hex, io::write_text_file},
@@ -67,10 +69,10 @@ use crate::api::{
 };
 
 const REGISTRY_USAGE: &str =
-    "usage: <registry-bin> <models|inspect|graph|doc|readiness|migrate|benchmark|verify|explain|coverage|orchestrate|generate-tests|replay|contract|commands|schema|batch> [model] [--json] [--progress=json] [--format=<mermaid|dot|svg|text|json>] [--view=<overview|logic>] [--property=<id>] [--backend=<explicit|mock-bmc|sat-varisat|smt-cvc5|command>] [--solver-exec <path>] [--solver-arg <arg>] [--focus-action=<id>] [--actions=a,b,c] [--strategy=<counterexample|transition|witness|guard|boundary|path|random>] [--repeat=<n>] [--baseline[=compare|record|ignore]] [--threshold-percent=<n>] [--write[=<path>]] [--check]";
+    "usage: <registry-bin> <models|inspect|graph|doc|readiness|migrate|benchmark|verify|explain|coverage|orchestrate|generate-tests|replay|contract|commands|schema|batch> [model] [--json] [--progress=json] [--format=<mermaid|dot|svg|text|json>] [--view=<overview|logic|failure>] [--property=<id>] [--backend=<explicit|mock-bmc|sat-varisat|smt-cvc5|command>] [--solver-exec <path>] [--solver-arg <arg>] [--focus-action=<id>] [--actions=a,b,c] [--strategy=<counterexample|transition|witness|guard|boundary|path|random>] [--repeat=<n>] [--baseline[=compare|record|ignore]] [--threshold-percent=<n>] [--write[=<path>]] [--check]";
 const LIST_USAGE: &str = "usage: <registry-bin> list [--json]";
 const INSPECT_USAGE: &str = "usage: <registry-bin> inspect <model> [--json] [--progress=json]";
-const GRAPH_USAGE: &str = "usage: <registry-bin> graph <model> [--format=mermaid|dot|svg|text|json] [--view=<overview|logic>] [--json] [--progress=json]";
+const GRAPH_USAGE: &str = "usage: <registry-bin> graph <model> [--format=mermaid|dot|svg|text|json] [--view=<overview|logic|failure>] [--property=<id>] [--json] [--progress=json]";
 const DOC_USAGE: &str =
     "usage: <registry-bin> doc <model> [--json] [--progress=json] [--write[=<path>]] [--check]";
 const LINT_USAGE: &str = "usage: <registry-bin> lint <model> [--json] [--progress=json]";
@@ -237,14 +239,79 @@ fn cmd_graph(models: &[RegisteredModel], args: Vec<String>) {
     );
     let response = (model.inspect)("registry-graph");
     let view = GraphView::parse(parsed.view.as_deref());
-    match parsed.format.as_deref().unwrap_or("mermaid") {
-        "json" => println!("{}", render_inspect_json(&response)),
-        "text" => print!("{}", render_inspect_text(&response)),
-        "dot" => println!("{}", render_model_dot_with_view(&response, view)),
-        "svg" => println!("{}", render_model_svg_with_view(&response, view)),
-        _ => println!("{}", render_model_mermaid_with_view(&response, view)),
+    let render_format = parsed.format.as_deref().unwrap_or("mermaid");
+    match render_registry_graph_output(model, &response, &parsed, render_format, view) {
+        Ok(body) => print!("{body}"),
+        Err(message) => message_exit("graph", json_output, &message, Some(GRAPH_USAGE)),
     }
     progress.finish(ExitCode::Success);
+}
+
+fn render_registry_graph_output(
+    model: &RegisteredModel,
+    response: &InspectResponse,
+    parsed: &ParsedArgs,
+    render_format: &str,
+    view: GraphView,
+) -> Result<String, String> {
+    if view != GraphView::Failure {
+        return Ok(match render_format {
+            "json" => format!("{}\n", render_inspect_json(response)),
+            "text" => render_inspect_text(response),
+            "dot" => format!("{}\n", render_model_dot_with_view(response, view)),
+            "svg" => format!("{}\n", render_model_svg_with_view(response, view)),
+            _ => format!("{}\n", render_model_mermaid_with_view(response, view)),
+        });
+    }
+
+    let property_id = parsed
+        .property_id
+        .as_ref()
+        .ok_or_else(|| "failure graph view requires --property=<id>".to_string())?;
+    let outcome = (model.check)("registry-graph-failure", Some(property_id.as_str()), None)
+        .map_err(|message| format!("failed to evaluate property `{property_id}`: {message}"))?;
+    let result = match outcome {
+        CheckOutcome::Completed(result) => result,
+        CheckOutcome::Errored(error) => {
+            return Err(error
+                .diagnostics
+                .first()
+                .map(|diagnostic| diagnostic.message.clone())
+                .unwrap_or_else(|| "failure graph check failed".to_string()))
+        }
+    };
+    let trace = result
+        .trace
+        .as_ref()
+        .ok_or_else(|| format!("property `{property_id}` did not produce evidence trace"))?;
+    let slice = build_failure_graph_slice(response, trace, property_id)?;
+
+    Ok(match render_format {
+        "json" => {
+            let mut body: Value = serde_json::from_str(&render_inspect_json(response))
+                .map_err(|err| format!("failed to prepare graph json: {err}"))?;
+            body["graph_view"] = Value::String("failure".to_string());
+            body["graph_slice"] = serde_json::json!({
+                "property_id": slice.property_id,
+                "failing_action_id": slice.failing_action_id,
+                "failing_step_index": slice.failing_step_index,
+                "focused_fields": slice.focused_fields,
+                "focused_reads": slice.focused_reads,
+                "focused_writes": slice.focused_writes,
+                "focused_path_tags": slice.focused_path_tags,
+                "focused_transition_indexes": slice.focused_transition_indexes,
+                "summary": slice.summary,
+            });
+            format!(
+                "{}\n",
+                serde_json::to_string(&body).map_err(|err| err.to_string())?
+            )
+        }
+        "text" => render_model_text_failure(response, &slice),
+        "dot" => format!("{}\n", render_model_dot_failure(response, &slice)),
+        "svg" => format!("{}\n", render_model_svg_failure(response, &slice)),
+        _ => format!("{}\n", render_model_mermaid_failure(response, &slice)),
+    })
 }
 
 fn cmd_doc(models: &[RegisteredModel], args: Vec<String>) {

--- a/packages/valid/src/reporter/mod.rs
+++ b/packages/valid/src/reporter/mod.rs
@@ -6,15 +6,121 @@ use crate::{api::InspectResponse, evidence::EvidenceTrace};
 pub enum GraphView {
     Overview,
     Logic,
+    Failure,
 }
 
 impl GraphView {
     pub fn parse(input: Option<&str>) -> Self {
         match input {
             Some("logic") | Some("detailed") | Some("full") => Self::Logic,
+            Some("failure") | Some("focused") => Self::Failure,
             _ => Self::Overview,
         }
     }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FailureGraphSlice {
+    pub property_id: String,
+    pub failing_action_id: Option<String>,
+    pub failing_step_index: usize,
+    pub focused_fields: Vec<String>,
+    pub focused_reads: Vec<String>,
+    pub focused_writes: Vec<String>,
+    pub focused_path_tags: Vec<String>,
+    pub focused_transition_indexes: Vec<usize>,
+    pub summary: String,
+}
+
+pub fn build_failure_graph_slice(
+    response: &InspectResponse,
+    trace: &EvidenceTrace,
+    property_id: &str,
+) -> Result<FailureGraphSlice, String> {
+    let property = response
+        .property_details
+        .iter()
+        .find(|candidate| candidate.property_id == property_id)
+        .ok_or_else(|| format!("unknown property `{property_id}`"))?;
+    let failure_step = trace
+        .steps
+        .last()
+        .ok_or_else(|| "failure graph requires a non-empty evidence trace".to_string())?;
+    let failing_action_id = failure_step.action_id.clone();
+    let focused_transition_indexes = response
+        .transition_details
+        .iter()
+        .enumerate()
+        .filter_map(|(index, transition)| {
+            if Some(transition.action_id.as_str()) == failing_action_id.as_deref() {
+                Some(index)
+            } else {
+                None
+            }
+        })
+        .collect::<Vec<_>>();
+    let focused_transition = focused_transition_indexes
+        .first()
+        .and_then(|index| response.transition_details.get(*index));
+    let focused_reads = focused_transition
+        .map(|transition| transition.reads.clone())
+        .unwrap_or_default();
+    let focused_writes = focused_transition
+        .map(|transition| transition.writes.clone())
+        .unwrap_or_default();
+    let focused_path_tags = if let Some(path) = &failure_step.path {
+        path.legacy_path_tags()
+    } else {
+        focused_transition
+            .map(|transition| visible_path_tags(&transition.path_tags))
+            .unwrap_or_default()
+    };
+
+    let mut focused_fields = failure_step
+        .state_before
+        .iter()
+        .filter_map(|(field, before)| {
+            let after = failure_step.state_after.get(field)?;
+            if before != after {
+                Some(field.clone())
+            } else {
+                None
+            }
+        })
+        .collect::<Vec<_>>();
+
+    if focused_fields.is_empty() {
+        focused_fields.extend(property_field_refs(property, &response.state_field_details));
+    }
+    if focused_fields.is_empty() {
+        focused_fields.extend(focused_reads.iter().cloned());
+        focused_fields.extend(focused_writes.iter().cloned());
+    }
+    focused_fields.sort();
+    focused_fields.dedup();
+
+    let summary = match &failing_action_id {
+        Some(action_id) => format!(
+            "property {property_id} fails after action {action_id} at step {}",
+            failure_step.index
+        ),
+        None => format!(
+            "property {property_id} fails at terminal step {}",
+            failure_step.index
+        ),
+    };
+
+    Ok(FailureGraphSlice {
+        property_id: property_id.to_string(),
+        failing_action_id,
+        failing_step_index: failure_step.index,
+        focused_fields,
+        focused_reads,
+        focused_writes,
+        focused_path_tags,
+        focused_transition_indexes,
+        summary,
+    })
 }
 
 fn capability_mode_label(response: &InspectResponse) -> String {
@@ -81,6 +187,7 @@ pub fn render_model_mermaid_with_view(response: &InspectResponse, view: GraphVie
     match view {
         GraphView::Overview => render_model_mermaid_overview(response),
         GraphView::Logic => render_model_mermaid_logic(response),
+        GraphView::Failure => render_model_mermaid_overview(response),
     }
 }
 
@@ -183,6 +290,7 @@ pub fn render_model_dot_with_view(response: &InspectResponse, view: GraphView) -
     match view {
         GraphView::Overview => render_model_dot_overview(response),
         GraphView::Logic => render_model_dot_logic(response),
+        GraphView::Failure => render_model_dot_overview(response),
     }
 }
 
@@ -289,7 +397,250 @@ pub fn render_model_svg_with_view(response: &InspectResponse, view: GraphView) -
     match view {
         GraphView::Overview => render_model_svg_overview(response),
         GraphView::Logic => render_model_svg_logic(response),
+        GraphView::Failure => render_model_svg_overview(response),
     }
+}
+
+pub fn render_model_mermaid_failure(
+    response: &InspectResponse,
+    slice: &FailureGraphSlice,
+) -> String {
+    let mut out = String::from("flowchart LR\n");
+    let model_node = sanitize_id(&format!("model_{}", response.model_id));
+    let property_node = sanitize_id(&format!("property_{}", slice.property_id));
+    out.push_str(&format!(
+        "  {model_node}[\"{}\"]\n",
+        mermaid_label(&[
+            format!("model: {}", response.model_id),
+            slice.summary.clone(),
+        ])
+    ));
+    out.push_str("  subgraph failure_slice[\"Failure Slice\"]\n");
+    if let Some(property) = response
+        .property_details
+        .iter()
+        .find(|candidate| candidate.property_id == slice.property_id)
+    {
+        out.push_str(&format!(
+            "    {property_node}[\"{}\"]\n",
+            mermaid_label(&property_overview_lines(property))
+        ));
+        out.push_str(&format!("  {model_node} --> {property_node}\n"));
+    }
+    if let Some(action_id) = &slice.failing_action_id {
+        let action_node = sanitize_id(&format!("action_{action_id}"));
+        let mut lines = vec![format!("action: {action_id}")];
+        if !slice.focused_reads.is_empty() {
+            lines.push(format!("reads: {}", slice.focused_reads.join(", ")));
+        }
+        if !slice.focused_writes.is_empty() {
+            lines.push(format!("writes: {}", slice.focused_writes.join(", ")));
+        }
+        if !slice.focused_path_tags.is_empty() {
+            lines.push(format!("tags: {}", slice.focused_path_tags.join(", ")));
+        }
+        out.push_str(&format!(
+            "    {action_node}[\"{}\"]\n",
+            mermaid_label(&lines)
+        ));
+        out.push_str(&format!("  {model_node} --> {action_node}\n"));
+        out.push_str(&format!("  {property_node} --> {action_node}\n"));
+        for field in &slice.focused_fields {
+            let field_node = sanitize_id(&format!("field_{field}"));
+            out.push_str(&format!("  {action_node} --> {field_node}\n"));
+        }
+    }
+    for field in response
+        .state_field_details
+        .iter()
+        .filter(|field| slice.focused_fields.contains(&field.name))
+    {
+        let field_node = sanitize_id(&format!("field_{}", field.name));
+        out.push_str(&format!(
+            "    {field_node}[\"{}\"]\n",
+            mermaid_label(&field_label_lines(field))
+        ));
+        out.push_str(&format!("  {property_node} -. depends .-> {field_node}\n"));
+    }
+    if response.machine_ir_ready {
+        for index in &slice.focused_transition_indexes {
+            if let Some(transition) = response.transition_details.get(*index) {
+                let transition_node =
+                    sanitize_id(&format!("transition_{}_{}", transition.action_id, index));
+                let action_node = sanitize_id(&format!("action_{}", transition.action_id));
+                out.push_str(&format!(
+                    "    {transition_node}[\"{}\"]\n",
+                    mermaid_label(&transition_label_lines(transition))
+                ));
+                out.push_str(&format!("  {action_node} --> {transition_node}\n"));
+            }
+        }
+    }
+    out.push_str("  end\n");
+    out
+}
+
+pub fn render_model_dot_failure(response: &InspectResponse, slice: &FailureGraphSlice) -> String {
+    let mut out = String::from(
+        "digraph model {\n  rankdir=LR;\n  node [shape=box, fontname=\"Helvetica\"];\n",
+    );
+    let model_node = sanitize_id(&format!("model_{}", response.model_id));
+    let property_node = sanitize_id(&format!("property_{}", slice.property_id));
+    out.push_str(&format!(
+        "  {model_node} [label=\"{}\"];\n",
+        dot_label(&[
+            format!("model: {}", response.model_id),
+            slice.summary.clone(),
+        ])
+    ));
+    out.push_str("  subgraph cluster_failure_slice {\n    label=\"Failure Slice\";\n");
+    if let Some(property) = response
+        .property_details
+        .iter()
+        .find(|candidate| candidate.property_id == slice.property_id)
+    {
+        out.push_str(&format!(
+            "    {property_node} [label=\"{}\"];\n",
+            dot_label(&property_overview_lines(property))
+        ));
+        out.push_str(&format!("  {model_node} -> {property_node};\n"));
+    }
+    if let Some(action_id) = &slice.failing_action_id {
+        let action_node = sanitize_id(&format!("action_{action_id}"));
+        let mut lines = vec![format!("action: {action_id}")];
+        if !slice.focused_reads.is_empty() {
+            lines.push(format!("reads: {}", slice.focused_reads.join(", ")));
+        }
+        if !slice.focused_writes.is_empty() {
+            lines.push(format!("writes: {}", slice.focused_writes.join(", ")));
+        }
+        if !slice.focused_path_tags.is_empty() {
+            lines.push(format!("tags: {}", slice.focused_path_tags.join(", ")));
+        }
+        out.push_str(&format!(
+            "    {action_node} [label=\"{}\"];\n",
+            dot_label(&lines)
+        ));
+        out.push_str(&format!("  {model_node} -> {action_node};\n"));
+        out.push_str(&format!("  {property_node} -> {action_node};\n"));
+    }
+    for field in response
+        .state_field_details
+        .iter()
+        .filter(|field| slice.focused_fields.contains(&field.name))
+    {
+        let field_node = sanitize_id(&format!("field_{}", field.name));
+        out.push_str(&format!(
+            "    {field_node} [label=\"{}\"];\n",
+            dot_label(&field_label_lines(field))
+        ));
+        out.push_str(&format!(
+            "  {property_node} -> {field_node} [style=dashed, label=\"depends\"];\n"
+        ));
+    }
+    if response.machine_ir_ready {
+        for index in &slice.focused_transition_indexes {
+            if let Some(transition) = response.transition_details.get(*index) {
+                let transition_node =
+                    sanitize_id(&format!("transition_{}_{}", transition.action_id, index));
+                let action_node = sanitize_id(&format!("action_{}", transition.action_id));
+                out.push_str(&format!(
+                    "    {transition_node} [label=\"{}\"];\n",
+                    dot_label(&transition_label_lines(transition))
+                ));
+                out.push_str(&format!("  {action_node} -> {transition_node};\n"));
+            }
+        }
+    }
+    out.push_str("  }\n}\n");
+    out
+}
+
+pub fn render_model_svg_failure(response: &InspectResponse, slice: &FailureGraphSlice) -> String {
+    let mut sections = Vec::new();
+    sections.push(("Failure Slice".to_string(), vec![slice.summary.clone()]));
+    sections.push((
+        "Focused Fields".to_string(),
+        if slice.focused_fields.is_empty() {
+            vec!["none".to_string()]
+        } else {
+            slice.focused_fields.clone()
+        },
+    ));
+    sections.push((
+        "Focused Action".to_string(),
+        slice
+            .failing_action_id
+            .as_ref()
+            .map(|action_id| {
+                let mut lines = vec![action_id.clone()];
+                if !slice.focused_reads.is_empty() {
+                    lines.push(format!("reads: {}", slice.focused_reads.join(", ")));
+                }
+                if !slice.focused_writes.is_empty() {
+                    lines.push(format!("writes: {}", slice.focused_writes.join(", ")));
+                }
+                lines
+            })
+            .unwrap_or_else(|| vec!["terminal violation".to_string()]),
+    ));
+    sections.push((
+        "Focused Property".to_string(),
+        vec![slice.property_id.clone()],
+    ));
+    if !slice.focused_path_tags.is_empty() {
+        sections.push(("Trace Tags".to_string(), slice.focused_path_tags.clone()));
+    }
+
+    let width = 1200;
+    let section_width = 1160;
+    let mut y = 90i32;
+    let mut body = String::new();
+    for (title, lines) in sections {
+        let line_count = usize::max(lines.len(), 1);
+        let height = 44 + (line_count as i32 * 22) + 12;
+        body.push_str(&svg_section(20, y, section_width, height, &title, &lines));
+        y += height + 18;
+    }
+    let total_height = y + 20;
+    format!(
+        "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"{width}\" height=\"{total_height}\" viewBox=\"0 0 {width} {total_height}\" role=\"img\" aria-label=\"Failure-focused graph for {title}\"><style>text{{font-family:Helvetica,Arial,sans-serif;fill:#1f2937}} .title{{font-size:28px;font-weight:700}} .section-title{{font-size:18px;font-weight:700}} .line{{font-size:14px}} .section{{fill:#f8fafc;stroke:#cbd5e1;stroke-width:1.5}} .accent{{fill:#fee2e2;stroke:#fca5a5;stroke-width:1.5}}</style><rect width=\"100%\" height=\"100%\" fill=\"#ffffff\"/><rect x=\"20\" y=\"20\" width=\"1160\" height=\"48\" rx=\"10\" class=\"accent\"/><text x=\"40\" y=\"50\" class=\"title\">{title}</text>{body}</svg>",
+        title = escape_xml(&format!("failure slice: {}", response.model_id)),
+        body = body,
+    )
+}
+
+pub fn render_model_text_failure(response: &InspectResponse, slice: &FailureGraphSlice) -> String {
+    let mut out = String::new();
+    out.push_str(&format!("model: {}\n", response.model_id));
+    out.push_str("graph_view: failure\n");
+    out.push_str(&format!("summary: {}\n", slice.summary));
+    out.push_str(&format!("property_id: {}\n", slice.property_id));
+    if let Some(action_id) = &slice.failing_action_id {
+        out.push_str(&format!("failing_action_id: {}\n", action_id));
+    }
+    out.push_str(&format!(
+        "focused_fields: {}\n",
+        if slice.focused_fields.is_empty() {
+            "none".to_string()
+        } else {
+            slice.focused_fields.join(", ")
+        }
+    ));
+    if !slice.focused_reads.is_empty() || !slice.focused_writes.is_empty() {
+        out.push_str(&format!(
+            "action_io: reads=[{}] writes=[{}]\n",
+            slice.focused_reads.join(", "),
+            slice.focused_writes.join(", ")
+        ));
+    }
+    if !slice.focused_path_tags.is_empty() {
+        out.push_str(&format!(
+            "path_tags: {}\n",
+            slice.focused_path_tags.join(", ")
+        ));
+    }
+    out
 }
 
 fn render_model_svg_logic(response: &InspectResponse) -> String {
@@ -849,9 +1200,10 @@ mod tests {
     };
 
     use super::{
-        render_model_dot, render_model_dot_with_view, render_model_mermaid,
-        render_model_mermaid_with_view, render_model_svg, render_trace_mermaid,
-        render_trace_sequence_mermaid, GraphView,
+        build_failure_graph_slice, render_model_dot, render_model_dot_failure,
+        render_model_dot_with_view, render_model_mermaid, render_model_mermaid_failure,
+        render_model_mermaid_with_view, render_model_svg, render_model_svg_failure,
+        render_trace_mermaid, render_trace_sequence_mermaid, GraphView,
     };
 
     #[test]
@@ -1143,5 +1495,93 @@ mod tests {
         let logic = render_model_mermaid_with_view(&inspect, GraphView::Logic);
         assert!(logic.contains("transition internals hidden"));
         assert!(!logic.contains("transition_INC_0"));
+    }
+
+    #[test]
+    fn renders_failure_slice_views() {
+        let inspect = InspectResponse {
+            schema_version: "1.0.0".to_string(),
+            request_id: "req-1".to_string(),
+            status: "ok".to_string(),
+            model_id: "CounterModel".to_string(),
+            machine_ir_ready: true,
+            machine_ir_error: None,
+            capabilities: InspectCapabilities::fully_ready(),
+            state_fields: vec!["x".to_string()],
+            actions: vec!["INC".to_string()],
+            predicates: vec![],
+            scenarios: vec![],
+            properties: vec!["P_RANGE".to_string()],
+            state_field_details: vec![InspectStateField {
+                name: "x".to_string(),
+                rust_type: "u8".to_string(),
+                range: Some("0..=3".to_string()),
+                variants: Vec::new(),
+                is_set: false,
+            }],
+            action_details: vec![InspectAction {
+                action_id: "INC".to_string(),
+                role: "business".to_string(),
+                reads: vec!["x".to_string()],
+                writes: vec!["x".to_string()],
+            }],
+            predicate_details: vec![],
+            scenario_details: vec![],
+            transition_details: vec![InspectTransition {
+                action_id: "INC".to_string(),
+                role: "business".to_string(),
+                guard: Some("x < 3".to_string()),
+                effect: Some("x := x + 1".to_string()),
+                reads: vec!["x".to_string()],
+                writes: vec!["x".to_string()],
+                path_tags: vec!["counterexample".to_string()],
+                updates: vec![InspectTransitionUpdate {
+                    field: "x".to_string(),
+                    expr: "x + 1".to_string(),
+                }],
+            }],
+            property_details: vec![InspectProperty {
+                property_id: "P_RANGE".to_string(),
+                kind: "invariant".to_string(),
+                expr: Some("state.x <= 1".to_string()),
+                scope_expr: None,
+                action_filter: None,
+            }],
+        };
+        let trace = EvidenceTrace {
+            schema_version: "1.0.0".to_string(),
+            evidence_id: "ev-1".to_string(),
+            run_id: "run-1".to_string(),
+            property_id: "P_RANGE".to_string(),
+            evidence_kind: EvidenceKind::Counterexample,
+            assurance_level: AssuranceLevel::Complete,
+            trace_hash: "sha256:x".to_string(),
+            steps: vec![TraceStep {
+                index: 0,
+                from_state_id: "s-0".to_string(),
+                action_id: Some("INC".to_string()),
+                action_label: Some("INC".to_string()),
+                to_state_id: "s-1".to_string(),
+                depth: 1,
+                state_before: BTreeMap::from([("x".to_string(), Value::UInt(1))]),
+                state_after: BTreeMap::from([("x".to_string(), Value::UInt(2))]),
+                path: None,
+                note: None,
+            }],
+        };
+        let slice = build_failure_graph_slice(&inspect, &trace, "P_RANGE").expect("slice");
+        assert_eq!(slice.failing_action_id.as_deref(), Some("INC"));
+        assert_eq!(slice.focused_fields, vec!["x".to_string()]);
+
+        let mermaid = render_model_mermaid_failure(&inspect, &slice);
+        assert!(mermaid.contains("Failure Slice"));
+        assert!(mermaid.contains("property P_RANGE fails after action INC"));
+
+        let dot = render_model_dot_failure(&inspect, &slice);
+        assert!(dot.contains("cluster_failure_slice"));
+        assert!(dot.contains("P_RANGE"));
+
+        let svg = render_model_svg_failure(&inspect, &slice);
+        assert!(svg.contains("failure slice: CounterModel"));
     }
 }

--- a/tests/e2e_cargo_valid.rs
+++ b/tests/e2e_cargo_valid.rs
@@ -488,6 +488,40 @@ fn cargo_valid_graph_marks_step_models_as_explicit_only() {
 }
 
 #[test]
+fn cargo_valid_graph_supports_failure_view() {
+    let _guard = cargo_guard();
+    let output = Command::new(cargo_valid_path())
+        .arg("--registry")
+        .arg(example_registry_file())
+        .arg("graph")
+        .arg("failing-counter")
+        .arg("--view=failure")
+        .arg("--property=P_FAIL")
+        .output()
+        .expect("cargo-valid failure graph should run");
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("Failure Slice"));
+    assert!(stdout.contains("P_FAIL"));
+
+    let json_output = Command::new(cargo_valid_path())
+        .arg("--registry")
+        .arg(example_registry_file())
+        .arg("graph")
+        .arg("failing-counter")
+        .arg("--view=failure")
+        .arg("--property=P_FAIL")
+        .arg("--format=json")
+        .output()
+        .expect("cargo-valid failure graph json should run");
+    assert!(json_output.status.success());
+    let json_stdout = String::from_utf8_lossy(&json_output.stdout);
+    assert!(json_stdout.contains("\"graph_view\":\"failure\""));
+    assert!(json_stdout.contains("\"graph_slice\""));
+    assert!(json_stdout.contains("\"property_id\":\"P_FAIL\""));
+}
+
+#[test]
 fn cargo_valid_checks_registered_model() {
     let _guard = cargo_guard();
     let output = Command::new(cargo_valid_path())

--- a/tests/e2e_cli.rs
+++ b/tests/e2e_cli.rs
@@ -227,6 +227,37 @@ fn cli_graph_supports_dot_and_svg_formats() {
 }
 
 #[test]
+fn cli_graph_supports_failure_view() {
+    let failing = repo_path("tests/fixtures/models/failing_counter.valid");
+    let output = Command::new(binary_path())
+        .arg("graph")
+        .arg(&failing)
+        .arg("--view=failure")
+        .arg("--property=P_FAIL")
+        .output()
+        .expect("graph failure view should run");
+    assert_eq!(output.status.code(), Some(0));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("Failure Slice"));
+    assert!(stdout.contains("P_FAIL"));
+    assert!(stdout.contains("property P_FAIL fails"));
+
+    let json_output = Command::new(binary_path())
+        .arg("graph")
+        .arg(&failing)
+        .arg("--view=failure")
+        .arg("--property=P_FAIL")
+        .arg("--format=json")
+        .output()
+        .expect("graph failure json should run");
+    assert_eq!(json_output.status.code(), Some(0));
+    let json_stdout = String::from_utf8_lossy(&json_output.stdout);
+    assert!(json_stdout.contains("\"graph_view\":\"failure\""));
+    assert!(json_stdout.contains("\"graph_slice\""));
+    assert!(json_stdout.contains("\"property_id\":\"P_FAIL\""));
+}
+
+#[test]
 fn lint_reports_clean_valid_models() {
     let source = read_fixture("tests/fixtures/models/safe_counter.valid");
     let response = lint_source(&InspectRequest {

--- a/tests/e2e_mcp.rs
+++ b/tests/e2e_mcp.rs
@@ -360,6 +360,22 @@ fn valid_mcp_lists_tools_and_executes_dsl_mode() {
         .expect("graph should be text")
         .contains("flowchart"));
 
+    let failure_graph = structured_content(client.call_tool(
+        "valid_graph",
+        json!({
+            "model_file": model_file_str,
+            "format": "json",
+            "view": "failure",
+            "property_id": "P_FAIL"
+        }),
+    ));
+    assert_eq!(failure_graph["graph_view"], "failure");
+    assert_eq!(failure_graph["graph_slice"]["property_id"], "P_FAIL");
+    assert!(failure_graph["graph_slice"]["summary"]
+        .as_str()
+        .expect("summary should exist")
+        .contains("P_FAIL"));
+
     let lint =
         structured_content(client.call_tool("valid_lint", json!({ "model_file": model_file_str })));
     assert_eq!(lint["status"], "ok");


### PR DESCRIPTION
## Summary
- add a failure-focused graph view that slices around a failing property and trace
- thread failure graph rendering through valid, cargo valid, registry, and MCP graph surfaces
- add targeted reporter, CLI, cargo-valid, and MCP regression coverage

## Testing
- cargo fmt
- cargo test -q -p valid reporter::tests::renders_failure_slice_views
- cargo test -q --test e2e_cli cli_graph_supports_failure_view -- --exact
- cargo test -q --test e2e_cargo_valid cargo_valid_graph_supports_failure_view -- --exact
- cargo test -q --test e2e_mcp

## Issue
- Closes #74