### PR TITLE
Group test vectors by requirement and risk

### DIFF
--- a/docs/rdd/09_reference/json_schemas.md
+++ b/docs/rdd/09_reference/json_schemas.md
@@ -42,6 +42,14 @@
 - 定義箇所: `08_specs/testgen_contract_coverage_specs.md`
 - 本体: [schemas/test_vector.schema.json](schemas/test_vector.schema.json)
 
+主要フィールド:
+
+- `expected_path_tags`
+- `setup_action_ids`
+- `business_action_ids`
+- `grouping.requirement_clusters`
+- `grouping.risk_clusters`
+
 ## 3.1 DiagnosticBundle
 
 - ID: `schema.diagnostic_bundle`
@@ -121,6 +129,14 @@
 - ID: `schema.ai.testgen`
 - 定義箇所: `08_specs/ai_solver_selfcheck_specs.md`
 - 本体: [schemas/ai_testgen_request.schema.json](schemas/ai_testgen_request.schema.json), [schemas/ai_testgen_response.schema.json](schemas/ai_testgen_response.schema.json)
+
+主要フィールド:
+
+- `vector_ids`
+- `vectors[].requirement_clusters`
+- `vectors[].risk_clusters`
+- `vector_groups[].group_kind`
+- `vector_groups[].group_id`
 
 ## 12.1 AI Orchestrate Request/Response
 

--- a/docs/rdd/09_reference/schemas/ai_testgen_response.schema.json
+++ b/docs/rdd/09_reference/schemas/ai_testgen_response.schema.json
@@ -11,6 +11,44 @@
       "type": "array",
       "items": { "type": "string" }
     },
+    "vectors": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "vector_id",
+          "run_id",
+          "strictness",
+          "derivation",
+          "source_kind",
+          "strategy",
+          "requirement_clusters",
+          "risk_clusters"
+        ],
+        "properties": {
+          "vector_id": { "type": "string" },
+          "run_id": { "type": "string" },
+          "strictness": { "type": "string" },
+          "derivation": { "type": "string" },
+          "source_kind": { "type": "string" },
+          "strategy": { "type": "string" },
+          "requirement_clusters": { "type": "array", "items": { "type": "string" } },
+          "risk_clusters": { "type": "array", "items": { "type": "string" } }
+        }
+      }
+    },
+    "vector_groups": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["group_kind", "group_id", "vector_ids"],
+        "properties": {
+          "group_kind": { "type": "string" },
+          "group_id": { "type": "string" },
+          "vector_ids": { "type": "array", "items": { "type": "string" } }
+        }
+      }
+    },
     "generated_files": {
       "type": "array",
       "items": { "type": "string" }

--- a/docs/rdd/09_reference/schemas/test_vector.schema.json
+++ b/docs/rdd/09_reference/schemas/test_vector.schema.json
@@ -18,7 +18,8 @@
     "expected_path_tags",
     "setup_action_ids",
     "business_action_ids",
-    "notes"
+    "notes",
+    "grouping"
   ],
   "properties": {
     "schema_version": { "type": "string" },
@@ -46,6 +47,14 @@
     "setup_action_ids": { "type": "array", "items": { "type": "string" } },
     "business_action_ids": { "type": "array", "items": { "type": "string" } },
     "notes": { "type": "array", "items": { "type": "string" } },
+    "grouping": {
+      "type": "object",
+      "required": ["requirement_clusters", "risk_clusters"],
+      "properties": {
+        "requirement_clusters": { "type": "array", "items": { "type": "string" } },
+        "risk_clusters": { "type": "array", "items": { "type": "string" } }
+      }
+    },
     "replay_target": { "type": ["object", "null"] }
   }
 }

--- a/packages/valid/src/api/mod.rs
+++ b/packages/valid/src/api/mod.rs
@@ -39,6 +39,59 @@ use crate::{
     },
 };
 
+pub fn summarize_testgen_groups(
+    vectors: &[crate::testgen::TestVector],
+) -> Vec<TestgenGroupSummary> {
+    let mut groups = BTreeMap::<(String, String), Vec<String>>::new();
+    for vector in vectors {
+        for cluster in &vector.grouping.requirement_clusters {
+            groups
+                .entry(("requirement".to_string(), cluster.clone()))
+                .or_default()
+                .push(vector.vector_id.clone());
+        }
+        for cluster in &vector.grouping.risk_clusters {
+            groups
+                .entry(("risk".to_string(), cluster.clone()))
+                .or_default()
+                .push(vector.vector_id.clone());
+        }
+    }
+    groups
+        .into_iter()
+        .map(|((group_kind, group_id), mut vector_ids)| {
+            vector_ids.sort();
+            vector_ids.dedup();
+            TestgenGroupSummary {
+                group_kind,
+                group_id,
+                vector_ids,
+            }
+        })
+        .collect()
+}
+
+fn backfill_testgen_grouping(property_id: &str, vectors: &mut [crate::testgen::TestVector]) {
+    let fallback_cluster = format!("property:{property_id}");
+    for vector in vectors {
+        if vector.grouping.requirement_clusters.is_empty() {
+            vector
+                .grouping
+                .requirement_clusters
+                .push(fallback_cluster.clone());
+        }
+        if vector.grouping.risk_clusters.is_empty()
+            && vector
+                .grouping
+                .requirement_clusters
+                .iter()
+                .any(|cluster| cluster == "risk_path")
+        {
+            vector.grouping.risk_clusters.push("risk_path".to_string());
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct InspectResponse {
     pub schema_version: String,
@@ -464,6 +517,7 @@ pub struct TestgenResponse {
     pub status: String,
     pub vector_ids: Vec<String>,
     pub vectors: Vec<TestgenVectorSummary>,
+    pub vector_groups: Vec<TestgenGroupSummary>,
     pub generated_files: Vec<String>,
 }
 
@@ -475,6 +529,15 @@ pub struct TestgenVectorSummary {
     pub derivation: String,
     pub source_kind: String,
     pub strategy: String,
+    pub requirement_clusters: Vec<String>,
+    pub risk_clusters: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TestgenGroupSummary {
+    pub group_kind: String,
+    pub group_id: String,
+    pub vector_ids: Vec<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
@@ -1582,7 +1645,7 @@ pub fn review_source(request: &CheckRequest) -> Result<ReviewResponse, CheckErro
             request.request_id.clone(),
             format!(
                 "run-{}",
-            stable_hash_hex(&request.request_id).replace("sha256:", "")
+                stable_hash_hex(&request.request_id).replace("sha256:", "")
             ),
             stable_hash_hex(&verification_source),
             "sha256:unknown".to_string(),
@@ -1626,7 +1689,11 @@ pub fn review_source(request: &CheckRequest) -> Result<ReviewResponse, CheckErro
             };
             return Err(error);
         };
-        let trace_steps = result.trace.as_ref().map(|trace| trace.steps.len()).unwrap_or(0);
+        let trace_steps = result
+            .trace
+            .as_ref()
+            .map(|trace| trace.steps.len())
+            .unwrap_or(0);
         let mut action_sequence = Vec::new();
         let mut ambiguity_flags = Vec::new();
         let mut candidate_causes = Vec::new();
@@ -1670,11 +1737,13 @@ pub fn review_source(request: &CheckRequest) -> Result<ReviewResponse, CheckErro
                 message: result
                     .property_result
                     .unknown_reason
-                    .map(|reason| format!(
-                        "property {} remained UNKNOWN because {}",
-                        result.property_result.property_id,
-                        review_unknown_reason_label(reason)
-                    ))
+                    .map(|reason| {
+                        format!(
+                            "property {} remained UNKNOWN because {}",
+                            result.property_result.property_id,
+                            review_unknown_reason_label(reason)
+                        )
+                    })
                     .unwrap_or_else(|| {
                         format!(
                             "property {} remained UNKNOWN and needs reviewer follow-up",
@@ -1696,14 +1765,20 @@ pub fn review_source(request: &CheckRequest) -> Result<ReviewResponse, CheckErro
             next_steps = explain.next_steps.clone();
             confidence = Some(explain.confidence);
             if explain.review_context.vacuous {
-                push_unique(&mut ambiguity_flags, "scope_or_scenario_mismatch".to_string());
+                push_unique(
+                    &mut ambiguity_flags,
+                    "scope_or_scenario_mismatch".to_string(),
+                );
             }
             if explain
                 .repair_targets
                 .iter()
                 .any(|target| target.target == "requirement_fix")
             {
-                push_unique(&mut ambiguity_flags, "requirement_interpretation".to_string());
+                push_unique(
+                    &mut ambiguity_flags,
+                    "requirement_interpretation".to_string(),
+                );
                 ambiguities.push(ReviewAmbiguity {
                     kind: "requirement_interpretation".to_string(),
                     severity: "info".to_string(),
@@ -1717,7 +1792,10 @@ pub fn review_source(request: &CheckRequest) -> Result<ReviewResponse, CheckErro
                 });
             }
         } else {
-            next_steps.push("review the model intent and property wording before expanding the model".to_string());
+            next_steps.push(
+                "review the model intent and property wording before expanding the model"
+                    .to_string(),
+            );
             if result.property_result.vacuous {
                 next_steps.push(
                     "confirm the scenario or property scope matches the intended requirement slice"
@@ -1768,9 +1846,7 @@ pub fn review_source(request: &CheckRequest) -> Result<ReviewResponse, CheckErro
             reason: if trace_count == 0 {
                 "no trace evidence executed this action in the reviewed run set".to_string()
             } else {
-                format!(
-                    "action did not appear in any of the {trace_count} collected trace(s)"
-                )
+                format!("action did not appear in any of the {trace_count} collected trace(s)")
             },
             observed_trace_count: trace_count,
         })
@@ -1798,25 +1874,40 @@ pub fn review_source(request: &CheckRequest) -> Result<ReviewResponse, CheckErro
         format!(
             "review flagged {} failing propert{} for {}",
             failing_properties.len(),
-            if failing_properties.len() == 1 { "y" } else { "ies" },
+            if failing_properties.len() == 1 {
+                "y"
+            } else {
+                "ies"
+            },
             inspect.model_id
         )
     } else if !unknown_properties.is_empty() {
         format!(
             "review found {} unknown propert{} for {}",
             unknown_properties.len(),
-            if unknown_properties.len() == 1 { "y" } else { "ies" },
+            if unknown_properties.len() == 1 {
+                "y"
+            } else {
+                "ies"
+            },
             inspect.model_id
         )
     } else if !vacuous_properties.is_empty() {
         format!(
             "review found {} vacuous propert{} for {}",
             vacuous_properties.len(),
-            if vacuous_properties.len() == 1 { "y" } else { "ies" },
+            if vacuous_properties.len() == 1 {
+                "y"
+            } else {
+                "ies"
+            },
             inspect.model_id
         )
     } else {
-        format!("review found no blocking validity gaps for {}", inspect.model_id)
+        format!(
+            "review found no blocking validity gaps for {}",
+            inspect.model_id
+        )
     };
 
     Ok(ReviewResponse {
@@ -2199,6 +2290,7 @@ pub fn testgen_source(request: &TestgenRequest) -> Result<TestgenResponse, Check
         }
         vectors
     };
+    backfill_testgen_grouping(target_property_id, &mut vectors);
     annotate_model_replay_targets(&request.source_name, target_property_id, &mut vectors);
     let generated_files =
         write_generated_test_files(&vectors).map_err(|message| CheckErrorEnvelope {
@@ -2228,8 +2320,11 @@ pub fn testgen_source(request: &TestgenRequest) -> Result<TestgenResponse, Check
                 derivation: vector.derivation.clone(),
                 source_kind: vector.source_kind.clone(),
                 strategy: vector.strategy.clone(),
+                requirement_clusters: vector.grouping.requirement_clusters.clone(),
+                risk_clusters: vector.grouping.risk_clusters.clone(),
             })
             .collect(),
+        vector_groups: summarize_testgen_groups(&vectors),
         generated_files,
     })
 }
@@ -5022,10 +5117,7 @@ pub fn validate_review_response(response: &ReviewResponse) -> Result<(), String>
     }
     for dead_action in &response.dead_actions {
         require_non_empty(&dead_action.action_id, "dead_actions[].action_id")?;
-        require_non_empty(
-            &dead_action.evidence_basis,
-            "dead_actions[].evidence_basis",
-        )?;
+        require_non_empty(&dead_action.evidence_basis, "dead_actions[].evidence_basis")?;
         require_non_empty(&dead_action.reason, "dead_actions[].reason")?;
     }
     for disagreement in &response.candidate_disagreements {
@@ -5033,10 +5125,7 @@ pub fn validate_review_response(response: &ReviewResponse) -> Result<(), String>
             &disagreement.property_id,
             "candidate_disagreements[].property_id",
         )?;
-        require_non_empty(
-            &disagreement.reason,
-            "candidate_disagreements[].reason",
-        )?;
+        require_non_empty(&disagreement.reason, "candidate_disagreements[].reason")?;
         if disagreement.targets.len() < 2 {
             return Err(
                 "candidate_disagreements[].targets must contain at least two entries".to_string(),
@@ -5074,7 +5163,6 @@ fn render_review_summary_json(summary: &ReviewSummary) -> String {
 pub fn validate_review_request(request: &CheckRequest) -> Result<(), String> {
     validate_check_request(request)
 }
-
 
 fn render_path_json(path: &Path) -> String {
     let mut out = String::from("{\"decisions\":[");
@@ -5168,6 +5256,23 @@ pub fn validate_testgen_response(response: &TestgenResponse) -> Result<(), Strin
         "vector_ids",
         "generated_files",
     )?;
+    for vector in &response.vectors {
+        require_non_empty(&vector.vector_id, "vectors[].vector_id")?;
+        require_non_empty(&vector.run_id, "vectors[].run_id")?;
+        for cluster in &vector.requirement_clusters {
+            require_non_empty(cluster, "vectors[].requirement_clusters[]")?;
+        }
+        for cluster in &vector.risk_clusters {
+            require_non_empty(cluster, "vectors[].risk_clusters[]")?;
+        }
+    }
+    for group in &response.vector_groups {
+        require_non_empty(&group.group_kind, "vector_groups[].group_kind")?;
+        require_non_empty(&group.group_id, "vector_groups[].group_id")?;
+        if group.vector_ids.is_empty() {
+            return Err("vector_groups[].vector_ids must not be empty".to_string());
+        }
+    }
     Ok(())
 }
 
@@ -6157,6 +6262,10 @@ property P_RECOVERY_VISIBLE:
         })
         .unwrap();
         assert!(response.vector_ids.len() >= 1);
+        assert!(response
+            .vectors
+            .iter()
+            .all(|vector| !vector.requirement_clusters.is_empty()));
         validate_testgen_response(&response).unwrap();
         cleanup_generated_files(&response.generated_files);
     }
@@ -6178,6 +6287,7 @@ property P_RECOVERY_VISIBLE:
         .unwrap();
         assert_eq!(response.vector_ids.len(), 1);
         assert_eq!(response.vectors[0].source_kind, "witness");
+        assert!(!response.vectors[0].requirement_clusters.is_empty());
         validate_testgen_response(&response).unwrap();
         cleanup_generated_files(&response.generated_files);
     }
@@ -6198,6 +6308,10 @@ property P_RECOVERY_VISIBLE:
         })
         .unwrap();
         assert!(!response.vector_ids.is_empty());
+        assert!(response
+            .vector_groups
+            .iter()
+            .any(|group| group.group_kind == "requirement"));
         validate_testgen_response(&response).unwrap();
         cleanup_generated_files(&response.generated_files);
     }

--- a/packages/valid/src/bin/cargo-valid.rs
+++ b/packages/valid/src/bin/cargo-valid.rs
@@ -1667,7 +1667,7 @@ fn cmd_testgen(parsed: ParsedArgs) {
         Ok(response) => {
             if parsed.json {
                 println!(
-                    "{{\"schema_version\":\"{}\",\"request_id\":\"{}\",\"status\":\"{}\",\"vector_ids\":[{}],\"vectors\":[{}],\"generated_files\":[{}]}}",
+                    "{{\"schema_version\":\"{}\",\"request_id\":\"{}\",\"status\":\"{}\",\"vector_ids\":[{}],\"vectors\":[{}],\"vector_groups\":[{}],\"generated_files\":[{}]}}",
                     response.schema_version,
                     response.request_id,
                     response.status,
@@ -1676,13 +1676,26 @@ fn cmd_testgen(parsed: ParsedArgs) {
                         .vectors
                         .iter()
                         .map(|vector| format!(
-                            "{{\"vector_id\":\"{}\",\"run_id\":\"{}\",\"strictness\":\"{}\",\"derivation\":\"{}\",\"source_kind\":\"{}\",\"strategy\":\"{}\"}}",
+                            "{{\"vector_id\":\"{}\",\"run_id\":\"{}\",\"strictness\":\"{}\",\"derivation\":\"{}\",\"source_kind\":\"{}\",\"strategy\":\"{}\",\"requirement_clusters\":[{}],\"risk_clusters\":[{}]}}",
                             vector.vector_id,
                             vector.run_id,
                             vector.strictness,
                             vector.derivation,
                             vector.source_kind,
-                            vector.strategy
+                            vector.strategy,
+                            vector.requirement_clusters.iter().map(|cluster| format!("\"{}\"", cluster)).collect::<Vec<_>>().join(","),
+                            vector.risk_clusters.iter().map(|cluster| format!("\"{}\"", cluster)).collect::<Vec<_>>().join(",")
+                        ))
+                        .collect::<Vec<_>>()
+                        .join(","),
+                    response
+                        .vector_groups
+                        .iter()
+                        .map(|group| format!(
+                            "{{\"group_kind\":\"{}\",\"group_id\":\"{}\",\"vector_ids\":[{}]}}",
+                            group.group_kind,
+                            group.group_id,
+                            group.vector_ids.iter().map(|id| format!("\"{}\"", id)).collect::<Vec<_>>().join(","),
                         ))
                         .collect::<Vec<_>>()
                         .join(","),
@@ -1694,13 +1707,34 @@ fn cmd_testgen(parsed: ParsedArgs) {
                     println!("vectors:");
                     for vector in &response.vectors {
                         println!(
-                            "- {} run_id={} strictness={} derivation={} source={} strategy={}",
+                            "- {} run_id={} strictness={} derivation={} source={} strategy={} requirements={} risks={}",
                             vector.vector_id,
                             vector.run_id,
                             vector.strictness,
                             vector.derivation,
                             vector.source_kind,
-                            vector.strategy
+                            vector.strategy,
+                            if vector.requirement_clusters.is_empty() {
+                                "-".to_string()
+                            } else {
+                                vector.requirement_clusters.join(",")
+                            },
+                            if vector.risk_clusters.is_empty() {
+                                "-".to_string()
+                            } else {
+                                vector.risk_clusters.join(",")
+                            }
+                        );
+                    }
+                }
+                if !response.vector_groups.is_empty() {
+                    println!("grouped output:");
+                    for group in &response.vector_groups {
+                        println!(
+                            "- {}:{} -> {}",
+                            group.group_kind,
+                            group.group_id,
+                            group.vector_ids.join(",")
                         );
                     }
                 }

--- a/packages/valid/src/bin/valid.rs
+++ b/packages/valid/src/bin/valid.rs
@@ -1633,7 +1633,7 @@ fn cmd_testgen(args: Vec<String>) {
             }
             if parsed.json {
                 println!(
-                    "{{\"schema_version\":\"{}\",\"request_id\":\"{}\",\"status\":\"{}\",\"vector_ids\":[{}],\"vectors\":[{}],\"generated_files\":[{}]}}",
+                    "{{\"schema_version\":\"{}\",\"request_id\":\"{}\",\"status\":\"{}\",\"vector_ids\":[{}],\"vectors\":[{}],\"vector_groups\":[{}],\"generated_files\":[{}]}}",
                     response.schema_version,
                     response.request_id,
                     response.status,
@@ -1647,13 +1647,41 @@ fn cmd_testgen(args: Vec<String>) {
                         .vectors
                         .iter()
                         .map(|vector| format!(
-                            "{{\"vector_id\":\"{}\",\"run_id\":\"{}\",\"strictness\":\"{}\",\"derivation\":\"{}\",\"source_kind\":\"{}\",\"strategy\":\"{}\"}}",
+                            "{{\"vector_id\":\"{}\",\"run_id\":\"{}\",\"strictness\":\"{}\",\"derivation\":\"{}\",\"source_kind\":\"{}\",\"strategy\":\"{}\",\"requirement_clusters\":[{}],\"risk_clusters\":[{}]}}",
                             vector.vector_id,
                             vector.run_id,
                             vector.strictness,
                             vector.derivation,
                             vector.source_kind,
-                            vector.strategy
+                            vector.strategy,
+                            vector
+                                .requirement_clusters
+                                .iter()
+                                .map(|s| format!("\"{}\"", s))
+                                .collect::<Vec<_>>()
+                                .join(","),
+                            vector
+                                .risk_clusters
+                                .iter()
+                                .map(|s| format!("\"{}\"", s))
+                                .collect::<Vec<_>>()
+                                .join(",")
+                        ))
+                        .collect::<Vec<_>>()
+                        .join(","),
+                    response
+                        .vector_groups
+                        .iter()
+                        .map(|group| format!(
+                            "{{\"group_kind\":\"{}\",\"group_id\":\"{}\",\"vector_ids\":[{}]}}",
+                            group.group_kind,
+                            group.group_id,
+                            group
+                                .vector_ids
+                                .iter()
+                                .map(|s| format!("\"{}\"", s))
+                                .collect::<Vec<_>>()
+                                .join(",")
                         ))
                         .collect::<Vec<_>>()
                         .join(","),
@@ -1668,14 +1696,35 @@ fn cmd_testgen(args: Vec<String>) {
                 println!("generated {} vector(s)", response.vector_ids.len());
                 for vector in &response.vectors {
                     println!(
-                        "  {} run_id={} strictness={} derivation={} source={} strategy={}",
+                        "  {} run_id={} strictness={} derivation={} source={} strategy={} requirements={} risks={}",
                         vector.vector_id,
                         vector.run_id,
                         vector.strictness,
                         vector.derivation,
                         vector.source_kind,
-                        vector.strategy
+                        vector.strategy,
+                        if vector.requirement_clusters.is_empty() {
+                            "-".to_string()
+                        } else {
+                            vector.requirement_clusters.join(",")
+                        },
+                        if vector.risk_clusters.is_empty() {
+                            "-".to_string()
+                        } else {
+                            vector.risk_clusters.join(",")
+                        }
                     );
+                }
+                if !response.vector_groups.is_empty() {
+                    println!("grouped output:");
+                    for group in &response.vector_groups {
+                        println!(
+                            "  {}:{} -> {}",
+                            group.group_kind,
+                            group.group_id,
+                            group.vector_ids.join(",")
+                        );
+                    }
                 }
                 for path in &response.generated_files {
                     println!("  {path}");

--- a/packages/valid/src/bundled_models.rs
+++ b/packages/valid/src/bundled_models.rs
@@ -301,8 +301,11 @@ pub fn testgen_bundled_model(
                 derivation: vector.derivation.clone(),
                 source_kind: vector.source_kind.clone(),
                 strategy: vector.strategy.clone(),
+                requirement_clusters: vector.grouping.requirement_clusters.clone(),
+                risk_clusters: vector.grouping.risk_clusters.clone(),
             })
             .collect(),
+        vector_groups: crate::api::summarize_testgen_groups(&vectors),
         generated_files,
     })
 }

--- a/packages/valid/src/conformance/mod.rs
+++ b/packages/valid/src/conformance/mod.rs
@@ -11,7 +11,7 @@ use crate::{
         eval::eval_expr,
         transition::{apply_action_transition, build_initial_state},
     },
-    testgen::{TestVector, VectorActionStep},
+    testgen::{TestVector, VectorActionStep, VectorGrouping},
 };
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -182,6 +182,7 @@ pub fn build_vector_from_actions(
         setup_action_ids: Vec::new(),
         business_action_ids,
         notes: vec!["generated from spec replay for implementation conformance".to_string()],
+        grouping: VectorGrouping::default(),
         replay_target: None,
     })
 }
@@ -419,7 +420,7 @@ mod tests {
     use crate::{
         frontend::compile_model,
         ir::{Path, Value},
-        testgen::{TestVector, VectorActionStep},
+        testgen::{TestVector, VectorActionStep, VectorGrouping},
     };
 
     use super::{
@@ -458,6 +459,7 @@ mod tests {
             setup_action_ids: Vec::new(),
             business_action_ids: vec!["Jump".to_string()],
             notes: Vec::new(),
+            grouping: VectorGrouping::default(),
             replay_target: None,
         }
     }

--- a/packages/valid/src/modeling/mod.rs
+++ b/packages/valid/src/modeling/mod.rs
@@ -2779,6 +2779,9 @@ pub fn build_machine_test_vectors_for_property<M: VerifiedMachine>(
                     .into_iter()
                     .map(|tag| format!("path_tag:{tag}"))
                     .collect(),
+                grouping: crate::testgen::vector_grouping_from_path_tags(
+                    &machine_transition_tags_for_action::<M>(&action_id),
+                ),
                 replay_target: None,
             });
         }
@@ -3150,6 +3153,7 @@ fn build_machine_vector_for_node<M: VerifiedMachine>(
         })
         .map(|step| step.action_id.clone())
         .collect::<Vec<_>>();
+    let grouping = crate::testgen::vector_grouping_from_path_tags(&expected_path_tags);
     Some(TestVector {
         schema_version: "1.0.0".to_string(),
         vector_id: format!(
@@ -3212,6 +3216,7 @@ fn build_machine_vector_for_node<M: VerifiedMachine>(
         setup_action_ids,
         business_action_ids,
         notes,
+        grouping,
         replay_target: None,
     })
 }

--- a/packages/valid/src/registry.rs
+++ b/packages/valid/src/registry.rs
@@ -825,7 +825,7 @@ fn cmd_testgen(models: &[RegisteredModel], args: Vec<String>) {
     );
     if parsed.json {
         println!(
-            "{{\"schema_version\":\"{}\",\"request_id\":\"{}\",\"status\":\"{}\",\"vector_ids\":[{}],\"vectors\":[{}],\"generated_files\":[{}]}}",
+            "{{\"schema_version\":\"{}\",\"request_id\":\"{}\",\"status\":\"{}\",\"vector_ids\":[{}],\"vectors\":[{}],\"vector_groups\":[{}],\"generated_files\":[{}]}}",
             response.schema_version,
             response.request_id,
             response.status,
@@ -834,12 +834,25 @@ fn cmd_testgen(models: &[RegisteredModel], args: Vec<String>) {
                 .vectors
                 .iter()
                 .map(|vector| format!(
-                    "{{\"vector_id\":\"{}\",\"strictness\":\"{}\",\"derivation\":\"{}\",\"source_kind\":\"{}\",\"strategy\":\"{}\"}}",
+                    "{{\"vector_id\":\"{}\",\"strictness\":\"{}\",\"derivation\":\"{}\",\"source_kind\":\"{}\",\"strategy\":\"{}\",\"requirement_clusters\":[{}],\"risk_clusters\":[{}]}}",
                     vector.vector_id,
                     vector.strictness,
                     vector.derivation,
                     vector.source_kind,
-                    vector.strategy
+                    vector.strategy,
+                    vector.requirement_clusters.iter().map(|cluster| format!("\"{}\"", cluster)).collect::<Vec<_>>().join(","),
+                    vector.risk_clusters.iter().map(|cluster| format!("\"{}\"", cluster)).collect::<Vec<_>>().join(",")
+                ))
+                .collect::<Vec<_>>()
+                .join(","),
+            response
+                .vector_groups
+                .iter()
+                .map(|group| format!(
+                    "{{\"group_kind\":\"{}\",\"group_id\":\"{}\",\"vector_ids\":[{}]}}",
+                    group.group_kind,
+                    group.group_id,
+                    group.vector_ids.iter().map(|id| format!("\"{}\"", id)).collect::<Vec<_>>().join(",")
                 ))
                 .collect::<Vec<_>>()
                 .join(","),
@@ -851,12 +864,33 @@ fn cmd_testgen(models: &[RegisteredModel], args: Vec<String>) {
             println!("vectors:");
             for vector in &response.vectors {
                 println!(
-                    "- {} strictness={} derivation={} source={} strategy={}",
+                    "- {} strictness={} derivation={} source={} strategy={} requirements={} risks={}",
                     vector.vector_id,
                     vector.strictness,
                     vector.derivation,
                     vector.source_kind,
-                    vector.strategy
+                    vector.strategy,
+                    if vector.requirement_clusters.is_empty() {
+                        "-".to_string()
+                    } else {
+                        vector.requirement_clusters.join(",")
+                    },
+                    if vector.risk_clusters.is_empty() {
+                        "-".to_string()
+                    } else {
+                        vector.risk_clusters.join(",")
+                    }
+                );
+            }
+        }
+        if !response.vector_groups.is_empty() {
+            println!("grouped output:");
+            for group in &response.vector_groups {
+                println!(
+                    "- {}:{} -> {}",
+                    group.group_kind,
+                    group.group_id,
+                    group.vector_ids.join(",")
                 );
             }
         }
@@ -1168,8 +1202,11 @@ fn testgen_machine<M: VerifiedMachine>(
                 derivation: vector.derivation.clone(),
                 source_kind: vector.source_kind.clone(),
                 strategy: vector.strategy.clone(),
+                requirement_clusters: vector.grouping.requirement_clusters.clone(),
+                risk_clusters: vector.grouping.risk_clusters.clone(),
             })
             .collect(),
+        vector_groups: crate::api::summarize_testgen_groups(&vectors),
         generated_files,
     }
 }

--- a/packages/valid/src/testgen/mod.rs
+++ b/packages/valid/src/testgen/mod.rs
@@ -566,6 +566,7 @@ fn build_model_deadlock_vector(
             ],
             None => vec!["deadlock_reached".to_string()],
         },
+        grouping: VectorGrouping::default(),
         replay_target: None,
     }
 }

--- a/packages/valid/src/testgen/mod.rs
+++ b/packages/valid/src/testgen/mod.rs
@@ -64,6 +64,8 @@ pub struct TestVector {
     #[serde(default)]
     pub notes: Vec<String>,
     #[serde(default)]
+    pub grouping: VectorGrouping,
+    #[serde(default)]
     pub replay_target: Option<ReplayTarget>,
 }
 
@@ -72,6 +74,14 @@ pub struct VectorActionStep {
     pub index: usize,
     pub action_id: String,
     pub action_label: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct VectorGrouping {
+    #[serde(default)]
+    pub requirement_clusters: Vec<String>,
+    #[serde(default)]
+    pub risk_clusters: Vec<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -93,6 +103,62 @@ fn vector_provenance(source_kind: &str, strategy: &str) -> (&'static str, &'stat
         (_, "random") => ("heuristic", "deterministic_random_search"),
         _ => ("heuristic", "model_exploration"),
     }
+}
+
+fn infer_vector_grouping(path_tags: &[String]) -> VectorGrouping {
+    let requirement_clusters = path_tags
+        .iter()
+        .filter(|tag| {
+            !matches!(
+                tag.as_str(),
+                "guard_path" | "read_path" | "write_path" | "transition_path"
+            )
+        })
+        .cloned()
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect::<Vec<_>>();
+    let risk_clusters = requirement_clusters
+        .iter()
+        .filter(|tag| is_risk_cluster_tag(tag))
+        .cloned()
+        .collect::<Vec<_>>();
+    VectorGrouping {
+        requirement_clusters,
+        risk_clusters,
+    }
+}
+
+pub fn vector_grouping_from_path_tags(path_tags: &[String]) -> VectorGrouping {
+    infer_vector_grouping(path_tags)
+}
+
+fn is_risk_cluster_tag(tag: &str) -> bool {
+    matches!(
+        tag,
+        "risk_path"
+            | "audit_path"
+            | "compliance_path"
+            | "exception_path"
+            | "regression_path"
+            | "recovery_path"
+            | "security_path"
+            | "privacy_path"
+            | "fraud_path"
+            | "governance_path"
+            | "boundary_path"
+            | "deny_path"
+            | "tenant_isolation_path"
+    ) || tag.contains("risk")
+        || tag.contains("audit")
+        || tag.contains("compliance")
+        || tag.contains("security")
+        || tag.contains("privacy")
+        || tag.contains("fraud")
+        || tag.contains("isolation")
+        || tag.contains("governance")
+        || tag.contains("regression")
+        || tag.contains("recovery")
 }
 
 pub fn build_counterexample_vector(trace: &EvidenceTrace) -> Result<TestVector, String> {
@@ -132,6 +198,7 @@ fn build_base_vector_from_trace(trace: &EvidenceTrace) -> Result<TestVector, Str
         .collect::<Vec<_>>();
     let expected_path = trace_path(trace);
     let expected_path_tags = path_tags_or_empty(&expected_path);
+    let grouping = infer_vector_grouping(&expected_path_tags);
     Ok(TestVector {
         schema_version: "1.0.0".to_string(),
         vector_id: trace.evidence_id.replace("ev-", "vec-"),
@@ -158,6 +225,7 @@ fn build_base_vector_from_trace(trace: &EvidenceTrace) -> Result<TestVector, Str
         setup_action_ids: Vec::new(),
         business_action_ids: Vec::new(),
         notes: Vec::new(),
+        grouping,
         replay_target: None,
     })
 }
@@ -515,6 +583,18 @@ fn reproduces_failure(
 pub fn render_rust_test(vector: &TestVector) -> String {
     let mut out = String::new();
     out.push_str(&format!("// valid-run-id: {}\n", vector.run_id));
+    if !vector.grouping.requirement_clusters.is_empty() {
+        out.push_str(&format!(
+            "// valid-requirement-clusters: {}\n",
+            vector.grouping.requirement_clusters.join(",")
+        ));
+    }
+    if !vector.grouping.risk_clusters.is_empty() {
+        out.push_str(&format!(
+            "// valid-risk-clusters: {}\n",
+            vector.grouping.risk_clusters.join(",")
+        ));
+    }
     out.push_str("#[test]\n");
     out.push_str(&format!(
         "fn generated_{}() {{\n",
@@ -578,6 +658,14 @@ pub fn render_rust_test(vector: &TestVector) -> String {
     for note in &vector.notes {
         out.push_str(&format!("    notes.push({note:?});\n"));
     }
+    out.push_str("    let mut requirement_clusters = Vec::new();\n");
+    for cluster in &vector.grouping.requirement_clusters {
+        out.push_str(&format!("    requirement_clusters.push({cluster:?});\n"));
+    }
+    out.push_str("    let mut risk_clusters = Vec::new();\n");
+    for cluster in &vector.grouping.risk_clusters {
+        out.push_str(&format!("    risk_clusters.push({cluster:?});\n"));
+    }
     out.push_str("    let mut expected_path_tags = Vec::new();\n");
     for tag in &vector.expected_path_tags {
         out.push_str(&format!("    expected_path_tags.push({tag:?});\n"));
@@ -629,6 +717,14 @@ pub fn render_rust_test(vector: &TestVector) -> String {
     out.push_str("    }\n");
     out.push_str("    for note in &notes {\n");
     out.push_str("        assert!(!note.is_empty(), \"note must be non-empty\");\n");
+    out.push_str("    }\n");
+    out.push_str("    for cluster in &requirement_clusters {\n");
+    out.push_str(
+        "        assert!(!cluster.is_empty(), \"requirement cluster must be non-empty\");\n",
+    );
+    out.push_str("    }\n");
+    out.push_str("    for cluster in &risk_clusters {\n");
+    out.push_str("        assert!(requirement_clusters.contains(cluster), \"risk cluster must also be a requirement cluster\");\n");
     out.push_str("    }\n");
     out.push_str("    assert!(focus_action_id.is_some() || focus_field.is_some() || !actions.is_empty() || expected_guard_enabled.is_some() || !expected_states.is_empty());\n");
     out.push_str("}\n");
@@ -1244,6 +1340,8 @@ fn build_model_vector_for_node(
                 })
         })
         .collect::<Vec<_>>();
+    let expected_path_tags = path_tags_or_empty(&expected_path);
+    let grouping = infer_vector_grouping(&expected_path_tags);
     Some(TestVector {
         schema_version: "1.0.0".to_string(),
         vector_id: format!(
@@ -1282,11 +1380,12 @@ fn build_model_vector_for_node(
         focus_field,
         expected_guard_enabled,
         expected_property_holds: Some(property_holds),
-        expected_path_tags: path_tags_or_empty(&expected_path),
+        expected_path_tags,
         expected_path,
         setup_action_ids,
         business_action_ids,
         notes,
+        grouping,
         replay_target: None,
     })
 }

--- a/tests/e2e_cargo_valid.rs
+++ b/tests/e2e_cargo_valid.rs
@@ -1086,9 +1086,12 @@ fn cargo_valid_testgen_path_generates_tagged_files() {
     assert!(output.status.success());
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(stdout.contains("\"generated_files\":["));
+    assert!(stdout.contains("\"vector_groups\":["));
+    assert!(stdout.contains("\"group_kind\":\"requirement\""));
     for path in extract_generated_files(&stdout) {
         let body = fs::read_to_string(&path).expect("generated file must exist");
         assert!(body.contains("path_tag:"));
+        assert!(body.contains("valid-requirement-clusters:"));
     }
     cleanup_generated_files(&stdout);
 }

--- a/tests/e2e_practical_suite.rs
+++ b/tests/e2e_practical_suite.rs
@@ -185,14 +185,21 @@ fn practical_suite_coverage_and_path_testgen_surface_business_paths() {
     assert!(testgen.status.success());
     let testgen_stdout = String::from_utf8_lossy(&testgen.stdout);
     assert!(testgen_stdout.contains("\"generated_files\":["));
+    assert!(testgen_stdout.contains("\"vector_groups\":["));
+    assert!(testgen_stdout.contains("\"group_kind\":\"requirement\""));
     let mut saw_business_tag = false;
+    let mut saw_group_comment = false;
     for path in extract_generated_files(&testgen_stdout) {
         let body = fs::read_to_string(&path).expect("generated file must exist");
         assert!(body.contains("path_tag:"));
+        if body.contains("valid-requirement-clusters:") {
+            saw_group_comment = true;
+        }
         if body.contains("finance_path") || body.contains("risk_path") {
             saw_business_tag = true;
         }
     }
     assert!(saw_business_tag);
+    assert!(saw_group_comment);
     cleanup_generated_files(&testgen_stdout);
 }


### PR DESCRIPTION
## Summary
- attach requirement/risk cluster metadata to generated test vectors and summaries
- expose grouped testgen output consistently across `valid`, `cargo valid`, and registry-backed flows
- document and test the grouped response shape in the practical suite and cargo-valid regressions

## Testing
- cargo test -q -p valid witness_testgen_can_fallback_to_synthetic_vectors
- cargo test -q --test e2e_practical_suite practical_suite_coverage_and_path_testgen_surface_business_paths -- --exact
- cargo test -q --test e2e_cargo_valid cargo_valid_testgen_path_generates_tagged_files -- --exact

## Issue
- Closes #60

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Test vectors now include requirement and risk clustering information in output (both JSON and human-readable formats)
  * Added grouped output section displaying vector organization by cluster kind and ID
  * New vector grouping field in test generation response structure

* **Documentation**
  * Updated JSON schema documentation with new test vector grouping fields (requirement clusters, risk clusters, vector groups)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->